### PR TITLE
SNOW-1043081: Adding support for qualified names for image repositories.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 ## New additions
 * Added support for fully qualified name (`database.schema.name`) in `name` parameter in streamlit project definition
+* Added support for fully qualified image repository names in `spcs image-repository` commands.
 
 ## Fixes and improvements
 * Adding `--image-name` option for image name argument in `spcs image-repository list-tags` for consistency with other commands.

--- a/src/snowflake/cli/api/utils/naming_utils.py
+++ b/src/snowflake/cli/api/utils/naming_utils.py
@@ -1,0 +1,27 @@
+import re
+from typing import Optional, Tuple
+
+from snowflake.cli.api.project.util import (
+    VALID_IDENTIFIER_REGEX,
+)
+
+
+def from_qualified_name(name: str) -> Tuple[str, Optional[str], Optional[str]]:
+    """
+    Takes in an object name in the form [[database.]schema.]name. Returns a tuple (name, [schema], [database])
+    """
+    # TODO: Use regex to match object name to a valid identifier or valid identifier (args). Second case is for sprocs and UDFs
+    qualifier_pattern = rf"(?:(?P<first_qualifier>{VALID_IDENTIFIER_REGEX})\.)?(?:(?P<second_qualifier>{VALID_IDENTIFIER_REGEX})\.)?(?P<name>.*)"
+    result = re.fullmatch(qualifier_pattern, name)
+
+    if result is None:
+        raise ValueError(f"'{name}' is not a valid qualified name")
+
+    unqualified_name = result.group("name")
+    if result.group("second_qualifier") is not None:
+        database = result.group("first_qualifier")
+        schema = result.group("second_qualifier")
+    else:
+        database = None
+        schema = result.group("first_qualifier")
+    return unqualified_name, schema, database

--- a/src/snowflake/cli/plugins/object/common.py
+++ b/src/snowflake/cli/plugins/object/common.py
@@ -4,8 +4,7 @@ from typing import Optional
 from click import ClickException
 from snowflake.cli.api.commands.flags import OverrideableOption
 from snowflake.cli.api.project.util import (
-    QUOTED_IDENTIFIER_REGEX,
-    UNQUOTED_IDENTIFIER_REGEX,
+    VALID_IDENTIFIER_REGEX,
     is_valid_identifier,
     to_string_literal,
 )
@@ -34,11 +33,9 @@ class TagError(ClickException):
 def _parse_tag(tag: str) -> Tag:
     import re
 
-    identifier_pattern = re.compile(
-        f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})"
-    )
-    value_pattern = re.compile(f"(?P<tag_value>.+)")
-    result = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
+    identifier_pattern = rf"(?P<tag_name>{VALID_IDENTIFIER_REGEX})"
+    value_pattern = r"(?P<tag_value>.+)"
+    result = re.fullmatch(rf"{identifier_pattern}={value_pattern}", tag)
     if result is not None:
         try:
             return Tag(result.group("tag_name"), result.group("tag_value"))

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -22,7 +22,7 @@ app = SnowTyper(
 
 
 def _repo_name_callback(name: str):
-    if not is_valid_object_name(name, max_depth=0, allow_quoted=True):
+    if not is_valid_object_name(name, max_depth=2, allow_quoted=False):
         raise ClickException(
             f"'{name}' is not a valid image repository name. Note that image repository names must be unquoted identifiers. The same constraint also applies to database and schema names where you create an image repository."
         )

--- a/tests/api/utils/test_naming_utils.py
+++ b/tests/api/utils/test_naming_utils.py
@@ -1,0 +1,15 @@
+import pytest
+from snowflake.cli.api.utils.naming_utils import from_qualified_name
+
+
+@pytest.mark.parametrize(
+    "qualified_name, expected",
+    [
+        ("func(number, number)", ("func(number, number)", None, None)),
+        ("name", ("name", None, None)),
+        ("schema.name", ("name", "schema", None)),
+        ("db.schema.name", ("name", "schema", "db")),
+    ],
+)
+def test_from_fully_qualified_name(qualified_name, expected):
+    assert from_qualified_name(qualified_name) == expected

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -4,12 +4,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
-from click import ClickException
 from snowflake.cli.api.constants import ObjectType
-from snowflake.cli.api.exceptions import (
-    DatabaseNotProvidedError,
-    SchemaNotProvidedError,
-)
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 from snowflake.connector.cursor import SnowflakeCursor
 
@@ -55,7 +50,7 @@ def test_create(
     mock_execute.return_value = cursor
     result = ImageRepositoryManager().create(name=repo_name)
     expected_query = "create image repository test_repo"
-    mock_execute.assert_called_once_with(expected_query)
+    mock_execute.assert_called_once_with(expected_query, name=repo_name)
     assert result == cursor
 
 
@@ -192,12 +187,9 @@ def test_get_repository_url_cli(mock_url, runner):
 
 
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.check_database_and_schema"
-)
-@mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.show_specific_object"
 )
-def test_get_repository_url(mock_get_row, mock_check_database_and_schema):
+def test_get_repository_url(mock_get_row):
     expected_row = MOCK_ROWS_DICT[0]
     mock_get_row.return_value = expected_row
     result = ImageRepositoryManager().get_repository_url(repo_name="IMAGES")
@@ -210,12 +202,9 @@ def test_get_repository_url(mock_get_row, mock_check_database_and_schema):
 
 
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.check_database_and_schema"
-)
-@mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.show_specific_object"
 )
-def test_get_repository_url_no_scheme(mock_get_row, mock_check_database_and_schema):
+def test_get_repository_url_no_scheme(mock_get_row):
     expected_row = MOCK_ROWS_DICT[0]
     mock_get_row.return_value = expected_row
     result = ImageRepositoryManager().get_repository_url(
@@ -230,45 +219,21 @@ def test_get_repository_url_no_scheme(mock_get_row, mock_check_database_and_sche
 
 
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.check_database_and_schema"
-)
-@mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._conn"
 )
 @mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.show_specific_object"
 )
-def test_get_repository_url_no_repo_found(
-    mock_get_row, mock_conn, mock_check_database_and_schema
-):
+def test_get_repository_url_no_repo_found(mock_get_row, mock_conn):
     mock_get_row.return_value = None
     mock_conn.database = "DB"
     mock_conn.schema = "SCHEMA"
-    with pytest.raises(ClickException) as e:
+    with pytest.raises(ProgrammingError) as e:
         ImageRepositoryManager().get_repository_url(repo_name="IMAGES")
     assert (
-        e.value.message
-        == "Image repository 'IMAGES' does not exist in database 'DB' and schema 'SCHEMA' or not authorized."
+        e.value.msg
+        == f"Image repository 'DB.SCHEMA.IMAGES' does not exist or not authorized."
     )
     mock_get_row.assert_called_once_with(
         "image repositories", "IMAGES", check_schema=True
     )
-
-
-@mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._conn"
-)
-def test_get_repository_url_no_database(mock_conn):
-    mock_conn.database = None
-    with pytest.raises(DatabaseNotProvidedError):
-        ImageRepositoryManager().get_repository_url("test_repo")
-
-
-@mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._conn"
-)
-@mock.patch("snowflake.cli.api.sql_execution.SqlExecutionMixin.check_database_exists")
-def test_get_repository_url_no_schema(mock_check_database_exists, mock_conn):
-    mock_conn.schema = None
-    with pytest.raises(SchemaNotProvidedError):
-        ImageRepositoryManager().get_repository_url("test_repo")

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -7,6 +7,7 @@ import pytest
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.errors import ProgrammingError
 
 from tests.spcs.test_common import SPCS_OBJECT_EXISTS_ERROR
 

--- a/tests/spcs/test_jobs.py
+++ b/tests/spcs/test_jobs.py
@@ -2,7 +2,10 @@ import os
 from tempfile import TemporaryDirectory
 from unittest import mock
 
+import pytest
 
+
+@pytest.mark.skip("Snowpark Container Services Job not supported.")
 @mock.patch("snowflake.connector.connect")
 def test_create_job(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
@@ -40,6 +43,7 @@ spec:
     )
 
 
+@pytest.mark.skip("Snowpark Container Services Job not supported.")
 @mock.patch("snowflake.connector.connect")
 def test_job_status(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
@@ -51,6 +55,7 @@ def test_job_status(mock_connector, runner, mock_ctx):
     assert ctx.get_query() == "CALL SYSTEM$GET_JOB_STATUS('jobName')"
 
 
+@pytest.mark.skip("Snowpark Container Services Job not supported.")
 @mock.patch("snowflake.connector.connect")
 def test_job_logs(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -4,8 +4,10 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.exceptions import SnowflakeSQLExecutionError
+from snowflake.cli.api.project.util import identifier_to_show_like_pattern
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import DictCursor
+from snowflake.connector.errors import ProgrammingError
 
 from tests.testing_utils.result_assertions import assert_that_result_is_usage_error
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Modified implementation of show_specific_object to allow qualified object names and added support for qualified image repository names by removing validation that image repository names are unqualified. Also added an explicit check that show_specific_object only returns a single row and throws an error otherwise.

**Usage**:
<img width="1143" alt="image" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/9cfeb225-12de-4cbd-869f-c5614a060fad">


**Errors when database, schema, repository don't exist**:
<img width="1171" alt="image" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/accbab8a-ceb1-47df-a350-55a347fad6ff">
