### PR TITLE
[NADE] Update CODEOWNERS to use NADE team id.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 * @sfc-gh-turbaszek @sfc-gh-pjob @sfc-gh-jsikorski @sfc-gh-astus @sfc-gh-mraba @sfc-gh-pczajka
 
 # Native Apps Owners
-src/snowflake/cli/plugins/nativeapp/ @sfc-gh-bgoel @sfc-gh-cgorrie @sfc-gh-bdufour @sfc-gh-melnacouzi
-tests/nativeapp/ @sfc-gh-bgoel @sfc-gh-cgorrie @sfc-gh-bdufour @sfc-gh-melnacouzi
-tests_integration/test_nativeapp.py @sfc-gh-bgoel @sfc-gh-cgorrie @sfc-gh-bdufour @sfc-gh-melnacouzi
+src/snowflake/cli/plugins/nativeapp/ @snowflakedb/nade
+tests/nativeapp/ @sfc-gh-bgoel @snowflakedb/nade
+tests_integration/test_nativeapp.py @snowflakedb/nade
 
 # Project Definition Owners
-src/snowflake/cli/api/project/schemas/native_app.py @sfc-gh-bgoel @sfc-gh-cgorrie @sfc-gh-bdufour @sfc-gh-melnacouzi
-tests/project/ @sfc-gh-turbaszek @sfc-gh-pjob @sfc-gh-jsikorski @sfc-gh-astus @sfc-gh-mraba @sfc-gh-pczajka @sfc-gh-bgoel @sfc-gh-cgorrie @sfc-gh-bdufour @sfc-gh-melnacouzi
+src/snowflake/cli/api/project/schemas/native_app.py @snowflakedb/nade
+tests/project/ @sfc-gh-turbaszek @sfc-gh-pjob @sfc-gh-jsikorski @sfc-gh-astus @sfc-gh-mraba @sfc-gh-pczajka @snowflakedb/nade


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code - N/A
   * [ ] I've added or updated integration tests to verify correctness of my new code - N/A
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually - N/A
   * [ ] I've confirmed that my changes are up-to-date with the target branch - N/A
   * [ ] I've described my changes in the release notes - N/A
   * [x] I've described my changes in the section below.

### Changes description
As title says. With the move from Snowflake-Labs to snowflakedb Github org, we can use the teams id in CODEOWNERS instead of specifying every NADE member's names.  
