### PR TITLE
unify LikeOption with api

### DIFF
--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -303,12 +303,6 @@ DebugOption = typer.Option(
     rich_help_panel=_CLI_BEHAVIOUR,
 )
 
-LikeOption = typer.Option(
-    "%%",
-    "--like",
-    "-l",
-    help='Regular expression for filtering objects by name. For example, `list --like "my%"` lists all objects that begin with “my”.',
-)
 
 # If IfExistsOption, IfNotExistsOption, or ReplaceOption are used with names other than those in CREATE_MODE_OPTION_NAMES,
 # you must also override mutually_exclusive if you want to retain the validation that at most one of these flags is
@@ -335,6 +329,15 @@ ReplaceOption = OverrideableOption(
     help="Replace this object if it already exists.",
     mutually_exclusive=CREATE_MODE_OPTION_NAMES,
 )
+
+
+def like_option(help_example: str):
+    return typer.Option(
+        "%%",
+        "--like",
+        "-l",
+        help=f"SQL LIKE pattern for filtering objects by name. For example, {help_example}.",
+    )
 
 
 def experimental_option(

--- a/src/snowflake/cli/plugins/object/commands.py
+++ b/src/snowflake/cli/plugins/object/commands.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import typer
 from click import ClickException
+from snowflake.cli.api.commands.flags import like_option
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.constants import SUPPORTED_OBJECTS, VALID_SCOPES
 from snowflake.cli.api.output.types import QueryResult
@@ -23,12 +24,8 @@ ObjectArgument = typer.Argument(
     help="Type of object. For example table, procedure, streamlit.",
     case_sensitive=False,
 )
-LikeOption = typer.Option(
-    "%%",
-    "--like",
-    "-l",
-    help='SQL LIKE pattern for filtering objects by name. For example, `list function --like "my%"` lists '
-    "all functions that begin with “my”.",
+LikeOption = like_option(
+    help_example='`list function --like "my%"` lists all functions that begin with “my”',
 )
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Use like_option factory from API instead of redefinig `LikeOption` in object commands
