### PR TITLE
[NADE][Bugfix] Use Pyyaml instead of StrictYAML

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
-import strictyaml
 from click import ClickException
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.secure_path import SecurePath
+from yaml import safe_load
 
 
 class DeployRootError(ClickException):
@@ -271,7 +271,7 @@ def find_version_info_in_manifest_file(
     with SecurePath(manifest_file).open(
         "r", read_file_limit_mb=DEFAULT_SIZE_LIMIT_MB
     ) as file:
-        manifest_content = strictyaml.load(file.read())
+        manifest_content = safe_load(file.read())
 
     version_name: Optional[str] = None
     patch_name: Optional[str] = None


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
The `manifest.yml` file in the Snowflake Native App world can use non-quoted scalar values within square brackets, as yaml allows for this. As an example:
```
references:
  - egress_eai:
      label: "Egress Eai"
      description: "EAI for Egress from NA+SPCS"
      privileges: [USAGE]
```
In Yaml, a value in square brackets is interpreted as a flow sequence, i.e a list. As a result, StrictYaml expects for any values inside to be enclosed in quotes. It throws an error in the case above along the lines of "JSONesque flow mapping". 

On the other hand, pyyaml enforces no such restriction and its behavior aligns with the yaml specification. Since pyyaml is also being used elsewhere in the code, we can drop strictyaml here in favor of pyyaml. 