### PR TITLE
Use keyword argument for with_pip argument

### DIFF
--- a/src/snowflake/cli/plugins/snowpark/venv.py
+++ b/src/snowflake/cli/plugins/snowpark/venv.py
@@ -65,7 +65,7 @@ class Venv:
         return process.returncode
 
     def _create_venv(self):
-        venv.create(self.directory.name, self.with_pip)
+        venv.create(self.directory.name, with_pip=self.with_pip)
 
     @staticmethod
     def _get_python_path(venv_dir: Path) -> Path:


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

We were playing around with snow cli mainly to package our own Python libs for uploading them into Snowpark.
Unfortunately, this did not work out of the box so we went down quite some rabbit hole in order to figure
out what's wrong. It turned out that the created virtual env had no pip support which lead to the
problem that the generated `python -m pip install -r requirements.txt` call always leads to return code `1`.
The bug is caused by using a positional parameter instead of the keyword.
