### PR TITLE
chore: run codespell

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -171,7 +171,7 @@
 # v1.2.0
 
 ## Backward incompatibility
-* Removed `snow streamlit create` command. Streamlit can be deployd using `snow streamlit deploy`
+* Removed `snow streamlit create` command. Streamlit can be deployed using `snow streamlit deploy`
 * Removed short option names in compute pool commands:
   * `-n` for `--name`, name of compute pool
   * `-d` for `--num`, number of pool's instances

--- a/performance_history_analysis.py
+++ b/performance_history_analysis.py
@@ -44,7 +44,7 @@ def _print_summary_performance_descending(
 ) -> None:
     commits_with_diffs: List[Tuple[Commit, Decimal]] = []
     last_result: Optional[Decimal] = None
-    for (commit, result) in reversed(commits_with_results):
+    for commit, result in reversed(commits_with_results):
         if last_result:
             result_diff = Decimal(result) - last_result
             if result_diff > 0:
@@ -54,7 +54,7 @@ def _print_summary_performance_descending(
         commits_with_diffs, key=lambda e: e[1], reverse=True
     )
     print("\nCommits causing performance descending:")
-    for (commit, diff) in sorted_list_of_diffs:
+    for commit, diff in sorted_list_of_diffs:
         print(
             f"Diff [{diff}] after commit {commit} ({commit.authored_datetime}) -> {commit.message.splitlines()[0]}"
         )

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -21,7 +21,7 @@ _CLI_BEHAVIOUR = "Global configuration"
 class OverrideableOption:
     """
     Class that allows you to generate instances of typer.models.OptionInfo with some default properties while allowing
-    specific values to be overriden.
+    specific values to be overridden.
 
     Custom parameters:
     - mutually_exclusive (Tuple[str]|List[str]): A list of parameter names that this Option is not compatible with. If this Option has

--- a/src/snowflake/cli/api/commands/project_initialisation.py
+++ b/src/snowflake/cli/api/commands/project_initialisation.py
@@ -22,9 +22,11 @@ def add_init_command(
     def init(
         project_name: str = Argument(
             f"example_{project_type.lower()}",
-            help=help_message
-            if help_message is not None
-            else f"Name of the {project_type} project you want to create.",
+            help=(
+                help_message
+                if help_message is not None
+                else f"Name of the {project_type} project you want to create."
+            ),
         ),
         **options,
     ) -> CommandResult:

--- a/src/snowflake/cli/api/console/abc.py
+++ b/src/snowflake/cli/api/console/abc.py
@@ -11,7 +11,7 @@ class AbstractConsole(ABC):
     """Interface for cli console implementation.
 
     Each console should have three methods implemented:
-    - `step` - for more detailed informations on steps
+    - `step` - for more detailed information on steps
     - `warning` - for displaying messages in a style that makes it
       visually stand out from other output
     - `phase` a context manager for organising steps into logical group
@@ -62,4 +62,4 @@ class AbstractConsole(ABC):
     def warning(self, message: str):
         """Displays message in a style that makes it visually stand out from other output.
 
-        Intended for diplaying messeges related to important messages."""
+        Intended for displaying messages related to important messages."""

--- a/src/snowflake/cli/api/console/console.py
+++ b/src/snowflake/cli/api/console/console.py
@@ -22,8 +22,8 @@ class CliConsoleNestingProhibitedError(RuntimeError):
 class CliConsole(AbstractConsole):
     """An utility for displaying intermediate output.
 
-    Provides following methods for handling displying messages:
-    - `step` - for more detailed informations on steps
+    Provides following methods for handling displaying messages:
+    - `step` - for more detailed information on steps
     - `warning` - for displaying messages in a style that makes it
       visually stand out from other output
     - `phase` a context manager for organising steps into logical group
@@ -39,7 +39,7 @@ class CliConsole(AbstractConsole):
     }
 
     def _format_message(self, message: str, output: Output) -> Text:
-        """Wraps message in rich Text object and applys formatting."""
+        """Wraps message in rich Text object and applies formatting."""
         style = self._styles.get(output, "default")
         text = Text(message, style=style)
 

--- a/src/snowflake/cli/api/project/errors.py
+++ b/src/snowflake/cli/api/project/errors.py
@@ -13,7 +13,7 @@ class SchemaValidationError(Exception):
 
     def __init__(self, error: ValidationError):
         errors = error.errors()
-        message = f"During evaluation of {error.title} schema following errors were encoutered:\n"
+        message = f"During evaluation of {error.title} schema following errors were encountered:\n"
         message += "\n".join(
             [
                 self.message_templates.get(e["type"], self.generic_message).format(**e)

--- a/src/snowflake/cli/plugins/nativeapp/exceptions.py
+++ b/src/snowflake/cli/plugins/nativeapp/exceptions.py
@@ -14,7 +14,7 @@ class ApplicationPackageAlreadyExistsError(ClickException):
 
 
 class ApplicationPackageDoesNotExistError(ClickException):
-    """An application package of the specified name does not exist in the Snowflake acccount."""
+    """An application package of the specified name does not exist in the Snowflake account."""
 
     def __init__(self, name: str):
         super().__init__(

--- a/src/snowflake/cli/plugins/nativeapp/policy.py
+++ b/src/snowflake/cli/plugins/nativeapp/policy.py
@@ -5,7 +5,7 @@ import typer
 
 
 class PolicyBase(ABC):
-    """Abtract Class for various policies that govern if a Snowflake CLI command can continue execution when it asks for a decision."""
+    """Abstract Class for various policies that govern if a Snowflake CLI command can continue execution when it asks for a decision."""
 
     @abstractmethod
     def should_proceed(self, user_prompt: Optional[str]) -> bool:

--- a/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
@@ -97,7 +97,7 @@ class NativeAppTeardownProcessor(NativeAppManager, NativeAppCommandProcessor):
 
     def drop_package(self, auto_yes: bool):
         """
-        Attemps to drop application package unless user specifies otherwise.
+        Attempts to drop application package unless user specifies otherwise.
         """
         needs_confirm = True
 

--- a/src/snowflake/cli/plugins/object/stage/diff.py
+++ b/src/snowflake/cli/plugins/object/stage/diff.py
@@ -47,9 +47,7 @@ class DiffResult:
         """
         Method override for the standard behavior of string representation for this class.
         """
-        components: List[
-            str
-        ] = (
+        components: List[str] = (
             []
         )  # py3.8 does not support subscriptions for builtin list, hence using List
 
@@ -94,7 +92,7 @@ def is_valid_md5sum(checksum: str) -> bool:
 
 def compute_md5sum(file: Path) -> str:
     """
-    Returns a hexidecimal checksum for the file located at the given path.
+    Returns a hexadecimal checksum for the file located at the given path.
     """
     if not file.is_file():
         raise ValueError(

--- a/src/snowflake/cli/plugins/object/stage/diff.py
+++ b/src/snowflake/cli/plugins/object/stage/diff.py
@@ -47,7 +47,9 @@ class DiffResult:
         """
         Method override for the standard behavior of string representation for this class.
         """
-        components: List[str] = (
+        components: List[
+            str
+        ] = (
             []
         )  # py3.8 does not support subscriptions for builtin list, hence using List
 

--- a/src/snowflake/cli/plugins/sql/commands.py
+++ b/src/snowflake/cli/plugins/sql/commands.py
@@ -34,7 +34,7 @@ def execute_sql(
         "-i",
         help="Read the query from standard input. Use it when piping input to this command.",
     ),
-    **options
+    **options,
 ) -> CommandResult:
     """
     Executes Snowflake query.

--- a/src/snowflake/cli/plugins/streamlit/manager.py
+++ b/src/snowflake/cli/plugins/streamlit/manager.py
@@ -127,7 +127,7 @@ class StreamlitManager(SqlExecutionMixin):
             try:
                 self._execute_query(f"ALTER streamlit {fully_qualified_name} CHECKOUT")
             except ProgrammingError as e:
-                # If an error is raised because a CHECKOUT has already occured,
+                # If an error is raised because a CHECKOUT has already occurred,
                 # simply skip it and continue
                 if "Checkout already exists" in str(e):
                     log.info("Checkout already exists, continuing")

--- a/test_external_plugins/override_build_in_command/src/snowflakecli/test_plugins/override_build_in_command/commands.py
+++ b/test_external_plugins/override_build_in_command/src/snowflakecli/test_plugins/override_build_in_command/commands.py
@@ -12,4 +12,4 @@ print("Outside command code")
 @app.command("list")
 @with_output
 def connection_list() -> CommandResult:
-    return MessageResult("Overriden command")
+    return MessageResult("Overridden command")

--- a/tests/object/stage/test_diff.py
+++ b/tests/object/stage/test_diff.py
@@ -185,7 +185,7 @@ def test_put_files_on_stage(mock_put, overwrite_param):
         expected = [
             mock.call(
                 local_path=local_path / "ui/nested/environment.yml",
-                stage_path=f"{stage_name}/ui/nested",  # TODO: verify if trailing slash is needed, doesnt seem so from regression tests
+                stage_path=f"{stage_name}/ui/nested",  # TODO: verify if trailing slash is needed, doesn't seem so from regression tests
                 role="some_role",
                 overwrite=overwrite_param,
             ),

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -37,9 +37,11 @@ def setup_config_and_logs(snowflake_home):
                     "",
                     "[cli.logs]",
                     f'path = "{logs_path}"' if use_custom_logs_path else None,
-                    f"save_logs = {str(save_logs).lower()}"
-                    if save_logs is not None
-                    else None,
+                    (
+                        f"save_logs = {str(save_logs).lower()}"
+                        if save_logs is not None
+                        else None
+                    ),
                     f'level = "{level}"' if level else None,
                 ]
                 if x is not None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 """These tests verify that the CLI runs work as expected."""
+
 from __future__ import annotations
 
 import json

--- a/tests_integration/test_package.py
+++ b/tests_integration/test_package.py
@@ -156,7 +156,7 @@ class TestPackage:
         """
         We use PyGame in this test for two reasons:
         1. We need a package with native libraries to trigger warning
-        2. This package should not be avaiable on Snowflake Conda channel.
+        2. This package should not be available on Snowflake Conda channel.
         As it is highly unlikely, that PyGame will be included in the channel, it's probably ok to leave it for now,
         but we may reconsider switch to a package controlled by us.
         """

--- a/tests_integration/testing_utils/snowpark_utils.py
+++ b/tests_integration/testing_utils/snowpark_utils.py
@@ -115,9 +115,11 @@ class SnowparkTestSteps:
         assert_that_result_contains_row_with(
             result,
             {
-                identifier.upper()
-                if object_type == TestType.FUNCTION.value
-                else entity_name.upper(): expected_value
+                (
+                    identifier.upper()
+                    if object_type == TestType.FUNCTION.value
+                    else entity_name.upper()
+                ): expected_value
             },
         )
 


### PR DESCRIPTION
Various typo corrections. Most of these were in docstrings, but some were in message responses. 

It may be worthwhile to add this as a pre-commit hook excluding cli output test assertions where new lines can break spelling and for any non-english, but Snowflake, related terms. 