### PR TITLE
Refactor classes to use dependency inversion in order to decouple non-CLI-specific classes from CLI-specific classes/objects

### DIFF
--- a/src/snowflake/cli/api/project/definition.py
+++ b/src/snowflake/cli/api/project/definition.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Dict, List
 
 import yaml.loader
-from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
 from snowflake.cli.api.project.schemas.project_definition import ProjectDefinition
 from snowflake.cli.api.project.util import (
@@ -12,6 +11,7 @@ from snowflake.cli.api.project.util import (
     to_identifier,
 )
 from snowflake.cli.api.secure_path import SecurePath
+from snowflake.connector.connection import SnowflakeConnection
 from yaml import load
 
 DEFAULT_USERNAME = "unknown_user"
@@ -55,6 +55,7 @@ def load_project_definition(paths: List[Path]) -> ProjectDefinition:
 
 
 def generate_local_override_yml(
+    conn: SnowflakeConnection,
     project: ProjectDefinition,
 ) -> ProjectDefinition:
     """
@@ -62,7 +63,6 @@ def generate_local_override_yml(
     schema. The returned YAML object can be saved directly to a file, if desired.
     A connection is made using global context to resolve current role and warehouse.
     """
-    conn = cli_context.connection
     user = clean_identifier(get_env_username() or DEFAULT_USERNAME)
     role = conn.role
     warehouse = conn.warehouse
@@ -95,8 +95,7 @@ def default_app_package(project_name: str):
     return append_to_identifier(to_identifier(project_name), f"_pkg_{user}")
 
 
-def default_role():
-    conn = cli_context.connection
+def default_role(conn: SnowflakeConnection):
     return conn.role
 
 

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -25,9 +25,7 @@ from snowflake.connector.errors import ProgrammingError
 
 
 class SqlExecutionMixin:
-    def __init__(
-        self, connection: SnowflakeConnection
-    ):  # TODO: Check calls to constructor and inheriting classes
+    def __init__(self, connection: SnowflakeConnection):
         self._conn = connection
 
     @cached_property

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -7,7 +7,6 @@ from io import StringIO
 from textwrap import dedent
 from typing import Iterable, Optional, Tuple
 
-from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.exceptions import (
     DatabaseNotProvidedError,
@@ -20,17 +19,16 @@ from snowflake.cli.api.project.util import (
 )
 from snowflake.cli.api.utils.cursor import find_first_row
 from snowflake.cli.api.utils.naming_utils import from_qualified_name
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import DictCursor, SnowflakeCursor
 from snowflake.connector.errors import ProgrammingError
 
 
 class SqlExecutionMixin:
-    def __init__(self):
-        pass
-
-    @property
-    def _conn(self):
-        return cli_context.connection
+    def __init__(
+        self, connection: SnowflakeConnection
+    ):  # TODO: Check calls to constructor and inheriting classes
+        self._conn = connection
 
     @cached_property
     def _log(self):

--- a/src/snowflake/cli/plugins/connection/commands.py
+++ b/src/snowflake/cli/plugins/connection/commands.py
@@ -251,7 +251,7 @@ def test(
     conn = cli_context.connection
 
     # Test session attributes
-    om = ObjectManager()
+    om = ObjectManager(cli_context.connection)
     try:
         if conn.role:
             om.use(object_type=ObjectType.ROLE, name=conn.role)

--- a/src/snowflake/cli/plugins/git/commands.py
+++ b/src/snowflake/cli/plugins/git/commands.py
@@ -79,7 +79,7 @@ def setup(
     * API integration - object allowing Snowflake to interact with git repository.
     """
     manager = GitManager(cli_context.connection)
-    om = ObjectManager()
+    om = ObjectManager(cli_context.connection)
     _assure_repository_does_not_exist(om, repository_name)
 
     url = typer.prompt("Origin url")

--- a/src/snowflake/cli/plugins/git/commands.py
+++ b/src/snowflake/cli/plugins/git/commands.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import typer
 from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import (
     PatternOption,
     identifier_argument,
@@ -77,7 +78,7 @@ def setup(
 
     * API integration - object allowing Snowflake to interact with git repository.
     """
-    manager = GitManager()
+    manager = GitManager(cli_context.connection)
     om = ObjectManager()
     _assure_repository_does_not_exist(om, repository_name)
 
@@ -151,7 +152,11 @@ def list_branches(
     """
     List all branches in the repository.
     """
-    return QueryResult(GitManager().show_branches(repo_name=repository_name, like=like))
+    return QueryResult(
+        GitManager(cli_context.connection).show_branches(
+            repo_name=repository_name, like=like
+        )
+    )
 
 
 @app.command(
@@ -168,7 +173,11 @@ def list_tags(
     """
     List all tags in the repository.
     """
-    return QueryResult(GitManager().show_tags(repo_name=repository_name, like=like))
+    return QueryResult(
+        GitManager(cli_context.connection).show_tags(
+            repo_name=repository_name, like=like
+        )
+    )
 
 
 @app.command(
@@ -184,7 +193,9 @@ def list_files(
     List files from given state of git repository.
     """
     return QueryResult(
-        GitManager().list_files(stage_name=repository_path, pattern=pattern)
+        GitManager(cli_context.connection).list_files(
+            stage_name=repository_path, pattern=pattern
+        )
     )
 
 
@@ -199,7 +210,9 @@ def fetch(
     """
     Fetch changes from origin to snowflake repository.
     """
-    return QueryResult(GitManager().fetch(repo_name=repository_name))
+    return QueryResult(
+        GitManager(cli_context.connection).fetch(repo_name=repository_name)
+    )
 
 
 @app.command(
@@ -225,11 +238,11 @@ def copy(
     """
     is_copy = is_stage_path(destination_path)
     if is_copy:
-        cursor = GitManager().copy_files(
+        cursor = GitManager(cli_context.connection).copy_files(
             source_path=repository_path, destination_path=destination_path
         )
     else:
-        cursor = GitManager().get(
+        cursor = GitManager(cli_context.connection).get(
             stage_path=repository_path,
             dest_path=Path(destination_path).resolve(),
             parallel=parallel,

--- a/src/snowflake/cli/plugins/git/manager.py
+++ b/src/snowflake/cli/plugins/git/manager.py
@@ -1,10 +1,14 @@
 from textwrap import dedent
 
 from snowflake.cli.plugins.object.stage.manager import StageManager
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 
 class GitManager(StageManager):
+    def __init__(self, conn: SnowflakeConnection):
+        super().__init__(conn)
+
     def show_branches(self, repo_name: str, like: str) -> SnowflakeCursor:
         return self._execute_query(f"show git branches like '{like}' in {repo_name}")
 

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -7,6 +7,7 @@ from snowflake.cli.api.commands.decorators import (
     with_project_definition,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyper
+from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.output.types import (
     CollectionResult,
     CommandResult,
@@ -124,6 +125,7 @@ def app_bundle(
     """
     manager = NativeAppManager(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -172,6 +174,7 @@ def app_run(
 
     processor = NativeAppRunProcessor(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -200,6 +203,7 @@ def app_open(
     """
     manager = NativeAppManager(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -223,6 +227,7 @@ def app_teardown(
     """
     processor = NativeAppTeardownProcessor(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -240,6 +245,7 @@ def app_deploy(
     """
     manager = NativeAppManager(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -123,6 +123,7 @@ def app_bundle(
     Prepares a local folder with configured app artifacts.
     """
     manager = NativeAppManager(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -170,6 +171,7 @@ def app_run(
         policy = DenyAlwaysPolicy()
 
     processor = NativeAppRunProcessor(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -197,6 +199,7 @@ def app_open(
     once it has been installed in your account.
     """
     manager = NativeAppManager(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -219,6 +222,7 @@ def app_teardown(
     Attempts to drop both the application object and application package as defined in the project definition file.
     """
     processor = NativeAppTeardownProcessor(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -235,6 +239,7 @@ def app_deploy(
     Creates an application package in your Snowflake account and syncs the local changes to the stage without creating or updating the application.
     """
     manager = NativeAppManager(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -191,7 +191,7 @@ class NativeAppManager(SqlExecutionMixin):
         if self.definition.package and self.definition.package.role:
             return self.definition.package.role
         else:
-            return default_role()
+            return default_role(self._conn)
 
     @cached_property
     def package_distribution(self) -> str:
@@ -212,7 +212,7 @@ class NativeAppManager(SqlExecutionMixin):
         if self.definition.application and self.definition.application.role:
             return self.definition.application.role
         else:
-            return default_role()
+            return default_role(self._conn)
 
     @cached_property
     def debug_mode(self) -> bool:

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -108,9 +108,7 @@ class NativeAppCommandProcessor(ABC):
         pass
 
 
-class NativeAppManager(
-    SqlExecutionMixin
-):  # TODO: Review calls to constructor and inheriting classes
+class NativeAppManager(SqlExecutionMixin):
     """
     Base class with frequently used functionality already implemented and ready to be used by related subclasses.
     """

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -28,14 +28,20 @@ from snowflake.cli.plugins.nativeapp.policy import PolicyBase
 from snowflake.cli.plugins.object.stage.diff import DiffResult
 from snowflake.cli.plugins.object.stage.manager import StageManager
 from snowflake.connector import ProgrammingError
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 UPGRADE_RESTRICTION_CODES = {93044, 93055, 93045, 93046}
 
 
 class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
-    def __init__(self, project_definition: NativeApp, project_root: Path):
-        super().__init__(project_definition, project_root)
+    def __init__(
+        self,
+        conn: SnowflakeConnection,
+        project_definition: NativeApp,
+        project_root: Path,
+    ):
+        super().__init__(conn, project_definition, project_root)
 
     def _create_dev_app(self, diff: DiffResult) -> None:
         """

--- a/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
@@ -21,12 +21,15 @@ from snowflake.cli.plugins.nativeapp.manager import (
     ensure_correct_owner,
 )
 from snowflake.cli.plugins.nativeapp.utils import needs_confirmation
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import DictCursor
 
 
 class NativeAppTeardownProcessor(NativeAppManager, NativeAppCommandProcessor):
-    def __init__(self, project_definition: Dict, project_root: Path):
-        super().__init__(project_definition, project_root)
+    def __init__(
+        self, conn: SnowflakeConnection, project_definition: Dict, project_root: Path
+    ):
+        super().__init__(conn, project_definition, project_root)
 
     def drop_generic_object(self, object_type: str, object_name: str, role: str):
         """

--- a/src/snowflake/cli/plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/commands.py
@@ -8,6 +8,7 @@ from snowflake.cli.api.commands.decorators import (
     with_project_definition,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyper
+from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.output.types import CommandResult, MessageResult, QueryResult
 from snowflake.cli.plugins.nativeapp.common_flags import ForceOption, InteractiveOption
 from snowflake.cli.plugins.nativeapp.policy import (
@@ -75,6 +76,7 @@ def create(
 
     processor = NativeAppVersionCreateProcessor(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -101,6 +103,7 @@ def version_list(
     """
     processor = NativeAppRunProcessor(
         conn=cli_context.connection,
+        console=cli_console,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )

--- a/src/snowflake/cli/plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/commands.py
@@ -74,6 +74,7 @@ def create(
         git_policy = AllowAlwaysPolicy()
 
     processor = NativeAppVersionCreateProcessor(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -99,6 +100,7 @@ def version_list(
     Lists all versions defined in an application package.
     """
     processor = NativeAppRunProcessor(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
@@ -131,6 +133,7 @@ def drop(
         policy = DenyAlwaysPolicy()
 
     processor = NativeAppVersionDropProcessor(
+        conn=cli_context.connection,
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )

--- a/src/snowflake/cli/plugins/nativeapp/version/version_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/version_processor.py
@@ -25,6 +25,7 @@ from snowflake.cli.plugins.nativeapp.manager import (
 from snowflake.cli.plugins.nativeapp.policy import PolicyBase
 from snowflake.cli.plugins.nativeapp.run_processor import NativeAppRunProcessor
 from snowflake.connector import ProgrammingError
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import DictCursor
 
 
@@ -67,8 +68,10 @@ def check_index_changes_in_git_repo(
 
 
 class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
-    def __init__(self, project_definition: Dict, project_root: Path):
-        super().__init__(project_definition, project_root)
+    def __init__(
+        self, conn: SnowflakeConnection, project_definition: Dict, project_root: Path
+    ):
+        super().__init__(conn, project_definition, project_root)
 
     def get_existing_release_directive_info_for_version(
         self, version: str
@@ -241,8 +244,13 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
 
 
 class NativeAppVersionDropProcessor(NativeAppManager, NativeAppCommandProcessor):
-    def __init__(self, project_definition: NativeApp, project_root: Path):
-        super().__init__(project_definition, project_root)
+    def __init__(
+        self,
+        conn: SnowflakeConnection,
+        project_definition: NativeApp,
+        project_root: Path,
+    ):
+        super().__init__(conn, project_definition, project_root)
 
     def process(
         self,

--- a/src/snowflake/cli/plugins/object/commands.py
+++ b/src/snowflake/cli/plugins/object/commands.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import typer
 from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import like_option
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.constants import SUPPORTED_OBJECTS, VALID_SCOPES
@@ -62,7 +63,9 @@ def list_(
 ):
     _scope_validate(object_type, scope)
     return QueryResult(
-        ObjectManager().show(object_type=object_type, like=like, scope=scope)
+        ObjectManager(cli_context.connection).show(
+            object_type=object_type, like=like, scope=scope
+        )
     )
 
 
@@ -71,7 +74,11 @@ def list_(
     requires_connection=True,
 )
 def drop(object_type: str = ObjectArgument, object_name: str = NameArgument, **options):
-    return QueryResult(ObjectManager().drop(object_type=object_type, name=object_name))
+    return QueryResult(
+        ObjectManager(cli_context.connection).drop(
+            object_type=object_type, name=object_name
+        )
+    )
 
 
 # Image repository is the only supported object that does not have a DESCRIBE command.
@@ -86,5 +93,7 @@ def describe(
     object_type: str = ObjectArgument, object_name: str = NameArgument, **options
 ):
     return QueryResult(
-        ObjectManager().describe(object_type=object_type, name=object_name)
+        ObjectManager(cli_context.connection).describe(
+            object_type=object_type, name=object_name
+        )
     )

--- a/src/snowflake/cli/plugins/object/manager.py
+++ b/src/snowflake/cli/plugins/object/manager.py
@@ -6,6 +6,7 @@ from click import ClickException
 from snowflake.cli.api.constants import OBJECT_TO_NAMES, ObjectNames
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector import ProgrammingError
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 
@@ -17,6 +18,9 @@ def _get_object_names(object_type: str) -> ObjectNames:
 
 
 class ObjectManager(SqlExecutionMixin):
+    def __init__(self, conn: SnowflakeConnection):
+        super().__init__(conn)
+
     def show(
         self,
         *,

--- a/src/snowflake/cli/plugins/object/stage/commands.py
+++ b/src/snowflake/cli/plugins/object/stage/commands.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import click
 import typer
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import PatternOption
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.console import cli_console
@@ -35,7 +36,9 @@ def stage_list(
     """
     Lists the stage contents.
     """
-    cursor = StageManager().list_files(stage_name=stage_name, pattern=pattern)
+    cursor = StageManager(cli_context.connection).list_files(
+        stage_name=stage_name, pattern=pattern
+    )
     return QueryResult(cursor)
 
 
@@ -98,7 +101,7 @@ def stage_create(stage_name: str = StageNameArgument, **options) -> CommandResul
     """
     Creates a named stage if it does not already exist.
     """
-    cursor = StageManager().create(stage_name=stage_name)
+    cursor = StageManager(cli_context.connection).create(stage_name=stage_name)
     return SingleQueryResult(cursor)
 
 
@@ -112,7 +115,9 @@ def stage_remove(
     Removes a file from a stage.
     """
 
-    cursor = StageManager().remove(stage_name=stage_name, path=file_name)
+    cursor = StageManager(cli_context.connection).remove(
+        stage_name=stage_name, path=file_name
+    )
     return SingleQueryResult(cursor)
 
 
@@ -125,7 +130,9 @@ def stage_diff(
     """
     Diffs a stage with a local folder.
     """
-    diff: DiffResult = stage_diff(Path(folder_name), stage_name)
+    diff: DiffResult = stage_diff(
+        StageManager(cli_context.connection), Path(folder_name), stage_name
+    )
     return ObjectResult(str(diff))
 
 

--- a/src/snowflake/cli/plugins/object/stage/diff.py
+++ b/src/snowflake/cli/plugins/object/stage/diff.py
@@ -156,7 +156,7 @@ def build_md5_map(list_stage_cursor: SnowflakeCursor) -> Dict[str, str]:
 
 def stage_diff(
     stage_manager: StageManager, local_path: Path, stage_fqn: str
-) -> DiffResult:  # TODO: Check all references
+) -> DiffResult:
     """
     Diffs the files in a stage with a local folder.
     """

--- a/src/snowflake/cli/plugins/object/stage/diff.py
+++ b/src/snowflake/cli/plugins/object/stage/diff.py
@@ -154,11 +154,12 @@ def build_md5_map(list_stage_cursor: SnowflakeCursor) -> Dict[str, str]:
     }
 
 
-def stage_diff(local_path: Path, stage_fqn: str) -> DiffResult:
+def stage_diff(
+    stage_manager: StageManager, local_path: Path, stage_fqn: str
+) -> DiffResult:  # TODO: Check all references
     """
     Diffs the files in a stage with a local folder.
     """
-    stage_manager = StageManager()
     local_files = enumerate_files(local_path)
     remote_md5 = build_md5_map(stage_manager.list_files(stage_fqn))
 
@@ -237,12 +238,15 @@ def put_files_on_stage(
 
 
 def sync_local_diff_with_stage(
-    role: str, deploy_root_path: Path, diff_result: DiffResult, stage_path: str
+    stage_manager: StageManager,
+    role: str,
+    deploy_root_path: Path,
+    diff_result: DiffResult,
+    stage_path: str,
 ):
     """
     Syncs a given local directory's contents with a Snowflake stage, including removing old files, and re-uploading modified and new files.
     """
-    stage_manager = StageManager()
     log.info(
         "Uploading diff-ed files from your local %s directory to the Snowflake stage.",
         deploy_root_path,

--- a/src/snowflake/cli/plugins/object/stage/manager.py
+++ b/src/snowflake/cli/plugins/object/stage/manager.py
@@ -11,6 +11,7 @@ from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.utils.path_utils import path_resolver
 from snowflake.connector import DictCursor
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 log = logging.getLogger(__name__)
@@ -20,6 +21,9 @@ UNQUOTED_FILE_URI_REGEX = r"[\w/*?\-.=&{}$#[\]\"\\!@%^+:]+"
 
 
 class StageManager(SqlExecutionMixin):
+    def __init__(self, conn: SnowflakeConnection):
+        super().__init__(conn)
+
     @staticmethod
     def get_standard_stage_prefix(name: str) -> str:
         # Handle embedded stages

--- a/src/snowflake/cli/plugins/snowpark/commands.py
+++ b/src/snowflake/cli/plugins/snowpark/commands.py
@@ -104,9 +104,9 @@ def deploy(
             "Please use build command to create it."
         )
 
-    pm = ProcedureManager()
-    fm = FunctionManager()
-    om = ObjectManager()
+    pm = ProcedureManager(cli_context.connection)
+    fm = FunctionManager(cli_context.connection)
+    om = ObjectManager(cli_context.connection)
 
     _assert_object_definitions_are_correct("function", functions)
     _assert_object_definitions_are_correct("procedure", procedures)
@@ -427,9 +427,9 @@ def _execute_object_method(
     **kwargs,
 ):
     if object_type == _SnowparkObject.PROCEDURE:
-        manager = ProcedureManager()
+        manager = ProcedureManager(cli_context.connection)
     elif object_type == _SnowparkObject.FUNCTION:
-        manager = FunctionManager()
+        manager = FunctionManager(cli_context.connection)
     else:
         raise ClickException(f"Unknown object type: {object_type}")
 

--- a/src/snowflake/cli/plugins/snowpark/commands.py
+++ b/src/snowflake/cli/plugins/snowpark/commands.py
@@ -124,7 +124,7 @@ def deploy(
 
     # Create stage
     stage_name = snowpark.stage_name
-    stage_manager = StageManager()
+    stage_manager = StageManager(cli_context.connection)
     stage_name = stage_manager.to_fully_qualified_name(stage_name)
     stage_manager.create(
         stage_name=stage_name, comment="deployments managed by Snowflake CLI"

--- a/src/snowflake/cli/plugins/snowpark/common.py
+++ b/src/snowflake/cli/plugins/snowpark/common.py
@@ -8,6 +8,7 @@ from snowflake.cli.api.project.schemas.snowpark.argument import Argument
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.snowpark.package_utils import generate_deploy_stage_name
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 DEFAULT_RUNTIME = "3.8"
@@ -112,6 +113,9 @@ def _sql_to_python_return_type_mapper(resource_return_type: str) -> str:
 
 
 class SnowparkObjectManager(SqlExecutionMixin):
+    def __init__(self, conn: SnowflakeConnection):
+        super().__init__(conn)
+
     @property
     def _object_type(self) -> ObjectType:
         raise NotImplementedError()

--- a/src/snowflake/cli/plugins/snowpark/manager.py
+++ b/src/snowflake/cli/plugins/snowpark/manager.py
@@ -5,12 +5,16 @@ from typing import Dict, List, Optional
 
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.plugins.snowpark.common import SnowparkObjectManager
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 log = logging.getLogger(__name__)
 
 
 class FunctionManager(SnowparkObjectManager):
+    def __init__(self, conn: SnowflakeConnection):
+        super().__init__(conn)
+
     @property
     def _object_type(self):
         return ObjectType.FUNCTION

--- a/src/snowflake/cli/plugins/snowpark/package/commands.py
+++ b/src/snowflake/cli/plugins/snowpark/package/commands.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import typer
 from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import (
     deprecated_flag_callback,
 )
@@ -35,6 +36,8 @@ from snowflake.cli.plugins.snowpark.snowpark_shared import (
     resolve_allow_shared_libraries_yes_no_ask,
 )
 from snowflake.cli.plugins.snowpark.zipper import zip_dir
+
+from src.snowflake.cli.plugins.object.stage.manager import StageManager
 
 app = SnowTyper(
     name="package",
@@ -123,7 +126,10 @@ def package_upload(
     """
     Uploads a Python package zip file to a Snowflake stage so it can be referenced in the imports of a procedure or function.
     """
-    return MessageResult(upload(file=file, stage=stage, overwrite=overwrite))
+    return MessageResult(
+        StageManager(cli_context.connection),
+        upload(file=file, stage=stage, overwrite=overwrite),
+    )
 
 
 deprecated_pypi_download_option = typer.Option(

--- a/src/snowflake/cli/plugins/snowpark/package/manager.py
+++ b/src/snowflake/cli/plugins/snowpark/package/manager.py
@@ -10,11 +10,10 @@ from snowflake.cli.plugins.snowpark.package.utils import prepare_app_zip
 log = logging.getLogger(__name__)
 
 
-def upload(file: Path, stage: str, overwrite: bool):
+def upload(sm: StageManager, file: Path, stage: str, overwrite: bool):
     log.info("Uploading %s to Snowflake @%s/%s...", file, stage, file)
     with SecurePath.temporary_directory() as temp_dir:
         temp_app_zip_path = prepare_app_zip(SecurePath(file), temp_dir)
-        sm = StageManager()
 
         sm.create(sm.get_stage_name_from_path(stage))
         put_response = sm.put(

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import typer
 from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import IfNotExistsOption, OverrideableOption
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import CommandResult, SingleQueryResult
@@ -95,7 +96,7 @@ def create(
     Creates a new compute pool.
     """
     max_nodes = validate_and_set_instances(min_nodes, max_nodes, "nodes")
-    cursor = ComputePoolManager().create(
+    cursor = ComputePoolManager(cli_context.connection).create(
         pool_name=name,
         min_nodes=min_nodes,
         max_nodes=max_nodes,
@@ -114,7 +115,7 @@ def stop_all(name: str = ComputePoolNameArgument, **options) -> CommandResult:
     """
     Deletes all services running on the compute pool.
     """
-    cursor = ComputePoolManager().stop(pool_name=name)
+    cursor = ComputePoolManager(cli_context.connection).stop(pool_name=name)
     return SingleQueryResult(cursor)
 
 
@@ -123,7 +124,7 @@ def suspend(name: str = ComputePoolNameArgument, **options) -> CommandResult:
     """
     Suspends the compute pool by suspending all currently running services and then releasing compute pool nodes.
     """
-    return SingleQueryResult(ComputePoolManager().suspend(name))
+    return SingleQueryResult(ComputePoolManager(cli_context.connection).suspend(name))
 
 
 @app.command(requires_connection=True)
@@ -131,7 +132,7 @@ def resume(name: str = ComputePoolNameArgument, **options) -> CommandResult:
     """
     Resumes the compute pool from a SUSPENDED state.
     """
-    return SingleQueryResult(ComputePoolManager().resume(name))
+    return SingleQueryResult(ComputePoolManager(cli_context.connection).resume(name))
 
 
 @app.command("set", requires_connection=True)
@@ -151,7 +152,7 @@ def set_property(
     """
     Sets one or more properties for the compute pool.
     """
-    cursor = ComputePoolManager().set_property(
+    cursor = ComputePoolManager(cli_context.connection).set_property(
         pool_name=name,
         min_nodes=min_nodes,
         max_nodes=max_nodes,
@@ -187,7 +188,7 @@ def unset_property(
     """
     Resets one or more properties for the compute pool to their default value(s).
     """
-    cursor = ComputePoolManager().unset_property(
+    cursor = ComputePoolManager(cli_context.connection).unset_property(
         pool_name=name,
         auto_resume=auto_resume,
         auto_suspend_secs=auto_suspend_secs,
@@ -201,5 +202,5 @@ def status(pool_name: str = ComputePoolNameArgument, **options) -> CommandResult
     """
     Retrieves the status of a compute pool along with a relevant message, if one exists.
     """
-    cursor = ComputePoolManager().status(pool_name=pool_name)
+    cursor = ComputePoolManager(cli_context.connection).status(pool_name=pool_name)
     return SingleQueryResult(cursor)

--- a/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
@@ -7,11 +7,15 @@ from snowflake.cli.plugins.spcs.common import (
     handle_object_already_exists,
     strip_empty_lines,
 )
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.errors import ProgrammingError
 
 
 class ComputePoolManager(SqlExecutionMixin):
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
+
     def create(
         self,
         pool_name: str,

--- a/src/snowflake/cli/plugins/spcs/image_registry/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_registry/commands.py
@@ -1,3 +1,4 @@
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import MessageResult, ObjectResult
 from snowflake.cli.plugins.spcs.image_registry.manager import (
@@ -28,7 +29,7 @@ def token(**options) -> ObjectResult:
 
 
     """
-    return ObjectResult(RegistryManager().get_token())
+    return ObjectResult(RegistryManager(cli_context.connection).get_token())
 
 
 @app.command(requires_connection=True)
@@ -38,7 +39,7 @@ def url(**options) -> MessageResult:
 
     Must be called from a role that can view at least one image repository in the image registry.
     """
-    return MessageResult(RegistryManager().get_registry_url())
+    return MessageResult(RegistryManager(cli_context.connection).get_registry_url())
 
 
 @app.command(requires_connection=True)
@@ -48,4 +49,6 @@ def login(**options) -> MessageResult:
 
     Must be called from a role that can view at least one image repository in the image registry.
     """
-    return MessageResult(RegistryManager().docker_registry_login().strip())
+    return MessageResult(
+        RegistryManager(cli_context.connection).docker_registry_login().strip()
+    )

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -4,6 +4,7 @@ from typing import Optional
 import requests
 import typer
 from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import IfNotExistsOption, ReplaceOption
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.console import cli_console
@@ -48,7 +49,7 @@ def create(
     Creates a new image repository in the current schema.
     """
     return SingleQueryResult(
-        ImageRepositoryManager().create(
+        ImageRepositoryManager(cli_context.connection).create(
             name=name, replace=replace, if_not_exists=if_not_exists
         )
     )
@@ -60,12 +61,12 @@ def list_images(
     **options,
 ) -> CollectionResult:
     """Lists images in the given repository."""
-    repository_manager = ImageRepositoryManager()
+    repository_manager = ImageRepositoryManager(cli_context.connection)
     database = repository_manager.get_database()
     schema = repository_manager.get_schema()
     url = repository_manager.get_repository_url(name)
     api_url = repository_manager.get_repository_api_url(url)
-    bearer_login = RegistryManager().login_to_registry(api_url)
+    bearer_login = RegistryManager(cli_context.connection).login_to_registry(api_url)
     repos = []
     query: Optional[str] = f"{api_url}/_catalog?n=10"
 
@@ -111,10 +112,10 @@ def list_tags(
 ) -> CollectionResult:
     """Lists tags for the given image in a repository."""
 
-    repository_manager = ImageRepositoryManager()
+    repository_manager = ImageRepositoryManager(cli_context.connection)
     url = repository_manager.get_repository_url(name)
     api_url = repository_manager.get_repository_api_url(url)
-    bearer_login = RegistryManager().login_to_registry(api_url)
+    bearer_login = RegistryManager(cli_context.connection).login_to_registry(api_url)
 
     image_realname = "/".join(image_name.split("/")[4:])
     tags = []
@@ -154,5 +155,9 @@ def repo_url(
 ):
     """Returns the URL for the given repository."""
     return MessageResult(
-        (ImageRepositoryManager().get_repository_url(repo_name=name, with_scheme=False))
+        (
+            ImageRepositoryManager(cli_context.connection).get_repository_url(
+                repo_name=name, with_scheme=False
+            )
+        )
     )

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -3,10 +3,14 @@ from urllib.parse import urlparse
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.spcs.common import handle_object_already_exists
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.errors import ProgrammingError
 
 
 class ImageRepositoryManager(SqlExecutionMixin):
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
+
     def get_database(self):
         return self._conn.database
 

--- a/src/snowflake/cli/plugins/spcs/jobs/commands.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/commands.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import typer
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import CommandResult, SingleQueryResult
 from snowflake.cli.plugins.spcs.common import print_log_lines
@@ -32,7 +33,9 @@ def create(
     """
     Creates a job to run in a compute pool.
     """
-    cursor = JobManager().create(compute_pool=compute_pool, spec_path=spec_path)
+    cursor = JobManager(cli_context).create(
+        compute_pool=compute_pool, spec_path=spec_path
+    )
     return SingleQueryResult(cursor)
 
 
@@ -47,7 +50,9 @@ def logs(
     """
     Retrieves local logs from a job container.
     """
-    results = JobManager().logs(job_name=identifier, container_name=container_name)
+    results = JobManager(cli_context.connection).logs(
+        job_name=identifier, container_name=container_name
+    )
     cursor = results.fetchone()
     logs = next(iter(cursor)).split("\n")
     print_log_lines(sys.stdout, identifier, "0", logs)
@@ -60,5 +65,5 @@ def status(
     """
     Returns the status of a named Snowpark Container Services job.
     """
-    cursor = JobManager().status(job_name=identifier)
+    cursor = JobManager(cli_context.connection).status(job_name=identifier)
     return SingleQueryResult(cursor)

--- a/src/snowflake/cli/plugins/spcs/jobs/manager.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/manager.py
@@ -3,10 +3,14 @@ from pathlib import Path
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 
 class JobManager(SqlExecutionMixin):
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
+
     def create(self, compute_pool: str, spec_path: Path) -> SnowflakeCursor:
         spec = self._read_yaml(spec_path)
         return self._execute_schema_query(

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 import typer
 from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.flags import IfNotExistsOption, OverrideableOption
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import (
@@ -102,7 +103,7 @@ def create(
     max_instances = validate_and_set_instances(
         min_instances, max_instances, "instances"
     )
-    cursor = ServiceManager().create(
+    cursor = ServiceManager(cli_context.connection).create(
         service_name=name,
         min_instances=min_instances,
         max_instances=max_instances,
@@ -123,7 +124,7 @@ def status(name: str = ServiceNameArgument, **options) -> CommandResult:
     """
     Retrieves the status of a service.
     """
-    cursor = ServiceManager().status(service_name=name)
+    cursor = ServiceManager(cli_context.connection).status(service_name=name)
     return QueryJsonValueResult(cursor)
 
 
@@ -144,7 +145,7 @@ def logs(
     """
     Retrieves local logs from a service container.
     """
-    results = ServiceManager().logs(
+    results = ServiceManager(cli_context.connection).logs(
         service_name=name,
         instance_id=instance_id,
         container_name=container_name,
@@ -165,7 +166,9 @@ def upgrade(
     Updates an existing service with a new specification file.
     """
     return SingleQueryResult(
-        ServiceManager().upgrade_spec(service_name=name, spec_path=spec_path)
+        ServiceManager(cli_context.connection).upgrade_spec(
+            service_name=name, spec_path=spec_path
+        )
     )
 
 
@@ -174,7 +177,9 @@ def list_endpoints(name: str = ServiceNameArgument, **options):
     """
     Lists the endpoints in a service.
     """
-    return QueryResult(ServiceManager().list_endpoints(service_name=name))
+    return QueryResult(
+        ServiceManager(cli_context.connection).list_endpoints(service_name=name)
+    )
 
 
 @app.command(requires_connection=True)
@@ -182,7 +187,7 @@ def suspend(name: str = ServiceNameArgument, **options) -> CommandResult:
     """
     Suspends the service, shutting down and deleting all its containers.
     """
-    return SingleQueryResult(ServiceManager().suspend(name))
+    return SingleQueryResult(ServiceManager(cli_context.connection).suspend(name))
 
 
 @app.command(requires_connection=True)
@@ -190,7 +195,7 @@ def resume(name: str = ServiceNameArgument, **options) -> CommandResult:
     """
     Resumes the service from a SUSPENDED state.
     """
-    return SingleQueryResult(ServiceManager().resume(name))
+    return SingleQueryResult(ServiceManager(cli_context.connection).resume(name))
 
 
 @app.command("set", requires_connection=True)
@@ -206,7 +211,7 @@ def set_property(
     """
     Sets one or more properties for the service.
     """
-    cursor = ServiceManager().set_property(
+    cursor = ServiceManager(cli_context.connection).set_property(
         service_name=name,
         min_instances=min_instances,
         max_instances=max_instances,
@@ -252,7 +257,7 @@ def unset_property(
     """
     Resets one or more properties for the service to their default value(s).
     """
-    cursor = ServiceManager().unset_property(
+    cursor = ServiceManager(cli_context.connection).unset_property(
         service_name=name,
         min_instances=min_instances,
         max_instances=max_instances,

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -12,11 +12,15 @@ from snowflake.cli.plugins.spcs.common import (
     handle_object_already_exists,
     strip_empty_lines,
 )
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.errors import ProgrammingError
 
 
 class ServiceManager(SqlExecutionMixin):
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
+
     def create(
         self,
         service_name: str,

--- a/src/snowflake/cli/plugins/sql/commands.py
+++ b/src/snowflake/cli/plugins/sql/commands.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import CommandResult, MultipleResults, QueryResult
 from snowflake.cli.plugins.sql.manager import SqlManager
@@ -42,7 +43,9 @@ def execute_sql(
     Query to execute can be specified using query option, filename option (all queries from file will be executed)
     or via stdin by piping output from other command. For example `cat my.sql | snow sql -i`.
     """
-    single_statement, cursors = SqlManager().execute(query, file, std_in)
+    single_statement, cursors = SqlManager(cli_context.connection).execute(
+        query, file, std_in
+    )
     if single_statement:
         return QueryResult(next(cursors))
     return MultipleResults((QueryResult(c) for c in cursors))

--- a/src/snowflake/cli/plugins/sql/manager.py
+++ b/src/snowflake/cli/plugins/sql/manager.py
@@ -6,11 +6,15 @@ from typing import Iterable, Optional, Tuple
 from click import UsageError
 from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.util_text import split_statements
 
 
 class SqlManager(SqlExecutionMixin):
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
+
     def execute(
         self, query: Optional[str], file: Optional[Path], std_in: bool
     ) -> Tuple[int, Iterable[SnowflakeCursor]]:

--- a/src/snowflake/cli/plugins/streamlit/commands.py
+++ b/src/snowflake/cli/plugins/streamlit/commands.py
@@ -60,7 +60,9 @@ def streamlit_share(
     """
     Shares a Streamlit app with another role.
     """
-    cursor = StreamlitManager().share(streamlit_name=name, to_role=to_role)
+    cursor = StreamlitManager(cli_context.connection).share(
+        streamlit_name=name, to_role=to_role
+    )
     return SingleQueryResult(cursor)
 
 
@@ -110,7 +112,7 @@ def streamlit_deploy(
     elif pages_dir is None:
         pages_dir = "pages"
 
-    url = StreamlitManager().deploy(
+    url = StreamlitManager(cli_context.connection).deploy(
         streamlit_name=streamlit.name,
         environment_file=Path(environment_file),
         pages_dir=Path(pages_dir),
@@ -135,7 +137,7 @@ def get_url(
     **options,
 ):
     """Returns a URL to the specified Streamlit app"""
-    url = StreamlitManager().get_url(streamlit_name=name)
+    url = StreamlitManager(cli_context.connection).get_url(streamlit_name=name)
     if open_:
         typer.launch(url)
     return MessageResult(url)

--- a/test_external_plugins/multilingual_hello_command_group/src/snowflakecli/test_plugins/multilingual_hello/commands.py
+++ b/test_external_plugins/multilingual_hello_command_group/src/snowflakecli/test_plugins/multilingual_hello/commands.py
@@ -1,4 +1,5 @@
 import typer
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
     with_output,
@@ -21,7 +22,7 @@ def _hello(
     name: str,
     language: HelloLanguage,
 ) -> CommandResult:
-    hello_manager = MultilingualHelloManager()
+    hello_manager = MultilingualHelloManager(cli_context.connection)
     cursor = hello_manager.say_hello(name, language)
     return SingleQueryResult(cursor)
 

--- a/test_external_plugins/multilingual_hello_command_group/src/snowflakecli/test_plugins/multilingual_hello/manager.py
+++ b/test_external_plugins/multilingual_hello_command_group/src/snowflakecli/test_plugins/multilingual_hello/manager.py
@@ -1,9 +1,13 @@
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflakecli.test_plugins.multilingual_hello.hello_language import HelloLanguage
 
 
 class MultilingualHelloManager(SqlExecutionMixin):
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
+
     def say_hello(self, name: str, language: HelloLanguage) -> SnowflakeCursor:
         prefix = "Hello"
         if language == HelloLanguage.en:

--- a/test_external_plugins/snowpark_hello_single_command/src/snowflakecli/test_plugins/snowpark_hello/commands.py
+++ b/test_external_plugins/snowpark_hello_single_command/src/snowflakecli/test_plugins/snowpark_hello/commands.py
@@ -1,4 +1,5 @@
 import typer
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
     with_output,
@@ -19,6 +20,6 @@ def hello(
     """
     Says hello
     """
-    hello_manager = SnowparkHelloManager()
+    hello_manager = SnowparkHelloManager(cli_context.connection)
     cursor = hello_manager.say_hello(name)
     return SingleQueryResult(cursor)

--- a/test_external_plugins/snowpark_hello_single_command/src/snowflakecli/test_plugins/snowpark_hello/manager.py
+++ b/test_external_plugins/snowpark_hello_single_command/src/snowflakecli/test_plugins/snowpark_hello/manager.py
@@ -1,5 +1,6 @@
 from snowflake.cli.api import api_provider
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 
@@ -9,6 +10,9 @@ class SnowparkHelloManager(SqlExecutionMixin):
     _greeting = _api.plugin_config_provider.get_config(
         "snowpark-hello"
     ).internal_config["greeting"]
+
+    def __init__(self, connection: SnowflakeConnection):
+        super().__init__(connection)
 
     def say_hello(self, name: str) -> SnowflakeCursor:
         return self._execute_query(

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import PropertyMock
 
 import pytest
+from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.project.definition import (
     generate_local_override_yml,
     load_project_definition,
@@ -45,7 +46,7 @@ def test_na_minimal_project(project_definition_files: List[Path]):
             # TODO: probably a better way of going about this is to not generate
             # a definition structure for these values but directly return defaults
             # in "getter" functions (higher-level data structures).
-            local = generate_local_override_yml(project)
+            local = generate_local_override_yml(cli_context.connection, project)
             assert local.native_app.application.name == "minimal_jsmith"
             assert local.native_app.application.role == "resolved_role"
             assert local.native_app.application.warehouse == "resolved_warehouse"


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
#### Why are these changes being proposed?

1. It would be useful for other teams to be able to use the **Python** code that handles the creation and manipulation of Native Apps (for example).
2. Currently, there are many objects that are directly or indirectly using the **CLI global context** (many objects inherit from the `SqlExecutionMixin`, which uses the **CLI global context connection**), or using the `cli_console`. This makes it complicated to use them out of the context of the CLI, if we wanted to do that (so that IDE plugins/extensions can take advantage of this code).

#### What are the changes?
1. The `SqlExecutionMixin` receives a connection through its constructor, instead of using the one from the **CLI global context**.
2. The descendants of the `SqlExecutionMixin` also receive the connection through its constructor and pass it to the constructor of its parent.
3. The functions that initialize objects which inherit from `SqlExecutionMixin` will need to pass them an explicit connection. Some functions have been modified to receive these objects instead of initializing them.
4. Classes that used to import the `cli_console` now receive an `AbstractConsole` parameter in the constructor.
5. **In summary, these changes promote classes receiving dependencies in the constructor, instead of using concrete objects that are imported from another module. The objective is to decouple these classes (which contain logic that is not specific from the CLI) from the classes/objects that are specific to the CLI.**
