### PR TITLE
Make connection tests errors more meaningful

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -73,6 +73,7 @@
 * Fix handling database/schema/role identifiers containing dashes
 * Fix schema override bug in `snow connection test`
 * Hidden incorrectly working config permissions warning on Windows
+* Make errors from `snow connection test` more meaningful when role, warehouse or database does not exist.
 
 # v2.1.2
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,7 @@
 * `snow sql` command supports now client-side templating of queries.
 
 ## Fixes and improvements
+* Make errors from `snow connection test` more meaningful when role, warehouse or database does not exist.
 
 
 # v2.2.0
@@ -73,7 +74,6 @@
 * Fix handling database/schema/role identifiers containing dashes
 * Fix schema override bug in `snow connection test`
 * Hidden incorrectly working config permissions warning on Windows
-* Make errors from `snow connection test` more meaningful when role, warehouse or database does not exist.
 
 # v2.1.2
 

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -64,7 +64,13 @@ class SqlExecutionMixin:
         return list(self._execute_string(dedent(queries), **kwargs))
 
     def use(self, object_type: ObjectType, name: str):
-        return self._execute_query(f"use {object_type.value.sf_name} {name}")
+        try:
+            self._execute_query(f"use {object_type.value.sf_name} {name}")
+        except ProgrammingError:
+            # Rewrite the error to make the message more useful.
+            raise ProgrammingError(
+                f"Could not use {object_type} {name}. Object does not exist, or operation cannot be performed."
+            )
 
     @contextmanager
     def use_role(self, new_role: str):

--- a/tests_integration/test_connection.py
+++ b/tests_integration/test_connection.py
@@ -43,4 +43,6 @@ def test_connection_not_existing_schema(
     with mock_single_env_var(SCHEMA_ENV_PARAMETER, value=schema):
         result = runner.invoke_with_connection(["connection", "test"])
         assert result.exit_code == 1, result.output
-        assert "Object does not exist" in result.output
+        assert (
+            f'Could not use schema "{schema}". Object does not exist' in result.output
+        )

--- a/tests_integration/test_connection.py
+++ b/tests_integration/test_connection.py
@@ -44,5 +44,6 @@ def test_connection_not_existing_schema(
         result = runner.invoke_with_connection(["connection", "test"])
         assert result.exit_code == 1, result.output
         assert (
-            f'Could not use schema "{schema}". Object does not exist' in result.output
+            f'Could not use schema "{schema.upper()}". Object does not exist'
+            in result.output
         )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Before:
```
➜ snow connection test -c int
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 002043 (02000): 01b3dc70-0509-12ff-0001-c1be00cebb6e: SQL compilation error:                                                                                                                                 │
│ Object does not exist, or operation cannot be performed.                                                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


````

After:
```
➜ snow connection test -c int
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Could not use database "TURBASZEK". Object does not exist, or operation cannot be performed.                                                                                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```
