### PR TITLE
Adding name parameter to job creation and using execute job service sql command

### DIFF
--- a/src/snowflake/cli/plugins/spcs/jobs/commands.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/commands.py
@@ -28,14 +28,18 @@ def create(
         exists=True,
     ),
     name: str = typer.Option(
-        None, "--name", help="Name of the job. If not provided, a random name is generated."
+        ...,
+        "--name",
+        help="Name of the job.",
     ),
     **options,
 ) -> CommandResult:
     """
     Creates a job to run in a compute pool.
     """
-    cursor = JobManager().create(compute_pool=compute_pool, spec_path=spec_path, name=name)
+    cursor = JobManager().create(
+        compute_pool=compute_pool, spec_path=spec_path, name=name
+    )
     return SingleQueryResult(cursor)
 
 

--- a/src/snowflake/cli/plugins/spcs/jobs/commands.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/commands.py
@@ -28,7 +28,7 @@ def create(
         exists=True,
     ),
     name: str = typer.Option(
-        ..., "--name", help="Name of the job. If not provided, a random name is generated."
+        None, "--name", help="Name of the job. If not provided, a random name is generated."
     ),
     **options,
 ) -> CommandResult:

--- a/src/snowflake/cli/plugins/spcs/jobs/commands.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/commands.py
@@ -27,12 +27,15 @@ def create(
         dir_okay=False,
         exists=True,
     ),
+    name: str = typer.Option(
+        ..., "--name", help="Name of the job. If not provided, a random name is generated."
+    ),
     **options,
 ) -> CommandResult:
     """
     Creates a job to run in a compute pool.
     """
-    cursor = JobManager().create(compute_pool=compute_pool, spec_path=spec_path)
+    cursor = JobManager().create(compute_pool=compute_pool, spec_path=spec_path, name=name)
     return SingleQueryResult(cursor)
 
 

--- a/src/snowflake/cli/plugins/spcs/jobs/manager.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/manager.py
@@ -7,7 +7,7 @@ from snowflake.connector.cursor import SnowflakeCursor
 
 
 class JobManager(SqlExecutionMixin):
-    def create(self, compute_pool: str, spec_path: Path, name: str | None) -> SnowflakeCursor:
+    def create(self, compute_pool: str, spec_path: Path, name: str) -> SnowflakeCursor:
         spec = self._read_yaml(spec_path)
         return self._execute_schema_query(
             f"""\
@@ -16,14 +16,7 @@ class JobManager(SqlExecutionMixin):
             NAME={name}
             FROM SPECIFICATION $$
             {spec}
-            $$
-            """ if name else f"""\
-            EXECUTE JOB SERVICE
-            IN COMPUTE POOL {compute_pool}
-            FROM SPECIFICATION $$
-            {spec}
-            $$
-            """
+            $$"""
         )
 
     def _read_yaml(self, path: Path) -> str:

--- a/src/snowflake/cli/plugins/spcs/jobs/manager.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/manager.py
@@ -7,11 +7,18 @@ from snowflake.connector.cursor import SnowflakeCursor
 
 
 class JobManager(SqlExecutionMixin):
-    def create(self, compute_pool: str, spec_path: Path) -> SnowflakeCursor:
+    def create(self, compute_pool: str, spec_path: Path, name: str) -> SnowflakeCursor:
         spec = self._read_yaml(spec_path)
         return self._execute_schema_query(
             f"""\
-            EXECUTE SERVICE
+            EXECUTE JOB SERVICE
+            IN COMPUTE POOL {compute_pool}
+            NAME={name}
+            FROM SPECIFICATION $$
+            {spec}
+            $$
+            """ if name else f"""\
+            EXECUTE JOB SERVICE
             IN COMPUTE POOL {compute_pool}
             FROM SPECIFICATION $$
             {spec}

--- a/src/snowflake/cli/plugins/spcs/jobs/manager.py
+++ b/src/snowflake/cli/plugins/spcs/jobs/manager.py
@@ -7,7 +7,7 @@ from snowflake.connector.cursor import SnowflakeCursor
 
 
 class JobManager(SqlExecutionMixin):
-    def create(self, compute_pool: str, spec_path: Path, name: str) -> SnowflakeCursor:
+    def create(self, compute_pool: str, spec_path: Path, name: str | None) -> SnowflakeCursor:
         spec = self._read_yaml(spec_path)
         return self._execute_schema_query(
             f"""\

--- a/tests/spcs/test_jobs.py
+++ b/tests/spcs/test_jobs.py
@@ -7,44 +7,6 @@ import pytest
 
 @pytest.mark.skip("Snowpark Container Services Job not supported.")
 @mock.patch("snowflake.connector.connect")
-def test_create_job(mock_connector, runner, mock_ctx):
-    ctx = mock_ctx()
-    mock_connector.return_value = ctx
-
-    test_spec = """
-spec:
-  containers:
-  - name: main
-    image: public.ecr.aws/myrepo:latest
-    """
-    with TemporaryDirectory() as temp_dir:
-        filepath = os.path.join(temp_dir, "test")
-        with open(filepath, "w") as fh:
-            fh.write(test_spec)
-        runner.invoke(
-            [
-                "spcs",
-                "job",
-                "create",
-                "--compute-pool",
-                "testPool",
-                "--spec-path",
-                filepath,
-            ]
-        )
-    assert ctx.get_query() == (
-        "USE DATABASE MockDatabase\n"
-        "USE MockDatabase.MockSchema\n"
-        "EXECUTE JOB SERVICE\n"
-        "IN COMPUTE POOL testPool\n"
-        "FROM SPECIFICATION $$\n"
-        '{"spec": {"containers": [{"name": "main", "image": "public.ecr.aws/myrepo:latest"}]}}\n'
-        "$$\n"
-    )
-
-
-@pytest.mark.skip("Snowpark Container Services Job not supported.")
-@mock.patch("snowflake.connector.connect")
 def test_create_job_with_name(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx

--- a/tests/spcs/test_jobs.py
+++ b/tests/spcs/test_jobs.py
@@ -35,8 +35,49 @@ spec:
     assert ctx.get_query() == (
         "USE DATABASE MockDatabase\n"
         "USE MockDatabase.MockSchema\n"
-        "EXECUTE SERVICE\n"
+        "EXECUTE JOB SERVICE\n"
         "IN COMPUTE POOL testPool\n"
+        "FROM SPECIFICATION $$\n"
+        '{"spec": {"containers": [{"name": "main", "image": "public.ecr.aws/myrepo:latest"}]}}\n'
+        "$$\n"
+    )
+
+
+@pytest.mark.skip("Snowpark Container Services Job not supported.")
+@mock.patch("snowflake.connector.connect")
+def test_create_job_with_name(mock_connector, runner, mock_ctx):
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    test_spec = """
+spec:
+  containers:
+  - name: main
+    image: public.ecr.aws/myrepo:latest
+    """
+    with TemporaryDirectory() as temp_dir:
+        filepath = os.path.join(temp_dir, "test")
+        with open(filepath, "w") as fh:
+            fh.write(test_spec)
+        runner.invoke(
+            [
+                "spcs",
+                "job",
+                "create",
+                "--compute-pool",
+                "testPool",
+                "--spec-path",
+                filepath,
+                "--name",
+                "test_job_name",
+            ]
+        )
+    assert ctx.get_query() == (
+        "USE DATABASE MockDatabase\n"
+        "USE MockDatabase.MockSchema\n"
+        "EXECUTE JOB SERVICE\n"
+        "IN COMPUTE POOL testPool\n"
+        "NAME=test_job_name"
         "FROM SPECIFICATION $$\n"
         '{"spec": {"containers": [{"name": "main", "image": "public.ecr.aws/myrepo:latest"}]}}\n'
         "$$\n"


### PR DESCRIPTION
### Changes description

In the hidden `snow spcs job` command I added a new parameter (`name`) this can be used in order to specify the name of the job and not rely on a randomly generated id.
Additionally this changes executing the job with the `EXECUTE SERVICE ...` SQL command to using `EXECUTING JOB SERVICE ...` which is used in the tutorials.