### PR TITLE
[SNOW-1345064] Fix stage path handling on Windows

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
   the number of anaconda dependencies for snowpark projects.
 * Added support for fully qualified stage names in stage and git execute commands.
 * Fixed a bug where `snow app run` was not upgrading the application when the local state and remote stage are identical (for example immediately after `snow app deploy`).
+* Fixed handling of stage path separators on Windows
 
 # v2.2.0
 

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -251,9 +251,8 @@ def app_deploy(
     Creates an application package in your Snowflake account and syncs the local changes to the stage without creating or updating the application.
     Running this command with no arguments at all, as in `snow app deploy`, is a shorthand for `snow app deploy --prune --recursive`.
     """
-    if files is None:
-        files = []
-    if prune is None and recursive is None and len(files) == 0:
+    has_files = files is not None and len(files) > 0
+    if prune is None and recursive is None and not has_files:
         prune = True
         recursive = True
     else:

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -321,7 +321,19 @@ class NativeAppManager(SqlExecutionMixin):
     ) -> DiffResult:
         """
         Ensures that the files on our remote stage match the artifacts we have in
-        the local filesystem. Returns the DiffResult used to make changes.
+        the local filesystem.
+
+        Args:
+            role (str): The name of the role to use for queries and commands.
+            prune (bool): Whether to prune artifacts from the stage that don't exist locally.
+            recursive (bool): Whether to traverse directories recursively.
+            local_paths_to_sync (List[Path], optional): List of local paths to sync. Defaults to None to sync all
+             local paths. Note that providing an empty list here is equivalent to None.
+            mapped_files: the file mapping computed during the `bundle` step. Required when local_paths_to_sync is
+             provided.
+
+        Returns:
+            A `DiffResult` instance describing the changes that were performed.
         """
 
         # Does a stage already exist within the application package, or we need to create one?
@@ -346,7 +358,9 @@ class NativeAppManager(SqlExecutionMixin):
         diff: DiffResult = compute_stage_diff(self.deploy_root, self.stage_fqn)
 
         files_not_removed = []
-        if local_paths_to_sync is not None:
+        if local_paths_to_sync:
+            assert mapped_files is not None
+
             # Deploying specific files/directories
             resolved_paths_to_sync = [
                 resolve_without_follow(p) for p in local_paths_to_sync

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -51,8 +51,8 @@ from snowflake.cli.plugins.nativeapp.utils import verify_exists, verify_no_direc
 from snowflake.cli.plugins.stage.diff import (
     DiffResult,
     StagePath,
+    compute_stage_diff,
     preserve_from_diff,
-    stage_diff,
     sync_local_diff_with_stage,
     to_stage_path,
 )
@@ -343,7 +343,7 @@ class NativeAppManager(SqlExecutionMixin):
             "Performing a diff between the Snowflake stage and your local deploy_root ('%s') directory."
             % self.deploy_root
         )
-        diff: DiffResult = stage_diff(self.deploy_root, self.stage_fqn)
+        diff: DiffResult = compute_stage_diff(self.deploy_root, self.stage_fqn)
 
         files_not_removed = []
         if local_paths_to_sync is not None:

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -50,9 +50,11 @@ from snowflake.cli.plugins.nativeapp.exceptions import (
 from snowflake.cli.plugins.nativeapp.utils import verify_exists, verify_no_directories
 from snowflake.cli.plugins.stage.diff import (
     DiffResult,
-    filter_from_diff,
+    StagePath,
+    preserve_from_diff,
     stage_diff,
     sync_local_diff_with_stage,
+    to_stage_path,
 )
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
@@ -106,18 +108,23 @@ def ensure_correct_owner(row: dict, role: str, obj_name: str) -> None:
         raise UnexpectedOwnerError(obj_name, role, actual_owner)
 
 
-def _get_paths_to_sync(paths_to_sync: List[Path], deploy_root: Path) -> List[str]:
-    """Takes a list of paths (files and directories), returning a list of all files recursively relative to the deploy root."""
-    paths = []
-    for path in paths_to_sync:
+def _get_stage_paths_to_sync(
+    local_paths_to_sync: List[Path], deploy_root: Path
+) -> List[StagePath]:
+    """
+    Takes a list of paths (files and directories), returning a list of all files recursively relative to the deploy root.
+    """
+
+    stage_paths = []
+    for path in local_paths_to_sync:
         if path.is_dir():
             for current_dir, _dirs, files in os.walk(path):
                 for file in files:
                     deploy_path = Path(current_dir, file).relative_to(deploy_root)
-                    paths.append(str(deploy_path))
+                    stage_paths.append(to_stage_path(deploy_path))
         else:
-            paths.append(str(path.relative_to(deploy_root)))
-    return paths
+            stage_paths.append(to_stage_path(path.relative_to(deploy_root)))
+    return stage_paths
 
 
 class NativeAppCommandProcessor(ABC):
@@ -309,7 +316,7 @@ class NativeAppManager(SqlExecutionMixin):
         role: str,
         prune: bool,
         recursive: bool,
-        paths_to_sync: List[Path] = [],  # relative to project root
+        local_paths_to_sync: List[Path] | None = None,
         mapped_files: Optional[ArtifactDeploymentMap] = None,
     ) -> DiffResult:
         """
@@ -339,9 +346,11 @@ class NativeAppManager(SqlExecutionMixin):
         diff: DiffResult = stage_diff(self.deploy_root, self.stage_fqn)
 
         files_not_removed = []
-        if len(paths_to_sync) > 0:
+        if local_paths_to_sync is not None:
             # Deploying specific files/directories
-            resolved_paths_to_sync = [resolve_without_follow(p) for p in paths_to_sync]
+            resolved_paths_to_sync = [
+                resolve_without_follow(p) for p in local_paths_to_sync
+            ]
             if not recursive:
                 verify_no_directories(resolved_paths_to_sync)
             deploy_paths_to_sync = [
@@ -349,24 +358,25 @@ class NativeAppManager(SqlExecutionMixin):
                 for p in resolved_paths_to_sync
             ]
             verify_exists(deploy_paths_to_sync)
-            paths_to_sync_set = set(
-                _get_paths_to_sync(deploy_paths_to_sync, self.deploy_root.resolve())
+            stage_paths_to_sync = _get_stage_paths_to_sync(
+                deploy_paths_to_sync, self.deploy_root.resolve()
             )
-            files_not_removed = filter_from_diff(diff, paths_to_sync_set, prune)
+            diff = preserve_from_diff(diff, stage_paths_to_sync)
         else:
             # Full deploy
             if not recursive:
-                deploy_files = os.listdir(str(self.deploy_root.resolve()))
-                verify_no_directories([Path(path_str) for path_str in deploy_files])
-            if not prune:
-                files_not_removed = diff.only_on_stage
-                diff.only_on_stage = []
+                deploy_files = [p for p in self.deploy_root.resolve().iterdir()]
+                verify_no_directories(deploy_files)
 
-        if len(files_not_removed) > 0:
-            files_not_removed_str = "\n".join(files_not_removed)
-            cc.warning(
-                f"The following files exist only on the stage:\n{files_not_removed_str}\n\nUse the --prune flag to delete them from the stage."
-            )
+        if not prune:
+            files_not_removed = [str(path) for path in diff.only_on_stage]
+            diff.only_on_stage = []
+
+            if len(files_not_removed) > 0:
+                files_not_removed_str = "\n".join(files_not_removed)
+                cc.warning(
+                    f"The following files exist only on the stage:\n{files_not_removed_str}\n\nUse the --prune flag to delete them from the stage."
+                )
 
         cc.message(str(diff))
 
@@ -380,7 +390,7 @@ class NativeAppManager(SqlExecutionMixin):
                 role=role,
                 deploy_root_path=self.deploy_root,
                 diff_result=diff,
-                stage_path=self.stage_fqn,
+                stage_fqn=self.stage_fqn,
             )
         return diff
 
@@ -497,7 +507,7 @@ class NativeAppManager(SqlExecutionMixin):
         self,
         prune: bool,
         recursive: bool,
-        paths_to_sync: List[Path] = [],
+        local_paths_to_sync: List[Path] | None = None,
         mapped_files: Optional[ArtifactDeploymentMap] = None,
     ) -> DiffResult:
         """app deploy process"""
@@ -511,7 +521,7 @@ class NativeAppManager(SqlExecutionMixin):
 
             # 3. Upload files from deploy root local folder to the above stage
             diff = self.sync_deploy_root_with_stage(
-                self.package_role, prune, recursive, paths_to_sync, mapped_files
+                self.package_role, prune, recursive, local_paths_to_sync, mapped_files
             )
 
         return diff

--- a/src/snowflake/cli/plugins/stage/commands.py
+++ b/src/snowflake/cli/plugins/stage/commands.py
@@ -22,7 +22,7 @@ from snowflake.cli.api.output.types import (
     SingleQueryResult,
 )
 from snowflake.cli.api.utils.path_utils import is_stage_path
-from snowflake.cli.plugins.stage.diff import DiffResult
+from snowflake.cli.plugins.stage.diff import DiffResult, compute_stage_diff
 from snowflake.cli.plugins.stage.manager import OnErrorType, StageManager
 
 app = SnowTyper(
@@ -125,14 +125,14 @@ def stage_remove(
 
 @app.command("diff", hidden=True, requires_connection=True)
 def stage_diff(
-    stage_name: str = typer.Argument(None, help="Fully qualified name of a stage"),
-    folder_name: str = typer.Argument(None, help="Path to local folder"),
+    stage_name: str = typer.Argument(help="Fully qualified name of a stage"),
+    folder_name: str = typer.Argument(help="Path to local folder"),
     **options,
 ) -> ObjectResult:
     """
     Diffs a stage with a local folder.
     """
-    diff: DiffResult = stage_diff(Path(folder_name), stage_name)
+    diff: DiffResult = compute_stage_diff(Path(folder_name), stage_name)
     return ObjectResult(str(diff))
 
 

--- a/src/snowflake/cli/plugins/stage/diff.py
+++ b/src/snowflake/cli/plugins/stage/diff.py
@@ -183,7 +183,7 @@ def preserve_from_diff(
     return preserved_diff
 
 
-def stage_diff(
+def compute_stage_diff(
     local_root: Path,
     stage_fqn: str,
 ) -> DiffResult:

--- a/src/snowflake/cli/plugins/stage/diff.py
+++ b/src/snowflake/cli/plugins/stage/diff.py
@@ -229,7 +229,8 @@ def compute_stage_diff(
 
 def get_stage_subpath(stage_path: StagePath) -> str:
     """
-    Returns the parent stage path (i.e. prefix or folder) for a given stage file path.
+    Returns the parent portion of a stage path, as a string, for inclusion in the fully qualified stage path. Note that
+    '.' treated specially here, and so the return value of this call is not a `StagePath` instance.
     """
     parent = str(stage_path.parent)
     return "" if parent == "." else parent

--- a/src/snowflake/cli/plugins/stage/diff.py
+++ b/src/snowflake/cli/plugins/stage/diff.py
@@ -2,8 +2,8 @@ import hashlib
 import logging
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Dict, List, Optional, Set
+from pathlib import Path, PurePosixPath
+from typing import Collection, Dict, List, Optional
 
 from snowflake.cli.api.exceptions import (
     SnowflakeSQLExecutionError,
@@ -18,24 +18,25 @@ CHUNK_SIZE_BYTES = 8192
 
 log = logging.getLogger(__name__)
 
+StagePath = PurePosixPath  # alias PurePosixPath as StagePath for clarity
+
 
 @dataclass
 class DiffResult:
     """
-    Each collection is a list of relative paths, either from
-    the stage root or from the root of the compared local directory.
+    Each collection is a list of stage paths ('/'-separated, regardless of the platform), relative to the stage root.
     """
 
-    identical: List[str] = field(default_factory=list)
+    identical: List[StagePath] = field(default_factory=list)
     "Files with matching md5sums"
 
-    different: List[str] = field(default_factory=list)
+    different: List[StagePath] = field(default_factory=list)
     "Files that may be different between the stage and the local directory"
 
-    only_local: List[str] = field(default_factory=list)
+    only_local: List[StagePath] = field(default_factory=list)
     "Files that only exist in the local directory"
 
-    only_on_stage: List[str] = field(default_factory=list)
+    only_on_stage: List[StagePath] = field(default_factory=list)
     "Files that only exist on the stage"
 
     def has_changes(self) -> bool:
@@ -72,16 +73,26 @@ class DiffResult:
             )
 
         if self.only_local:
-            components.extend(["New files only on your local:", *self.only_local])
+            components.extend(
+                ["New files only on your local:", *[str(p) for p in self.only_local]]
+            )
         if self.only_on_stage:
-            components.extend(["New files only on the stage:", *self.only_on_stage])
+            components.extend(
+                ["New files only on the stage:", *[str(p) for p in self.only_on_stage]]
+            )
         if self.different:
             components.extend(
-                ["Existing files modified or status unknown:", *self.different]
+                [
+                    "Existing files modified or status unknown:",
+                    *[str(p) for p in self.different],
+                ]
             )
         if self.identical:
             components.extend(
-                ["Existing files identical to the stage:", *self.identical]
+                [
+                    "Existing files identical to the stage:",
+                    *[str(p) for p in self.identical],
+                ]
             )
 
         return "\n".join(components)
@@ -141,12 +152,12 @@ def enumerate_files(path: Path) -> List[Path]:
     return paths
 
 
-def strip_stage_name(path: str) -> str:
+def strip_stage_name(path: str) -> StagePath:
     """Returns the given stage path without the stage name as the first part."""
-    return "/".join(path.split("/")[1:])
+    return StagePath(*path.split("/")[1:])
 
 
-def build_md5_map(list_stage_cursor: DictCursor) -> Dict[str, str]:
+def build_md5_map(list_stage_cursor: DictCursor) -> Dict[StagePath, str]:
     """
     Returns a mapping of relative stage paths to their md5sums.
     """
@@ -156,101 +167,115 @@ def build_md5_map(list_stage_cursor: DictCursor) -> Dict[str, str]:
     }
 
 
-def filter_from_diff(
-    diff: DiffResult, paths_to_sync: Set[str], prune: bool
-) -> List[str]:
-    """Modifies the given diff, keeping only the provided paths. If prune is false, remote-only paths will be empty and the non-removed paths will be returned."""
-    diff.different = [i for i in diff.different if i in paths_to_sync]
-    diff.only_local = [i for i in diff.only_local if i in paths_to_sync]
-    only_on_stage = [i for i in diff.only_on_stage if i in paths_to_sync]
-    files_not_removed = []
-    if prune:
-        diff.only_on_stage = only_on_stage
-    else:
-        files_not_removed = only_on_stage
-        diff.only_on_stage = []
-    return files_not_removed
+def preserve_from_diff(
+    diff: DiffResult, stage_paths_to_sync: Collection[StagePath]
+) -> DiffResult:
+    """
+    Returns a filtered version of the provided diff, keeping only the provided stage paths.
+    """
+    preserved_diff: DiffResult = DiffResult()
+    preserved_diff.identical = [i for i in diff.identical if i in stage_paths_to_sync]
+    preserved_diff.different = [i for i in diff.different if i in stage_paths_to_sync]
+    preserved_diff.only_local = [i for i in diff.only_local if i in stage_paths_to_sync]
+    preserved_diff.only_on_stage = [
+        i for i in diff.only_on_stage if i in stage_paths_to_sync
+    ]
+    return preserved_diff
 
 
 def stage_diff(
-    local_path: Path,
+    local_root: Path,
     stage_fqn: str,
 ) -> DiffResult:
     """
     Diffs the files in a stage with a local folder.
     """
     stage_manager = StageManager()
-    local_files = enumerate_files(local_path)
+    local_files = enumerate_files(local_root)
     remote_md5 = build_md5_map(stage_manager.list_files(stage_fqn))
 
     result: DiffResult = DiffResult()
 
     for local_file in local_files:
-        relpath = str(local_file.relative_to(local_path))
-        if relpath not in remote_md5:
+        relpath = local_file.relative_to(local_root)
+        stage_filename = to_stage_path(relpath)
+        if stage_filename not in remote_md5:
             # doesn't exist on the stage
-            result.only_local.append(relpath)
+            result.only_local.append(stage_filename)
         else:
             # N.B. we could compare local size vs remote size to skip the relatively-
             # expensive md5sum operation, but after seeing a comment that says the value
             # may not always be correctly populated, we'll ignore that column.
-            stage_md5sum = remote_md5[relpath]
+            stage_md5sum = remote_md5[stage_filename]
             if is_valid_md5sum(stage_md5sum) and stage_md5sum == compute_md5sum(
                 local_file
             ):
                 # the file definitely hasn't changed
-                result.identical.append(relpath)
+                result.identical.append(stage_filename)
             else:
                 # either the file has changed, or we can't tell if it has
-                result.different.append(relpath)
+                result.different.append(stage_filename)
 
             # mark this file as seen
-            del remote_md5[relpath]
+            del remote_md5[stage_filename]
 
     # every entry here is a file we never saw locally
-    for relpath in remote_md5.keys():
-        result.only_on_stage.append(relpath)
+    for stage_filename in remote_md5.keys():
+        result.only_on_stage.append(stage_filename)
 
     return result
 
 
-def get_stage_path_from_file(filepath: str):
-    parent = str(Path(filepath).parent)
-    stage_path = "" if parent == "." else parent
-    return stage_path
+def get_stage_subpath(stage_path: StagePath) -> str:
+    """
+    Returns the parent stage path (i.e. prefix or folder) for a given stage file path.
+    """
+    parent = str(stage_path.parent)
+    return "" if parent == "." else parent
+
+
+def to_stage_path(filename: Path) -> StagePath:
+    """
+    Returns the stage file name, with the path separator suitably transformed if needed.
+    """
+    return StagePath(*filename.parts)
+
+
+def to_local_path(stage_path: StagePath) -> Path:
+    return Path(*stage_path.parts)
 
 
 def delete_only_on_stage_files(
     stage_manager: StageManager,
     stage_fqn: str,
-    only_on_stage: List[str],
+    only_on_stage: List[StagePath],
     role: Optional[str] = None,
 ):
     """
     Deletes all files from a Snowflake stage according to the input list of filenames, using a custom role.
     """
-    for _file in only_on_stage:
-        stage_manager.remove(stage_name=stage_fqn, path=_file, role=role)
+    for _stage_filename in only_on_stage:
+        stage_manager.remove(stage_name=stage_fqn, path=str(_stage_filename), role=role)
 
 
 def put_files_on_stage(
     stage_manager: StageManager,
     stage_fqn: str,
     deploy_root_path: Path,
-    files: List[str],
+    stage_paths: List[StagePath],
     role: Optional[str] = None,
     overwrite: bool = False,
 ):
     """
     Uploads all files given input list of filenames on your local filesystem, to a Snowflake stage, using a custom role.
     """
-    for _file in files:
-        stage_sub_path = get_stage_path_from_file(_file)
+    for _stage_path in stage_paths:
+        stage_sub_path = get_stage_subpath(_stage_path)
         full_stage_path = (
             f"{stage_fqn}/{stage_sub_path}" if stage_sub_path else stage_fqn
         )
         stage_manager.put(
-            local_path=deploy_root_path / _file,
+            local_path=deploy_root_path / to_local_path(_stage_path),
             stage_path=full_stage_path,
             role=role,
             overwrite=overwrite,
@@ -258,7 +283,7 @@ def put_files_on_stage(
 
 
 def sync_local_diff_with_stage(
-    role: str, deploy_root_path: Path, diff_result: DiffResult, stage_path: str
+    role: str, deploy_root_path: Path, diff_result: DiffResult, stage_fqn: str
 ):
     """
     Syncs a given local directory's contents with a Snowflake stage, including removing old files, and re-uploading modified and new files.
@@ -271,18 +296,18 @@ def sync_local_diff_with_stage(
 
     try:
         delete_only_on_stage_files(
-            stage_manager, stage_path, diff_result.only_on_stage, role
+            stage_manager, stage_fqn, diff_result.only_on_stage, role
         )
         put_files_on_stage(
             stage_manager,
-            stage_path,
+            stage_fqn,
             deploy_root_path,
             diff_result.different,
             role,
             overwrite=True,
         )
         put_files_on_stage(
-            stage_manager, stage_path, deploy_root_path, diff_result.only_local, role
+            stage_manager, stage_fqn, deploy_root_path, diff_result.only_local, role
         )
     except Exception as err:
         # Could be ProgrammingError or IntegrityError from SnowflakeCursor

--- a/src/snowflake/cli/plugins/stage/diff.py
+++ b/src/snowflake/cli/plugins/stage/diff.py
@@ -173,12 +173,13 @@ def preserve_from_diff(
     """
     Returns a filtered version of the provided diff, keeping only the provided stage paths.
     """
+    paths_to_preserve = set(stage_paths_to_sync)
     preserved_diff: DiffResult = DiffResult()
-    preserved_diff.identical = [i for i in diff.identical if i in stage_paths_to_sync]
-    preserved_diff.different = [i for i in diff.different if i in stage_paths_to_sync]
-    preserved_diff.only_local = [i for i in diff.only_local if i in stage_paths_to_sync]
+    preserved_diff.identical = [i for i in diff.identical if i in paths_to_preserve]
+    preserved_diff.different = [i for i in diff.different if i in paths_to_preserve]
+    preserved_diff.only_local = [i for i in diff.only_local if i in paths_to_preserve]
     preserved_diff.only_on_stage = [
-        i for i in diff.only_on_stage if i in stage_paths_to_sync
+        i for i in diff.only_on_stage if i in paths_to_preserve
     ]
     return preserved_diff
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5299,14 +5299,14 @@
 # name: test_help_messages[stage.diff]
   '''
                                                                                   
-   Usage: default stage diff [OPTIONS] [STAGE_NAME] [FOLDER_NAME]                 
+   Usage: default stage diff [OPTIONS] STAGE_NAME FOLDER_NAME                     
                                                                                   
    Diffs a stage with a local folder.                                             
                                                                                   
   ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-  │   stage_name       [STAGE_NAME]   Fully qualified name of a stage            │
-  │                                   [default: None]                            │
-  │   folder_name      [FOLDER_NAME]  Path to local folder [default: None]       │
+  │ *    stage_name       TEXT  Fully qualified name of a stage [default: None]  │
+  │                             [required]                                       │
+  │ *    folder_name      TEXT  Path to local folder [default: None] [required]  │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --help  -h        Show this message and exit.                                │

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -18,11 +18,12 @@ from snowflake.cli.plugins.nativeapp.exceptions import (
 from snowflake.cli.plugins.nativeapp.manager import (
     NativeAppManager,
     SnowflakeSQLExecutionError,
-    _get_paths_to_sync,
+    _get_stage_paths_to_sync,
     ensure_correct_owner,
 )
 from snowflake.cli.plugins.stage.diff import (
     DiffResult,
+    StagePath,
 )
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
@@ -71,7 +72,7 @@ def test_sync_deploy_root_with_stage(
     mock_local_diff_with_stage, mock_stage_diff, mock_execute, temp_dir, mock_cursor
 ):
     mock_execute.return_value = mock_cursor([{"CURRENT_ROLE()": "old_role"}], [])
-    mock_diff_result = DiffResult(different=["setup.sql"])
+    mock_diff_result = DiffResult(different=[StagePath("setup.sql")])
     mock_stage_diff.return_value = mock_diff_result
     mock_local_diff_with_stage.return_value = None
     current_working_directory = os.getcwd()
@@ -798,5 +799,5 @@ def test_get_paths_to_sync(
     touch("deploy/dir/nested_dir/nested_file3")
 
     paths_to_sync = [Path(p) for p in paths_to_sync]
-    result = _get_paths_to_sync(paths_to_sync, Path("deploy/"))
-    assert result.sort() == expected_result.sort()
+    result = _get_stage_paths_to_sync(paths_to_sync, Path("deploy/"))
+    assert result.sort() == [StagePath(p) for p in expected_result].sort()

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -66,14 +66,18 @@ def _get_na_manager():
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock.patch(f"{NATIVEAPP_MODULE}.stage_diff")
+@mock.patch(f"{NATIVEAPP_MODULE}.compute_stage_diff")
 @mock.patch(f"{NATIVEAPP_MODULE}.sync_local_diff_with_stage")
 def test_sync_deploy_root_with_stage(
-    mock_local_diff_with_stage, mock_stage_diff, mock_execute, temp_dir, mock_cursor
+    mock_local_diff_with_stage,
+    mock_compute_stage_diff,
+    mock_execute,
+    temp_dir,
+    mock_cursor,
 ):
     mock_execute.return_value = mock_cursor([{"CURRENT_ROLE()": "old_role"}], [])
     mock_diff_result = DiffResult(different=[StagePath("setup.sql")])
-    mock_stage_diff.return_value = mock_diff_result
+    mock_compute_stage_diff.return_value = mock_diff_result
     mock_local_diff_with_stage.return_value = None
     current_working_directory = os.getcwd()
     create_named_file(
@@ -99,7 +103,7 @@ def test_sync_deploy_root_with_stage(
         mock.call("use role old_role"),
     ]
     assert mock_execute.mock_calls == expected
-    mock_stage_diff.assert_called_once_with(
+    mock_compute_stage_diff.assert_called_once_with(
         native_app_manager.deploy_root, "app_pkg.app_src.stage"
     )
     mock_local_diff_with_stage.assert_called_once_with(
@@ -112,7 +116,7 @@ def test_sync_deploy_root_with_stage(
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
 @mock.patch(f"{NATIVEAPP_MODULE}.sync_local_diff_with_stage")
-@mock.patch(f"{NATIVEAPP_MODULE}.stage_diff")
+@mock.patch(f"{NATIVEAPP_MODULE}.compute_stage_diff")
 @mock.patch(f"{NATIVEAPP_MODULE}.cc.warning")
 @pytest.mark.parametrize(
     "prune,only_on_stage_files,expected_warn",
@@ -131,7 +135,7 @@ def test_sync_deploy_root_with_stage(
 )
 def test_sync_deploy_root_with_stage_prune(
     mock_warning,
-    mock_stage_diff,
+    mock_compute_stage_diff,
     mock_local_diff_with_stage,
     mock_execute,
     prune,
@@ -139,7 +143,7 @@ def test_sync_deploy_root_with_stage_prune(
     expected_warn,
     temp_dir,
 ):
-    mock_stage_diff.return_value = DiffResult(only_on_stage=only_on_stage_files)
+    mock_compute_stage_diff.return_value = DiffResult(only_on_stage=only_on_stage_files)
     create_named_file(
         file_name="snowflake.yml",
         dir_name=os.getcwd(),

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -106,7 +106,7 @@ def test_sync_deploy_root_with_stage(
         role="new_role",
         deploy_root_path=native_app_manager.deploy_root,
         diff_result=mock_diff_result,
-        stage_path="app_pkg.app_src.stage",
+        stage_fqn="app_pkg.app_src.stage",
     )
 
 

--- a/tests/stage/test_diff.py
+++ b/tests/stage/test_diff.py
@@ -12,12 +12,12 @@ from snowflake.cli.plugins.stage.diff import (
     DiffResult,
     StagePath,
     build_md5_map,
+    compute_stage_diff,
     delete_only_on_stage_files,
     enumerate_files,
     get_stage_subpath,
     preserve_from_diff,
     put_files_on_stage,
-    stage_diff,
     sync_local_diff_with_stage,
 )
 from snowflake.cli.plugins.stage.manager import StageManager
@@ -72,7 +72,7 @@ def test_empty_stage(mock_list, mock_cursor):
     mock_list.return_value = mock_cursor(rows=[], columns=STAGE_LS_COLUMNS)
 
     with temp_local_dir(FILE_CONTENTS) as local_path:
-        diff_result = stage_diff(local_path, "a.b.c")
+        diff_result = compute_stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
         assert len(diff_result.different) == 0
         assert len(diff_result.identical) == 0
@@ -89,7 +89,7 @@ def test_empty_dir(mock_list, mock_cursor):
     )
 
     with temp_local_dir({}) as local_path:
-        diff_result = stage_diff(local_path, "a.b.c")
+        diff_result = compute_stage_diff(local_path, "a.b.c")
         assert sorted(diff_result.only_on_stage) == sorted(
             as_stage_paths(FILE_CONTENTS.keys())
         )
@@ -106,7 +106,7 @@ def test_identical_stage(mock_list, mock_cursor):
     )
 
     with temp_local_dir(FILE_CONTENTS) as local_path:
-        diff_result = stage_diff(local_path, "a.b.c")
+        diff_result = compute_stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
         assert len(diff_result.different) == 0
         assert sorted(diff_result.identical) == sorted(
@@ -125,7 +125,7 @@ def test_new_local_file(mock_list, mock_cursor):
     with temp_local_dir(
         {**FILE_CONTENTS, "a/new/README.md": "### I am a new markdown readme"}
     ) as local_path:
-        diff_result = stage_diff(local_path, "a.b.c")
+        diff_result = compute_stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
         assert len(diff_result.different) == 0
         assert sorted(diff_result.identical) == sorted(
@@ -147,7 +147,7 @@ def test_modified_file(mock_list, mock_cursor):
             "README.md": "This is a modification to the existing README",
         }
     ) as local_path:
-        diff_result = stage_diff(local_path, "a.b.c")
+        diff_result = compute_stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
         assert sorted(diff_result.different) == as_stage_paths(["README.md"])
         assert sorted(diff_result.identical) == as_stage_paths(

--- a/tests/stage/test_diff.py
+++ b/tests/stage/test_diff.py
@@ -1,4 +1,5 @@
 import hashlib
+import typing
 from pathlib import Path
 from typing import Dict, List, Union
 from unittest import mock
@@ -9,11 +10,12 @@ from snowflake.cli.api.exceptions import (
 )
 from snowflake.cli.plugins.stage.diff import (
     DiffResult,
+    StagePath,
     build_md5_map,
     delete_only_on_stage_files,
     enumerate_files,
-    filter_from_diff,
-    get_stage_path_from_file,
+    get_stage_subpath,
+    preserve_from_diff,
     put_files_on_stage,
     stage_diff,
     sync_local_diff_with_stage,
@@ -32,6 +34,10 @@ FILE_CONTENTS = {
 }
 DEFAULT_LAST_MODIFIED = "Tue, 5 Sep 2023 17:59:21 GMT"
 STAGE_LS_COLUMNS = ["name", "size", "md5", "last_modified"]
+
+
+def as_stage_paths(paths: typing.Iterable[str]) -> List[StagePath]:
+    return [StagePath(p) for p in paths]
 
 
 def md5_of(contents: Union[str, bytes]) -> str:
@@ -70,7 +76,9 @@ def test_empty_stage(mock_list, mock_cursor):
         assert len(diff_result.only_on_stage) == 0
         assert len(diff_result.different) == 0
         assert len(diff_result.identical) == 0
-        assert sorted(diff_result.only_local) == sorted(FILE_CONTENTS.keys())
+        assert sorted(diff_result.only_local) == sorted(
+            as_stage_paths(FILE_CONTENTS.keys())
+        )
 
 
 @mock.patch(f"{STAGE_MANAGER}.list_files")
@@ -82,7 +90,9 @@ def test_empty_dir(mock_list, mock_cursor):
 
     with temp_local_dir({}) as local_path:
         diff_result = stage_diff(local_path, "a.b.c")
-        assert sorted(diff_result.only_on_stage) == sorted(FILE_CONTENTS.keys())
+        assert sorted(diff_result.only_on_stage) == sorted(
+            as_stage_paths(FILE_CONTENTS.keys())
+        )
         assert len(diff_result.different) == 0
         assert len(diff_result.identical) == 0
         assert len(diff_result.only_local) == 0
@@ -99,7 +109,9 @@ def test_identical_stage(mock_list, mock_cursor):
         diff_result = stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
         assert len(diff_result.different) == 0
-        assert sorted(diff_result.identical) == sorted(FILE_CONTENTS.keys())
+        assert sorted(diff_result.identical) == sorted(
+            as_stage_paths(FILE_CONTENTS.keys())
+        )
         assert len(diff_result.only_local) == 0
 
 
@@ -116,8 +128,10 @@ def test_new_local_file(mock_list, mock_cursor):
         diff_result = stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
         assert len(diff_result.different) == 0
-        assert sorted(diff_result.identical) == sorted(FILE_CONTENTS.keys())
-        assert diff_result.only_local == ["a/new/README.md"]
+        assert sorted(diff_result.identical) == sorted(
+            as_stage_paths(FILE_CONTENTS.keys())
+        )
+        assert diff_result.only_local == as_stage_paths(["a/new/README.md"])
 
 
 @mock.patch(f"{STAGE_MANAGER}.list_files")
@@ -135,8 +149,10 @@ def test_modified_file(mock_list, mock_cursor):
     ) as local_path:
         diff_result = stage_diff(local_path, "a.b.c")
         assert len(diff_result.only_on_stage) == 0
-        assert sorted(diff_result.different) == ["README.md"]
-        assert sorted(diff_result.identical) == ["my.jar", "ui/streamlit.py"]
+        assert sorted(diff_result.different) == as_stage_paths(["README.md"])
+        assert sorted(diff_result.identical) == as_stage_paths(
+            ["my.jar", "ui/streamlit.py"]
+        )
         assert len(diff_result.only_local) == 0
 
 
@@ -159,7 +175,7 @@ def test_get_stage_path_from_file():
         local_files = enumerate_files(local_path)
         for local_file in local_files:
             relpath = str(local_file.relative_to(local_path))
-            actual.append(get_stage_path_from_file(relpath))
+            actual.append(get_stage_subpath(StagePath(relpath)))
     assert actual.sort() == expected
 
 
@@ -168,7 +184,9 @@ def test_delete_only_on_stage_files(mock_remove):
     stage_name = "some_stage_name"
     random_file = "some_file_on_stage"
 
-    delete_only_on_stage_files(StageManager(), stage_name, [random_file], "some_role")
+    delete_only_on_stage_files(
+        StageManager(), stage_name, as_stage_paths([random_file]), "some_role"
+    )
     mock_remove.assert_has_calls(
         [mock.call(stage_name=stage_name, path=random_file, role="some_role")]
     )
@@ -188,7 +206,7 @@ def test_put_files_on_stage(mock_put, overwrite_param):
             stage_manager=StageManager(),
             stage_fqn=stage_name,
             deploy_root_path=local_path,
-            files=["ui/nested/environment.yml", "README.md"],
+            stage_paths=as_stage_paths(["ui/nested/environment.yml", "README.md"]),
             role="some_role",
             overwrite=overwrite_param,
         )
@@ -218,9 +236,9 @@ def test_build_md5_map(mock_cursor):
     )
 
     expected = {
-        "README.md": "9b650974f65cc49be96a5ed34ac6d1fd",
-        "my.jar": "fc605d0e2e50cf3e71873d57f4c598b0",
-        "ui/streamlit.py": "a7dfdfaf892ecfc5f164914123c7f2cc",
+        StagePath("README.md"): "9b650974f65cc49be96a5ed34ac6d1fd",
+        StagePath("my.jar"): "fc605d0e2e50cf3e71873d57f4c598b0",
+        StagePath("ui/streamlit.py"): "a7dfdfaf892ecfc5f164914123c7f2cc",
     }
 
     assert actual == expected
@@ -240,7 +258,7 @@ def test_sync_local_diff_with_stage(mock_remove, other_directory):
             role="some_role",
             deploy_root_path=temp_dir,
             diff_result=diff,
-            stage_path=stage_name,
+            stage_fqn=stage_name,
         )
 
 
@@ -265,43 +283,20 @@ def test_filter_from_diff():
         "dir/only_on_stage-2",
     ]
 
-    paths_to_sync = set(
-        [
-            "different",
-            "only-local",
-            "only-stage",
-            "dir/different",
-            "dir/only-local",
-            "dir/only-stage",
-        ]
-    )
-    filter_from_diff(diff, paths_to_sync, True)
-
-    for path in diff.different:
-        assert path in paths_to_sync
-    for path in diff.only_local:
-        assert path in paths_to_sync
-    for path in diff.only_on_stage:
-        assert path in paths_to_sync
-
-
-# When prune flag is off, remote-only files are filtered out
-def test_filter_from_diff_no_prune():
-    diff = DiffResult()
-    diff.only_on_stage = [
-        "only-stage-1.txt",
-        "only-stage-2.txt",
-        "only-stage-3.txt",
+    paths_to_sync = [
+        "different",
+        "only-local",
+        "only-stage",
+        "dir/different",
+        "dir/only-local",
+        "dir/only-stage",
     ]
-    paths_to_sync = set(
-        [
-            "on-both.txt",
-            "only-stage-1.txt",
-            "only-stage-2.txt",
-            "only-local.txt",
-        ]
-    )
+    new_diff = preserve_from_diff(diff, as_stage_paths(paths_to_sync))
 
-    filter_from_diff(diff, paths_to_sync, False)
-
-    assert len(diff.only_on_stage) == 0
+    for path in new_diff.different:
+        assert path in paths_to_sync
+    for path in new_diff.only_local:
+        assert path in paths_to_sync
+    for path in new_diff.only_on_stage:
+        assert path in paths_to_sync
+    assert new_diff.identical == diff.identical

--- a/tests_integration/test_nativeapp.py
+++ b/tests_integration/test_nativeapp.py
@@ -786,10 +786,6 @@ def test_nativeapp_deploy_nested_directories(
             )
             assert contains_row_with(
                 stage_files.json, {"name": "stage/nested/dir/file.txt"}
-            ) or contains_row_with(
-                # Windows path
-                stage_files.json,
-                {"name": "stage/nested\\dir/file.txt"},
             )
 
             # make sure we always delete the app


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

The current stage diff code assumes that Unix path separators are used on the local execution environment. This is not the case on Windows, leading to incorrect stage path separators being used. This change introduces an explicit `StagePath` type to make sure that stage paths are handled correctly throughout the diff & deploy logic. I also ended up fixing a hidden stage diff command that has always been broken.

### Testing

Updated all existing tests to pass with the new logic, and removed the workaround for the Windows bug from previous commits. Also manually verified the behaviour of `snow app deploy` with various arguments as well as  `snow app run` on both Mac and Windows. I manually checked the contents of the remote app package stages to make sure the files were published correctly.
