### PR TITLE
Fix app run to always upgrade

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,7 @@
 * Optimize snowpark dependency search to lower the size of .zip artifacts and
   the number of anaconda dependencies for snowpark projects.
 * Added support for fully qualified stage names in stage and git execute commands.
+* Fixed `snow app run` not upgrading the application after `snow app deploy`.
 
 # v2.2.0
 

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -71,13 +71,10 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
 
                 # If all the above checks are in order, proceed to upgrade
                 try:
-                    if diff.has_changes():
-                        cc.step(
-                            f"Upgrading existing application object {self.app_name}."
-                        )
-                        self._execute_query(
-                            f"alter application {self.app_name} upgrade using @{self.stage_fqn}"
-                        )
+                    cc.step(f"Upgrading existing application object {self.app_name}.")
+                    self._execute_query(
+                        f"alter application {self.app_name} upgrade using @{self.stage_fqn}"
+                    )
 
                     # ensure debug_mode is up-to-date
                     self._execute_query(

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -415,6 +415,12 @@ def test_create_dev_app_no_diff_changes(
             ),
             (None, mock.call("use role app_role")),
             (None, mock.call("use warehouse app_warehouse")),
+            (
+                None,
+                mock.call(
+                    "alter application myapp upgrade using @app_pkg.app_src.stage"
+                ),
+            ),
             (None, mock.call("alter application myapp set debug_mode = True")),
             (None, mock.call("use role old_role")),
         ]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

When users run `snow app deploy` and then `snow app run`, the local state and the remote stage are identical, so the upgrade step is skipped.
This PR fixes that by always upgrading the application on `snow app run`.

### Manual test

Running `snow app deploy` and then `snow app run`, verifying that the app was upgraded:

```
$ snow app deploy
Checking if stage exists, or creating a new one if none exists.
Performing a diff between the Snowflake stage and your local deploy_root ('~/test-app/output/deploy') directory.
There are no new files that exist only in your local directory.
There are no new files that exist only on the stage.
Existing files modified or status unknown:
README.md
Existing files identical to the stage:
manifest.yml
service_spec.yml
services.sql
setup.sql
Uploading diff-ed files from your local ~/test-app/output/deploy directory to the Snowflake stage.
Deployed successfully.

$ snow app run
Checking if stage exists, or creating a new one if none exists.
Performing a diff between the Snowflake stage and your local deploy_root ('~/test-app/output/deploy') directory.
There are no new files that exist only in your local directory.
There are no new files that exist only on the stage.
There are no existing files that have been modified, or their status is unknown.
Existing files identical to the stage:
README.md
manifest.yml
service_spec.yml
services.sql
setup.sql
Upgrading existing application object spcs_na_5_gbloom.
Your application object (spcs_na_5_gbloom) is now available:
https://<redacted>/#/apps/application/SPCS_NA_5_GBLOOM
```
