### PR TITLE
Snow 1348392 update replace checks

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 * Added support for fully qualified stage names in stage and git execute commands.
 * Fixed a bug where `snow app run` was not upgrading the application when the local state and remote stage are identical (for example immediately after `snow app deploy`).
 * Fixed handling of stage path separators on Windows
+* Change to `external_access_integrations` in `snowflake.yml` now also triggers function replace
 
 # v2.2.0
 

--- a/src/snowflake/cli/plugins/snowpark/commands.py
+++ b/src/snowflake/cli/plugins/snowpark/commands.py
@@ -275,6 +275,7 @@ def _deploy_single_object(
     handler = object_definition.handler
     returns = object_definition.returns
     imports = object_definition.imports
+    external_access_integrations = object_definition.external_access_integrations
     replace_object = False
 
     object_exists = identifier in existing_objects
@@ -285,6 +286,7 @@ def _deploy_single_object(
             handler=handler,
             return_type=returns,
             snowflake_dependencies=snowflake_dependencies,
+            external_access_integrations=external_access_integrations,
             imports=imports,
             stage_artifact_file=stage_artifact_path,
         )

--- a/src/snowflake/cli/plugins/snowpark/common.py
+++ b/src/snowflake/cli/plugins/snowpark/common.py
@@ -44,7 +44,7 @@ def check_if_replace_is_required(
         return True
 
     if set(external_access_integrations) != set(
-        resource_json.get("external_access_integration", [])
+        resource_json.get("external_access_integrations", [])
     ):
         log.info(
             "Found difference of external access integrations. Replacing the %s.",

--- a/src/snowflake/cli/plugins/snowpark/common.py
+++ b/src/snowflake/cli/plugins/snowpark/common.py
@@ -43,8 +43,13 @@ def check_if_replace_is_required(
         )
         return True
 
-    if set(external_access_integrations) != set(resource_json.get("external_access_integration",[])):
-        log.info("Found difference of external access integrations. Replacing the %s.",object_type)
+    if set(external_access_integrations) != set(
+        resource_json.get("external_access_integration", [])
+    ):
+        log.info(
+            "Found difference of external access integrations. Replacing the %s.",
+            object_type,
+        )
         return True
 
     if (
@@ -59,7 +64,6 @@ def check_if_replace_is_required(
 
     if _compare_imports(resource_json, imports, stage_artifact_file):
         return True
-
 
     return False
 
@@ -195,7 +199,7 @@ def build_udf_sproc_identifier(
             result += f" default {val}"
         return result
 
-    if udf_sproc.signature and udf_sproc.signature != 'null':
+    if udf_sproc.signature and udf_sproc.signature != "null":
         arguments = ", ".join(format_arg(arg) for arg in udf_sproc.signature)
     else:
         arguments = ""

--- a/tests_integration/test_snowpark_external_access.py
+++ b/tests_integration/test_snowpark_external_access.py
@@ -7,11 +7,9 @@ STAGE_NAME = "dev_deployment"
 
 
 @pytest.mark.integration
-def test_snowpark_external_access(
-    project_directory, _test_steps, test_database, alter_snowflake_yml
-):
+def test_snowpark_external_access(project_directory, _test_steps, test_database):
 
-    with project_directory("snowpark_external_access") as tmp_dir:
+    with project_directory("snowpark_external_access"):
         _test_steps.snowpark_build_should_zip_files()
 
         _test_steps.snowpark_deploy_should_finish_successfully_and_return(

--- a/tests_integration/test_snowpark_external_access.py
+++ b/tests_integration/test_snowpark_external_access.py
@@ -7,7 +7,9 @@ STAGE_NAME = "dev_deployment"
 
 
 @pytest.mark.integration
-def test_snowpark_external_access(project_directory, _test_steps, test_database, alter_snowflake_yml):
+def test_snowpark_external_access(
+    project_directory, _test_steps, test_database, alter_snowflake_yml
+):
 
     with project_directory("snowpark_external_access") as tmp_dir:
         _test_steps.snowpark_build_should_zip_files()
@@ -38,35 +40,10 @@ def test_snowpark_external_access(project_directory, _test_steps, test_database,
             expected_value="200",
         )
 
-        alter_snowflake_yml(
-            tmp_dir / "snowflake.yml",
-            parameter_path = "snowpark.functions.0.external_access_integrations.0",
-            value="TEST_INTEGRATION"
-        )
 
-        alter_snowflake_yml(
-            tmp_dir / "snowflake.yml",
-            parameter_path = "snowpark.procedures.0.external_access_integrations.0",
-            value="TEST_INTEGRATION"
-        )
-
-        _test_steps.snowpark_deploy_should_finish_successfully_and_return(
-            additional_arguments=["--replace"],
-            expected_result=[
-                {
-                    "object": f"{test_database.upper()}.PUBLIC.STATUS_PROCEDURE()",
-                    "status": "packages updated",
-                    "type": "procedure",
-                },
-                {
-                    "object": f"{test_database.upper()}.PUBLIC.STATUS_FUNCTION()",
-                    "status": "packages updated",
-                    "type": "function",
-                },
-            ]
-        )
-
-def test_snowpark_upgrades_with_external_access(project_directory, _test_steps, test_database, alter_snowflake_yml):
+def test_snowpark_upgrades_with_external_access(
+    project_directory, _test_steps, test_database, alter_snowflake_yml
+):
 
     with project_directory("snowpark") as tmp_dir:
         _test_steps.snowpark_build_should_zip_files()
@@ -94,13 +71,12 @@ def test_snowpark_upgrades_with_external_access(project_directory, _test_steps, 
         alter_snowflake_yml(
             tmp_dir / "snowflake.yml",
             parameter_path="snowpark.functions.0.external_access_integrations",
-            value=["snowflake_docs_access_integration"]
+            value=["snowflake_docs_access_integration"],
         )
-
         alter_snowflake_yml(
             tmp_dir / "snowflake.yml",
             parameter_path="snowpark.procedures.0.external_access_integrations",
-            value=["snowflake_docs_access_integration"]
+            value=["snowflake_docs_access_integration"],
         )
 
         _test_steps.snowpark_deploy_should_finish_successfully_and_return(
@@ -121,9 +97,72 @@ def test_snowpark_upgrades_with_external_access(project_directory, _test_steps, 
                     "type": "function",
                 },
             ],
-            additional_arguments=["--replace"]
+            additional_arguments=["--replace"],
         )
 
+        alter_snowflake_yml(
+            tmp_dir / "snowflake.yml",
+            parameter_path="snowpark.functions.0.external_access_integrations",
+            value=["CLI_TEST_INTEGRATION"],
+        )
+
+        alter_snowflake_yml(
+            tmp_dir / "snowflake.yml",
+            parameter_path="snowpark.procedures.0.external_access_integrations",
+            value=["CLI_TEST_INTEGRATION"],
+        )
+
+        _test_steps.snowpark_deploy_should_finish_successfully_and_return(
+            [
+                {
+                    "object": f"{test_database.upper()}.PUBLIC.HELLO_PROCEDURE(name string)",
+                    "status": "definition updated",
+                    "type": "procedure",
+                },
+                {
+                    "object": f"{test_database.upper()}.PUBLIC.TEST()",
+                    "status": "packages updated",
+                    "type": "procedure",
+                },
+                {
+                    "object": f"{test_database.upper()}.PUBLIC.HELLO_FUNCTION(name string)",
+                    "status": "definition updated",
+                    "type": "function",
+                },
+            ],
+            additional_arguments=["--replace"],
+        )
+
+        alter_snowflake_yml(
+            tmp_dir / "snowflake.yml",
+            parameter_path="snowpark.functions.0.external_access_integrations",
+            value=[],
+        )
+        alter_snowflake_yml(
+            tmp_dir / "snowflake.yml",
+            parameter_path="snowpark.procedures.0.external_access_integrations",
+            value=[],
+        )
+        _test_steps.snowpark_deploy_should_finish_successfully_and_return(
+            [
+                {
+                    "object": f"{test_database.upper()}.PUBLIC.HELLO_PROCEDURE(name string)",
+                    "status": "definition updated",
+                    "type": "procedure",
+                },
+                {
+                    "object": f"{test_database.upper()}.PUBLIC.TEST()",
+                    "status": "packages updated",
+                    "type": "procedure",
+                },
+                {
+                    "object": f"{test_database.upper()}.PUBLIC.HELLO_FUNCTION(name string)",
+                    "status": "definition updated",
+                    "type": "function",
+                },
+            ],
+            additional_arguments=["--replace"],
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes the missing check for changes in `external access integrations` when deploying snowpark objects with `--replace`.

Also, this solves a little bug with building and udf sproc identifier, when argument is  set to empty string.
