### PR TITLE
Integration tests: use warehouse and role env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 .coverage
 gen_docs/
 /venv/
+.env
 
 ^app.zip
 ^snowflake.yml

--- a/tests_integration/snowflake_connector.py
+++ b/tests_integration/snowflake_connector.py
@@ -79,6 +79,8 @@ def snowflake_session():
         "user": _get_from_env("USER"),
         "password": _get_from_env("PASSWORD"),
         "host": _get_from_env("HOST", allow_none=True),
+        "warehouse": _get_from_env("WAREHOUSE", allow_none=True),
+        "role": _get_from_env("ROLE", allow_none=True),
     }
     config = {k: v for k, v in config.items() if v is not None}
     connection = connector.connect(**config)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * I've added or updated automated unit tests to verify correctness of my new code.
   * I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

When we use the `snowflake_session` fixture in our integration tests, the config values are read from env variables prefixed with `SNOWFLAKE_CONNECTIONS_INTEGRATION_`.

This PR adds `WAREHOUSE` and `ROLE` to the list.
I also added `.env` to `.gitignore` as it's a common convention to put there local/test configuration that you don't want to check in.

### Test

I noticed the problem when I tried to run the integration tests locally. I verified the values are correctly picked up after the change:

```
eval $(cat .env) python -m pytest -m integration

# .env content
SNOWFLAKE_CONNECTIONS_INTEGRATION_ACCOUNT="..."
SNOWFLAKE_CONNECTIONS_INTEGRATION_USER="..."
SNOWFLAKE_CONNECTIONS_INTEGRATION_PASSWORD="..."
SNOWFLAKE_CONNECTIONS_INTEGRATION_ROLE="..."
SNOWFLAKE_CONNECTIONS_INTEGRATION_WAREHOUSE="..."
...
```
