### PR TITLE
Introduce BundleMap to encapsulate artifact path mappings

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@
 * Fixed handling of stage path separators on Windows
 * Change to `external_access_integrations` in `snowflake.yml` now also triggers function replace
 * The `--info` callback returns info about configured feature flags.
+* Fixed bugs in source artifact mapping logic for native applications
 
 
 # v2.2.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,7 @@
 
 ## Fixes and improvements
 * Improved support for quoted identifiers.
+* Fixed bugs in source artifact mapping logic for native applications
 
 # v2.3.0
 
@@ -41,8 +42,6 @@
 * Fixed handling of stage path separators on Windows
 * Change to `external_access_integrations` in `snowflake.yml` now also triggers function replace
 * The `--info` callback returns info about configured feature flags.
-* Fixed bugs in source artifact mapping logic for native applications
-
 
 # v2.2.0
 

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -205,7 +205,7 @@ class BundleMap:
         self,
         src: Path,
         absolute: bool = False,
-        walk_directories: bool = False,
+        expand_directories: bool = False,
         predicate: ArtifactPredicate = lambda src, dest: True,
     ) -> Iterator[Tuple[Path, Path]]:
         canonical_src = self._canonical_src(src)
@@ -220,8 +220,8 @@ class BundleMap:
             if predicate(src_for_output, d):
                 yield src_for_output, d
 
-        if absolute_src.is_dir() and walk_directories:
-            # both src and dest are directories, and walking directories was requested. Traverse src, and map each
+        if absolute_src.is_dir() and expand_directories:
+            # both src and dest are directories, and expanding directories was requested. Traverse src, and map each
             # file to the dest directory
             for (root, subdirs, files) in os.walk(absolute_src, followlinks=True):
                 relative_root = Path(root).relative_to(absolute_src)
@@ -235,7 +235,7 @@ class BundleMap:
     def all_mappings(
         self,
         absolute: bool = False,
-        walk_directories: bool = False,
+        expand_directories: bool = False,
         predicate: ArtifactPredicate = lambda src, dest: True,
     ) -> Iterator[Tuple[Path, Path]]:
         """
@@ -246,7 +246,7 @@ class BundleMap:
             self: this instance
             absolute (bool): Specifies whether the yielded paths should be joined with the project or deploy roots,
              as appropriate.
-            walk_directories (bool): Specifies whether directory to directory mappings should be expanded to
+            expand_directories (bool): Specifies whether directory to directory mappings should be expanded to
              resolve their contained files.
             predicate (PathPredicate): If provided, the predicate is invoked with both the source path and the
              destination path as arguments. Only pairs selected by the predicate are returned.
@@ -258,7 +258,7 @@ class BundleMap:
             for deployed_src, deployed_dest in self._mappings_for_source(
                 src,
                 absolute=absolute,
-                walk_directories=walk_directories,
+                expand_directories=expand_directories,
                 predicate=predicate,
             ):
                 yield deployed_src, deployed_dest
@@ -458,7 +458,7 @@ def build_bundle(
         bundle_map.add(artifact)
 
     for (absolute_src, absolute_dest) in bundle_map.all_mappings(
-        absolute=True, walk_directories=False
+        absolute=True, expand_directories=False
     ):
         symlink_or_copy(absolute_src, absolute_dest)
 

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -280,20 +280,23 @@ class BundleMap:
             # No mapping is possible for this src path
             return []
 
+        output_destinations: List[Path] = []
+
         canonical_dests = self._src_to_dest.get(canonical_src)
         if canonical_dests is not None:
-            return [self._to_output_dest(d, is_absolute) for d in canonical_dests]
+            for d in canonical_dests:
+                output_destinations.append(self._to_output_dest(d, is_absolute))
 
         canonical_parent = canonical_src.parent
         canonical_parent_dests = self.to_deploy_paths(canonical_parent)
         if canonical_parent_dests:
             canonical_child = canonical_src.relative_to(canonical_parent)
-            return [
-                self._to_output_dest(d / canonical_child, is_absolute)
-                for d in canonical_parent_dests
-            ]
+            for d in canonical_parent_dests:
+                output_destinations.append(
+                    self._to_output_dest(d / canonical_child, is_absolute)
+                )
 
-        return []
+        return output_destinations
 
     def _absolute_src(self, src: Path) -> Path:
         if src.is_absolute():

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -172,7 +172,9 @@ class BundleMap:
             if dest:
                 dest_stem = dest.rstrip("/")
                 if not dest_stem:
-                    # handle '/' as the destination as a special case
+                    # handle '/' as the destination as a special case. This is because specifying only '/' as a
+                    # a destination looks like '.' once all forwards slashes are stripped. If we don't handle it
+                    # specially here, `dest: /` would incorrectly be allowed.
                     raise NotInDeployRootError(dest, self._deploy_root)
                 dest_path = Path(dest.rstrip("/"))
                 if dest_path.is_absolute():

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -219,19 +220,19 @@ class BundleMap:
         else:
             src_for_output, dest_for_output = canonical_src, canonical_dest
 
+        if predicate(src_for_output, dest_for_output):
+            yield src_for_output, dest_for_output
+
         if absolute_src.is_dir() and walk_directories:
             # both src and dest are directories, and walking directories was requested. Traverse src, and map each file
             # to the dest directory
-            for (root, _, files) in os.walk(absolute_src, followlinks=True):
+            for (root, subdirs, files) in os.walk(absolute_src, followlinks=True):
                 relative_root = Path(root).relative_to(absolute_src)
-                for f in files:
-                    src_file_for_output = src_for_output / relative_root / f
-                    dest_file_for_output = dest_for_output / relative_root / f
+                for name in itertools.chain(subdirs, files):
+                    src_file_for_output = src_for_output / relative_root / name
+                    dest_file_for_output = dest_for_output / relative_root / name
                     if predicate(src_file_for_output, dest_file_for_output):
                         yield src_file_for_output, dest_file_for_output
-        else:
-            if predicate(src_for_output, dest_for_output):
-                yield src_for_output, dest_for_output
 
     def all_mappings(
         self,

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -373,10 +373,10 @@ class NativeAppManager(SqlExecutionMixin):
             deploy_paths_to_sync = []
             for resolved_path in resolved_paths_to_sync:
                 verify_exists(resolved_path)
-                deploy_path = bundle_map.to_deploy_path(resolved_path)
-                if deploy_path is None:
+                deploy_paths = bundle_map.to_deploy_paths(resolved_path)
+                if not deploy_paths:
                     raise ClickException(f"No artifact found for {resolved_path}")
-                deploy_paths_to_sync.append(deploy_path)
+                deploy_paths_to_sync.extend(deploy_paths)
 
             stage_paths_to_sync = _get_stage_paths_to_sync(
                 deploy_paths_to_sync, resolve_without_follow(self.deploy_root)

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -373,7 +373,7 @@ class NativeAppManager(SqlExecutionMixin):
             ]
             verify_exists(deploy_paths_to_sync)
             stage_paths_to_sync = _get_stage_paths_to_sync(
-                deploy_paths_to_sync, self.deploy_root.resolve()
+                deploy_paths_to_sync, resolve_without_follow(self.deploy_root)
             )
             diff = preserve_from_diff(diff, stage_paths_to_sync)
         else:

--- a/src/snowflake/cli/plugins/nativeapp/utils.py
+++ b/src/snowflake/cli/plugins/nativeapp/utils.py
@@ -79,7 +79,6 @@ def verify_no_directories(paths_to_sync: List[Path]):
             )
 
 
-def verify_exists(paths_to_sync: List[Path]):
-    for path in paths_to_sync:
-        if not path.exists():
-            raise ClickException(f"The following path does not exist: {path}")
+def verify_exists(path: Path):
+    if not path.exists():
+        raise ClickException(f"The following path does not exist: {path}")

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -308,10 +308,19 @@ def test_bundle_map_allows_mapping_file_to_multiple_destinations(
 
     verify_mappings(
         bundle_map,
-        {
+        expected_mappings={
             "README.md": ["deployed/README1.md", "deployed/README2.md"],
             "src/streamlit": ["deployed/streamlit_orig", "deployed/streamlit_copy"],
-            "src/streamlit/main_ui.py": "deployed/main_ui.py",
+            "src/streamlit/main_ui.py": ["deployed/main_ui.py"],
+        },
+        expected_deploy_paths={
+            "README.md": ["deployed/README1.md", "deployed/README2.md"],
+            "src/streamlit": ["deployed/streamlit_orig", "deployed/streamlit_copy"],
+            "src/streamlit/main_ui.py": [
+                "deployed/main_ui.py",
+                "deployed/streamlit_orig/main_ui.py",
+                "deployed/streamlit_copy/main_ui.py",
+            ],
         },
     )
 
@@ -341,7 +350,11 @@ def test_bundle_map_allows_mapping_file_to_multiple_destinations(
         expected_deploy_paths={
             "README.md": ["deployed/README1.md", "deployed/README2.md"],
             "src/streamlit": ["deployed/streamlit_orig", "deployed/streamlit_copy"],
-            "src/streamlit/main_ui.py": ["deployed/main_ui.py"],
+            "src/streamlit/main_ui.py": [
+                "deployed/main_ui.py",
+                "deployed/streamlit_orig/main_ui.py",
+                "deployed/streamlit_copy/main_ui.py",
+            ],
             "src/streamlit/helpers": [
                 "deployed/streamlit_orig/helpers",
                 "deployed/streamlit_copy/helpers",
@@ -694,13 +707,13 @@ def test_bundle_map_to_deploy_path_returns_multiple_matches(bundle_map):
         Path("d2/a/b"),
     ]
 
-    # bundle_map.add(PathMapping(src="src/snowpark/a", dest="d3"))
+    bundle_map.add(PathMapping(src="src/snowpark/a", dest="d3"))
 
-    # assert sorted(bundle_map.to_deploy_paths(Path("src/snowpark/a/b/file3.py"))) == [
-    #     Path("d1/a/b/file3.py"),
-    #     Path("d2/a/b/file3.py"),
-    #     Path("d3/b/file3.py"),
-    # ]
+    assert sorted(bundle_map.to_deploy_paths(Path("src/snowpark/a/b/file3.py"))) == [
+        Path("d1/a/b/file3.py"),
+        Path("d2/a/b/file3.py"),
+        Path("d3/b/file3.py"),
+    ]
 
 
 def test_bundle_map_ignores_sources_in_deploy_root(bundle_map):

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -2,25 +2,27 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 import pytest
-from click.exceptions import ClickException
 from snowflake.cli.api.project.definition import load_project_definition
+from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.plugins.nativeapp.artifacts import (
+    ArtifactError,
     ArtifactMapping,
+    ArtifactPredicate,
+    BundleMap,
     DeployRootError,
-    GlobMatchedNothingError,
     NotInDeployRootError,
     SourceNotFoundError,
     TooManyFilesError,
     build_bundle,
     resolve_without_follow,
-    source_path_to_deploy_path,
     translate_artifact,
 )
 
 from tests.nativeapp.utils import touch
+from tests.testing_utils.files_and_dirs import temp_local_dir
 
 
 def trimmed_contents(path: Path) -> Optional[str]:
@@ -42,6 +44,488 @@ def dir_structure(path: Path, prefix="") -> List[str]:
             parts.append(f"{prefix}{child.name}")
 
     return parts
+
+
+@pytest.fixture
+def bundle_map():
+    project_files = {
+        "snowflake.yml": "# empty",
+        "README.md": "# Test Project",
+        "app/setup.sql": "-- empty",
+        "app/manifest.yml": "# empty",
+        "src/snowpark/main.py": "# empty",
+        "src/snowpark/a/file1.py": "# empty",
+        "src/snowpark/a/file2.py": "# empty",
+        "src/snowpark/a/b/file3.py": "# empty",
+        "src/snowpark/a/b/file4.py": "# empty",
+        "src/snowpark/a/c/file5.py": "# empty",
+        "src/streamlit/main_ui.py": "# empty",
+        "src/streamlit/helpers/file1.py": "# empty",
+        "src/streamlit/helpers/file2.py": "# empty",
+    }
+    with temp_local_dir(project_files) as project_root:
+        deploy_root = project_root / "output" / "deploy"
+        yield BundleMap(project_root=project_root, deploy_root=deploy_root)
+
+
+def ensure_path(path: Union[Path, str]) -> Path:
+    if isinstance(path, str):
+        return Path(path)
+    return path
+
+
+def verify_mappings(
+    bundle_map: BundleMap,
+    expected_mappings: Dict[Union[str, Path], Optional[Union[str, Path]]],
+    **kwargs,
+):
+    for src, dest in expected_mappings.items():
+        if dest is None:
+            assert bundle_map.to_deploy_path(ensure_path(src)) is None
+        else:
+            assert bundle_map.to_deploy_path(ensure_path(src)) == ensure_path(dest)
+
+    actual_path_mappings = dict(bundle_map.all_mappings(**kwargs))
+    expected_path_mappings = {
+        ensure_path(src): ensure_path(dest)
+        for (src, dest) in expected_mappings.items()
+        if dest is not None
+    }
+    assert actual_path_mappings == expected_path_mappings
+
+
+def path_mapping_factory(src: str, dest: Optional[str] = None) -> PathMapping:
+    return PathMapping(src=src, dest=dest)
+
+
+def test_empty_bundle_map(bundle_map):
+    mappings = list(bundle_map.all_mappings())
+    assert mappings == []
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app/setup.sql": None,
+            ".": None,
+            "/not/in/project": None,
+        },
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_handles_file_to_file_mappings(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("README.md", "deployed_readme.md"))
+    bundle_map.add(mapping_factory("app/setup.sql", "app_setup.sql"))
+    bundle_map.add(mapping_factory("app/manifest.yml", "manifest.yml"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "README.md": "deployed_readme.md",
+            "app/setup.sql": "app_setup.sql",
+            "app/manifest.yml": "manifest.yml",
+        },
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_supports_double_star_glob(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("src/snowpark/**/*.py", "deployed/"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "src/snowpark/main.py": "deployed/main.py",
+            "src/snowpark/a/file1.py": "deployed/file1.py",
+            "src/snowpark/a/file2.py": "deployed/file2.py",
+            "src/snowpark/a/b/file3.py": "deployed/file3.py",
+            "src/snowpark/a/b/file4.py": "deployed/file4.py",
+            "src/snowpark/a/c/file5.py": "deployed/file5.py",
+        },
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_supports_complex_globbing(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("src/s*/**/file[3-5].py", "deployed/"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "src/snowpark/main.py": None,
+            "src/snowpark/a/file1.py": None,
+            "src/snowpark/a/file2.py": None,
+            "src/snowpark/a/b/file3.py": "deployed/file3.py",
+            "src/snowpark/a/b/file4.py": "deployed/file4.py",
+            "src/snowpark/a/c/file5.py": "deployed/file5.py",
+        },
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_handles_mapping_to_deploy_root(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("app/*", "./"))
+    bundle_map.add(mapping_factory("README.md", "./"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app/setup.sql": "setup.sql",
+            "app/manifest.yml": "manifest.yml",
+            "README.md": "README.md",
+        },
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_can_rename_directories(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("app", "deployed"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app": "deployed",
+        },
+        walk_directories=False,
+    )
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app/setup.sql": "deployed/setup.sql",
+            "app/manifest.yml": "deployed/manifest.yml",
+        },
+        walk_directories=True,
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_honours_trailing_slashes(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("app", "deployed/"))
+    bundle_map.add(mapping_factory("README.md", "deployed/"))
+    bundle_map.add(
+        # src trailing slash has no effect
+        mapping_factory("src/snowpark/", "deployed/")
+    )
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app": "deployed/app",
+            "src/snowpark": "deployed/snowpark",
+            "README.md": "deployed/README.md",
+        },
+    )
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app/manifest.yml": "deployed/app/manifest.yml",
+            "app/setup.sql": "deployed/app/setup.sql",
+            "src/snowpark/main.py": "deployed/snowpark/main.py",
+            "src/snowpark/a/file1.py": "deployed/snowpark/a/file1.py",
+            "src/snowpark/a/file2.py": "deployed/snowpark/a/file2.py",
+            "src/snowpark/a/b/file3.py": "deployed/snowpark/a/b/file3.py",
+            "src/snowpark/a/b/file4.py": "deployed/snowpark/a/b/file4.py",
+            "src/snowpark/a/c/file5.py": "deployed/snowpark/a/c/file5.py",
+            "README.md": "deployed/README.md",
+        },
+        walk_directories=True,
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_overwriting_deploy_root(mapping_factory, bundle_map):
+    with pytest.raises(NotInDeployRootError):
+        bundle_map.add(mapping_factory("app/*", "."))
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_unknown_sources(mapping_factory, bundle_map):
+    with pytest.raises(SourceNotFoundError):
+        bundle_map.add(mapping_factory("missing/*", "deployed/"))
+
+    with pytest.raises(SourceNotFoundError):
+        bundle_map.add(mapping_factory("missing", "deployed/"))
+
+    with pytest.raises(SourceNotFoundError):
+        bundle_map.add(mapping_factory("**/*.missing", "deployed/"))
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_mapping_multiple_to_file(mapping_factory, bundle_map):
+    with pytest.raises(TooManyFilesError):
+        # multiple files named 'file1.py' would collide
+        bundle_map.add(mapping_factory("**/file1.py", "deployed/"))
+
+    with pytest.raises(TooManyFilesError):
+        bundle_map.add(mapping_factory("**/file1.py", "deployed/"))
+
+
+def test_bundle_map_handles_missing_dest(bundle_map):
+    bundle_map.add(PathMapping(src="app"))
+    bundle_map.add(PathMapping(src="README.md"))
+    bundle_map.add(PathMapping(src="src/streamlit/"))
+
+    verify_mappings(
+        bundle_map,
+        {"app": "app", "README.md": "README.md", "src/streamlit": "src/streamlit"},
+    )
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app/setup.sql": "app/setup.sql",
+            "app/manifest.yml": "app/manifest.yml",
+            "README.md": "README.md",
+            "src/streamlit/main_ui.py": "src/streamlit/main_ui.py",
+            "src/streamlit/helpers/file1.py": "src/streamlit/helpers/file1.py",
+            "src/streamlit/helpers/file2.py": "src/streamlit/helpers/file2.py",
+        },
+        walk_directories=True,
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_conflicting_dest_types(mapping_factory, bundle_map):
+    bundle_map.add(mapping_factory("app", "deployed/"))
+    with pytest.raises(ArtifactError):
+        bundle_map.add(mapping_factory("**/main.py", "deployed"))
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_mapping_outside_deploy_root(mapping_factory, bundle_map):
+    with pytest.raises(NotInDeployRootError):
+        bundle_map.add(mapping_factory("app", "deployed/../../"))
+
+    with pytest.raises(NotInDeployRootError):
+        bundle_map.add(mapping_factory("app", Path().resolve().root))
+
+    with pytest.raises(NotInDeployRootError):
+        bundle_map.add(mapping_factory("app", "/////"))
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_absolute_src(mapping_factory, bundle_map):
+    with pytest.raises(ArtifactError):
+        absolute_src = bundle_map.project_root() / "app"
+        assert absolute_src.is_absolute()
+        bundle_map.add(mapping_factory(str(absolute_src), "deployed"))
+
+
+@pytest.mark.parametrize("mapping_factory", [ArtifactMapping, path_mapping_factory])
+def test_bundle_map_disallows_absolute_dest(mapping_factory, bundle_map):
+    with pytest.raises(ArtifactError):
+        absolute_dest = bundle_map.deploy_root() / "deployed"
+        assert absolute_dest.is_absolute()
+        bundle_map.add(mapping_factory("app", str(absolute_dest)))
+
+
+def test_bundle_map_checks_mapping_type(bundle_map):
+    with pytest.raises(RuntimeError):
+        bundle_map.add({"src": "app", "dest": "deployed"})
+
+
+def test_bundle_map_all_mappings_can_generates_absolute_directories_when_requested(
+    bundle_map,
+):
+    project_root = bundle_map.project_root()
+    assert project_root.is_absolute()
+    deploy_root = bundle_map.deploy_root()
+    assert deploy_root.is_absolute()
+
+    bundle_map.add(PathMapping(src="app", dest="deployed_app"))
+    bundle_map.add(PathMapping(src="README.md", dest="deployed_README.md"))
+    bundle_map.add(PathMapping(src="src/streamlit", dest="deployed_streamlit"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app": "deployed_app",
+            "README.md": "deployed_README.md",
+            "src/streamlit": "deployed_streamlit",
+        },
+    )
+
+    verify_mappings(
+        bundle_map,
+        {
+            project_root / "app": deploy_root / "deployed_app",
+            project_root / "README.md": deploy_root / "deployed_README.md",
+            project_root / "src/streamlit": deploy_root / "deployed_streamlit",
+        },
+        absolute=True,
+        walk_directories=False,
+    )
+
+    verify_mappings(
+        bundle_map,
+        {
+            project_root / "app/setup.sql": deploy_root / "deployed_app/setup.sql",
+            project_root
+            / "app/manifest.yml": deploy_root
+            / "deployed_app/manifest.yml",
+            project_root / "README.md": deploy_root / "deployed_README.md",
+            project_root
+            / "src/streamlit/main_ui.py": deploy_root
+            / "deployed_streamlit/main_ui.py",
+            project_root
+            / "src/streamlit/helpers/file1.py": deploy_root
+            / "deployed_streamlit/helpers/file1.py",
+            project_root
+            / "src/streamlit/helpers/file2.py": deploy_root
+            / "deployed_streamlit/helpers/file2.py",
+        },
+        absolute=True,
+        walk_directories=True,
+    )
+
+
+def test_bundle_map_all_mappings_accepts_predicates(bundle_map):
+    project_root = bundle_map.project_root()
+    assert project_root.is_absolute()
+    deploy_root = bundle_map.deploy_root()
+    assert deploy_root.is_absolute()
+
+    bundle_map.add(PathMapping(src="app", dest="deployed_app"))
+    bundle_map.add(PathMapping(src="README.md", dest="deployed_README.md"))
+    bundle_map.add(PathMapping(src="src/streamlit", dest="deployed_streamlit"))
+
+    collected: Dict[Path, Path] = {}
+
+    def collecting_predicate(predicate: ArtifactPredicate) -> ArtifactPredicate:
+        def _predicate(src: Path, dest: Path) -> bool:
+            collected[src] = dest
+            return predicate(src, dest)
+
+        return _predicate
+
+    verify_mappings(
+        bundle_map,
+        {
+            project_root
+            / "src/streamlit/main_ui.py": deploy_root
+            / "deployed_streamlit/main_ui.py",
+            project_root
+            / "src/streamlit/helpers/file1.py": deploy_root
+            / "deployed_streamlit/helpers/file1.py",
+            project_root
+            / "src/streamlit/helpers/file2.py": deploy_root
+            / "deployed_streamlit/helpers/file2.py",
+        },
+        absolute=True,
+        walk_directories=True,
+        predicate=collecting_predicate(lambda src, dest: src.suffix == ".py"),
+    )
+
+    assert collected == {
+        project_root / "app/setup.sql": deploy_root / "deployed_app/setup.sql",
+        project_root / "app/manifest.yml": deploy_root / "deployed_app/manifest.yml",
+        project_root / "README.md": deploy_root / "deployed_README.md",
+        project_root
+        / "src/streamlit/main_ui.py": deploy_root
+        / "deployed_streamlit/main_ui.py",
+        project_root
+        / "src/streamlit/helpers/file1.py": deploy_root
+        / "deployed_streamlit/helpers/file1.py",
+        project_root
+        / "src/streamlit/helpers/file2.py": deploy_root
+        / "deployed_streamlit/helpers/file2.py",
+    }
+
+    collected = {}
+
+    verify_mappings(
+        bundle_map,
+        {
+            "src/streamlit/main_ui.py": "deployed_streamlit/main_ui.py",
+            "src/streamlit/helpers/file1.py": "deployed_streamlit/helpers/file1.py",
+            "src/streamlit/helpers/file2.py": "deployed_streamlit/helpers/file2.py",
+        },
+        absolute=False,
+        walk_directories=True,
+        predicate=collecting_predicate(lambda src, dest: src.suffix == ".py"),
+    )
+
+    assert collected == {
+        Path("app/setup.sql"): Path("deployed_app/setup.sql"),
+        Path("app/manifest.yml"): Path("deployed_app/manifest.yml"),
+        Path("README.md"): Path("deployed_README.md"),
+        Path("src/streamlit/main_ui.py"): Path("deployed_streamlit/main_ui.py"),
+        Path("src/streamlit/helpers/file1.py"): Path(
+            "deployed_streamlit/helpers/file1.py"
+        ),
+        Path("src/streamlit/helpers/file2.py"): Path(
+            "deployed_streamlit/helpers/file2.py"
+        ),
+    }
+
+
+def test_bundle_map_to_deploy_path(bundle_map):
+    bundle_map.add(PathMapping(src="app", dest="deployed_app"))
+    bundle_map.add(PathMapping(src="README.md", dest="deployed_README.md"))
+    bundle_map.add(PathMapping(src="src/streamlit", dest="deployed_streamlit"))
+
+    # to_deploy_path returns relative paths when relative paths are given as input
+    assert bundle_map.to_deploy_path(Path("app")) == Path("deployed_app")
+    assert bundle_map.to_deploy_path(Path("README.md")) == Path("deployed_README.md")
+    assert bundle_map.to_deploy_path(Path("src/streamlit")) == Path(
+        "deployed_streamlit"
+    )
+    assert bundle_map.to_deploy_path(Path("src/streamlit/main_ui.py")) == Path(
+        "deployed_streamlit/main_ui.py"
+    )
+    assert bundle_map.to_deploy_path(Path("src/streamlit/helpers")) == Path(
+        "deployed_streamlit/helpers"
+    )
+    assert bundle_map.to_deploy_path(Path("src/streamlit/helpers/file1.py")) == Path(
+        "deployed_streamlit/helpers/file1.py"
+    )
+    assert bundle_map.to_deploy_path(Path("src/streamlit/missing.py")) is None
+
+    # to_deploy_path returns absolute paths when absolute paths are given as input
+    project_root = bundle_map.project_root()
+    deploy_root = bundle_map.deploy_root()
+    assert (
+        bundle_map.to_deploy_path(project_root / "app") == deploy_root / "deployed_app"
+    )
+    assert (
+        bundle_map.to_deploy_path(project_root / "README.md")
+        == deploy_root / "deployed_README.md"
+    )
+    assert (
+        bundle_map.to_deploy_path(project_root / "src/streamlit")
+        == deploy_root / "deployed_streamlit"
+    )
+    assert (
+        bundle_map.to_deploy_path(project_root / "src/streamlit/main_ui.py")
+        == deploy_root / "deployed_streamlit/main_ui.py"
+    )
+    assert (
+        bundle_map.to_deploy_path(project_root / "src/streamlit/helpers")
+        == deploy_root / "deployed_streamlit/helpers"
+    )
+    assert (
+        bundle_map.to_deploy_path(project_root / "src/streamlit/helpers/file1.py")
+        == deploy_root / "deployed_streamlit/helpers/file1.py"
+    )
+    assert bundle_map.to_deploy_path(project_root / "src/streamlit/missing.py") is None
+
+
+def test_bundle_map_ignores_sources_in_deploy_root(bundle_map):
+    bundle_map.deploy_root().mkdir(parents=True, exist_ok=True)
+    deploy_root_source = bundle_map.deploy_root() / "should_not_match.yml"
+    touch(str(deploy_root_source))
+
+    bundle_map.add(PathMapping(src="**/*.yml", dest="deployed/"))
+
+    verify_mappings(
+        bundle_map,
+        {
+            "app/manifest.yml": "deployed/manifest.yml",
+            "snowflake.yml": "deployed/snowflake.yml",
+        },
+    )
 
 
 @pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
@@ -106,7 +590,7 @@ def test_source_not_found(project_definition_files):
 @pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
 def test_glob_matched_nothing(project_definition_files):
     project_root = project_definition_files[0].parent
-    with pytest.raises(GlobMatchedNothingError):
+    with pytest.raises(SourceNotFoundError):
         build_bundle(
             project_root,
             deploy_root=Path(project_root, "deploy"),
@@ -217,14 +701,14 @@ def test_source_path_to_deploy_path(
     os.symlink("srcfile", "deploy/file")
     os.symlink(Path("srcdir").resolve(), Path("deploy/dir"))
 
-    files_mapping = {
-        Path("srcdir").resolve(): resolve_without_follow(Path("deploy/dir")),
-        Path("srcfile").resolve(): resolve_without_follow(Path("deploy/file")),
-    }
+    bundle_map = BundleMap(
+        project_root=Path().resolve(), deploy_root=Path("deploy").resolve()
+    )
+    bundle_map.add(ArtifactMapping("srcdir", "./dir"))
+    bundle_map.add(ArtifactMapping("srcfile", "./file"))
 
+    result = bundle_map.to_deploy_path(resolve_without_follow(Path(project_path)))
     if expected_path:
-        result = source_path_to_deploy_path(Path(project_path).resolve(), files_mapping)
         assert result == resolve_without_follow(Path(expected_path))
     else:
-        with pytest.raises(ClickException):
-            source_path_to_deploy_path(Path(project_path).resolve(), files_mapping)
+        assert result is None

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -214,7 +214,7 @@ def test_bundle_map_can_rename_directories(mapping_factory, bundle_map):
         {
             "app": "deployed",
         },
-        walk_directories=False,
+        expand_directories=False,
     )
 
     verify_mappings(
@@ -224,7 +224,7 @@ def test_bundle_map_can_rename_directories(mapping_factory, bundle_map):
             "app/setup.sql": "deployed/setup.sql",
             "app/manifest.yml": "deployed/manifest.yml",
         },
-        walk_directories=True,
+        expand_directories=True,
     )
 
 
@@ -264,7 +264,7 @@ def test_bundle_map_honours_trailing_slashes(mapping_factory, bundle_map):
             "src/snowpark/a/c/file5.py": "deployed/snowpark/a/c/file5.py",
             "README.md": "deployed/README.md",
         },
-        walk_directories=True,
+        expand_directories=True,
     )
 
 
@@ -368,7 +368,7 @@ def test_bundle_map_allows_mapping_file_to_multiple_destinations(
                 "deployed/streamlit_copy/helpers/file2.py",
             ],
         },
-        walk_directories=True,
+        expand_directories=True,
     )
 
 
@@ -395,7 +395,7 @@ def test_bundle_map_handles_missing_dest(bundle_map):
             "src/streamlit/helpers/file1.py": "src/streamlit/helpers/file1.py",
             "src/streamlit/helpers/file2.py": "src/streamlit/helpers/file2.py",
         },
-        walk_directories=True,
+        expand_directories=True,
     )
 
 
@@ -436,7 +436,7 @@ def test_bundle_map_allows_deploying_other_sources_to_renamed_directory(
             "src/snowpark/a/c": "snowpark/a/c",
             "src/snowpark/a/c/file5.py": "snowpark/a/c/file5.py",
         },
-        walk_directories=True,
+        expand_directories=True,
     )
 
 
@@ -518,7 +518,7 @@ def test_bundle_map_all_mappings_can_generates_absolute_directories_when_request
             project_root / "src/streamlit": deploy_root / "deployed_streamlit",
         },
         absolute=True,
-        walk_directories=False,
+        expand_directories=False,
     )
 
     verify_mappings(
@@ -545,7 +545,7 @@ def test_bundle_map_all_mappings_can_generates_absolute_directories_when_request
             / "deployed_streamlit/helpers/file2.py",
         },
         absolute=True,
-        walk_directories=True,
+        expand_directories=True,
     )
 
 
@@ -582,7 +582,7 @@ def test_bundle_map_all_mappings_accepts_predicates(bundle_map):
             / "deployed_streamlit/helpers/file2.py",
         },
         absolute=True,
-        walk_directories=True,
+        expand_directories=True,
         predicate=collecting_predicate(
             lambda src, dest: src.is_file() and src.suffix == ".py"
         ),
@@ -618,7 +618,7 @@ def test_bundle_map_all_mappings_accepts_predicates(bundle_map):
             "src/streamlit/helpers/file2.py": "deployed_streamlit/helpers/file2.py",
         },
         absolute=False,
-        walk_directories=True,
+        expand_directories=True,
         predicate=collecting_predicate(lambda src, dest: src.suffix == ".py"),
     )
 

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -192,6 +192,7 @@ def test_bundle_map_can_rename_directories(mapping_factory, bundle_map):
     verify_mappings(
         bundle_map,
         {
+            "app": "deployed",
             "app/setup.sql": "deployed/setup.sql",
             "app/manifest.yml": "deployed/manifest.yml",
         },
@@ -220,13 +221,18 @@ def test_bundle_map_honours_trailing_slashes(mapping_factory, bundle_map):
     verify_mappings(
         bundle_map,
         {
+            "app": "deployed/app",
             "app/manifest.yml": "deployed/app/manifest.yml",
             "app/setup.sql": "deployed/app/setup.sql",
+            "src/snowpark": "deployed/snowpark",
             "src/snowpark/main.py": "deployed/snowpark/main.py",
+            "src/snowpark/a": "deployed/snowpark/a",
             "src/snowpark/a/file1.py": "deployed/snowpark/a/file1.py",
             "src/snowpark/a/file2.py": "deployed/snowpark/a/file2.py",
+            "src/snowpark/a/b": "deployed/snowpark/a/b",
             "src/snowpark/a/b/file3.py": "deployed/snowpark/a/b/file3.py",
             "src/snowpark/a/b/file4.py": "deployed/snowpark/a/b/file4.py",
+            "src/snowpark/a/c": "deployed/snowpark/a/c",
             "src/snowpark/a/c/file5.py": "deployed/snowpark/a/c/file5.py",
             "README.md": "deployed/README.md",
         },
@@ -275,9 +281,12 @@ def test_bundle_map_handles_missing_dest(bundle_map):
     verify_mappings(
         bundle_map,
         {
+            "app": "app",
             "app/setup.sql": "app/setup.sql",
             "app/manifest.yml": "app/manifest.yml",
             "README.md": "README.md",
+            "src/streamlit": "src/streamlit",
+            "src/streamlit/helpers": "src/streamlit/helpers",
             "src/streamlit/main_ui.py": "src/streamlit/main_ui.py",
             "src/streamlit/helpers/file1.py": "src/streamlit/helpers/file1.py",
             "src/streamlit/helpers/file2.py": "src/streamlit/helpers/file2.py",
@@ -361,11 +370,16 @@ def test_bundle_map_all_mappings_can_generates_absolute_directories_when_request
     verify_mappings(
         bundle_map,
         {
+            project_root / "app": deploy_root / "deployed_app",
             project_root / "app/setup.sql": deploy_root / "deployed_app/setup.sql",
             project_root
             / "app/manifest.yml": deploy_root
             / "deployed_app/manifest.yml",
             project_root / "README.md": deploy_root / "deployed_README.md",
+            project_root / "src/streamlit": deploy_root / "deployed_streamlit",
+            project_root
+            / "src/streamlit/helpers": deploy_root
+            / "deployed_streamlit/helpers",
             project_root
             / "src/streamlit/main_ui.py": deploy_root
             / "deployed_streamlit/main_ui.py",
@@ -415,13 +429,20 @@ def test_bundle_map_all_mappings_accepts_predicates(bundle_map):
         },
         absolute=True,
         walk_directories=True,
-        predicate=collecting_predicate(lambda src, dest: src.suffix == ".py"),
+        predicate=collecting_predicate(
+            lambda src, dest: src.is_file() and src.suffix == ".py"
+        ),
     )
 
     assert collected == {
+        project_root / "app": deploy_root / "deployed_app",
         project_root / "app/setup.sql": deploy_root / "deployed_app/setup.sql",
         project_root / "app/manifest.yml": deploy_root / "deployed_app/manifest.yml",
         project_root / "README.md": deploy_root / "deployed_README.md",
+        project_root / "src/streamlit": deploy_root / "deployed_streamlit",
+        project_root
+        / "src/streamlit/helpers": deploy_root
+        / "deployed_streamlit/helpers",
         project_root
         / "src/streamlit/main_ui.py": deploy_root
         / "deployed_streamlit/main_ui.py",
@@ -448,10 +469,13 @@ def test_bundle_map_all_mappings_accepts_predicates(bundle_map):
     )
 
     assert collected == {
+        Path("app"): Path("deployed_app"),
         Path("app/setup.sql"): Path("deployed_app/setup.sql"),
         Path("app/manifest.yml"): Path("deployed_app/manifest.yml"),
         Path("README.md"): Path("deployed_README.md"),
+        Path("src/streamlit"): Path("deployed_streamlit"),
         Path("src/streamlit/main_ui.py"): Path("deployed_streamlit/main_ui.py"),
+        Path("src/streamlit/helpers"): Path("deployed_streamlit/helpers"),
         Path("src/streamlit/helpers/file1.py"): Path(
             "deployed_streamlit/helpers/file1.py"
         ),

--- a/tests_integration/nativeapp/test_bundle.py
+++ b/tests_integration/nativeapp/test_bundle.py
@@ -1,0 +1,57 @@
+import os
+import os.path
+import uuid
+from textwrap import dedent
+
+from snowflake.cli.api.project.util import generate_user_env
+
+from tests.project.fixtures import *
+from tests_integration.test_utils import pushd
+
+USER_NAME = f"user_{uuid.uuid4().hex}"
+TEST_ENV = generate_user_env(USER_NAME)
+
+
+# Tests that we disallow polluting the project source through symlinks
+@pytest.mark.integration
+def test_nativeapp_bundle_does_not_create_files_outside_deploy_root(
+    runner,
+    snowflake_session,
+    temporary_working_directory,
+):
+    project_name = "myapp"
+    result = runner.invoke_json(
+        ["app", "init", project_name],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0
+
+    with pushd(Path(os.getcwd(), project_name)):
+        # overwrite the snowflake.yml rules
+        with open("snowflake.yml", "w") as f:
+            f.write(
+                dedent(
+                    f"""
+            definition_version: 1
+            native_app:
+              name: myapp
+              artifacts:
+                - src: app
+                  dest: ./
+                - src: snowflake.yml
+                  dest: ./app/
+            """
+                )
+            )
+
+        result = runner.invoke_json(
+            ["app", "bundle"],
+            env=TEST_ENV,
+        )
+        assert result.exit_code == 1
+        assert (
+            "The specified destination path is outside of the deploy root"
+            in result.output
+        )
+
+        assert not os.path.exists("app/snowflake.yml")


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * [X] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [N/A] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

Introduced BundleMap as an abstraction that encapsulates src -> dest mapping in native app projects. This will enable other parts of the logic (e.g. artifact processors) to query the mapping in a much cleaner way. There are some changes in behaviour introduced as part of this change, most notably enforcing that all src & dest mappings are relative paths.

### Testing

* New logic is fully unit tested, including as many corner cases in the contract as I could think of
* Verified the previous logic manually before capturing the corner cases
* Verified the implementation by running `snow app bundle` manually