### PR TITLE
Fix creation of the 3rd+ patch on an app pkg version

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,9 +12,8 @@
    * `snow snowpark` for procedures and functions
 
 ## Fixes and improvements
-
-## Fixes and improvements
 * Improved support for quoted identifiers.
+* Fixed creating patches with `snow app version create` when there are 2 or more existing patches on a version
 
 # v2.3.0
 

--- a/src/snowflake/cli/plugins/nativeapp/constants.py
+++ b/src/snowflake/cli/plugins/nativeapp/constants.py
@@ -7,6 +7,7 @@ NAME_COL = "name"
 COMMENT_COL = "comment"
 OWNER_COL = "owner"
 VERSION_COL = "version"
+PATCH_COL = "patch"
 
 INTERNAL_DISTRIBUTION = "internal"
 EXTERNAL_DISTRIBUTION = "external"

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -9,10 +9,16 @@ from click import UsageError
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.exceptions import SnowflakeSQLExecutionError
 from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
+from snowflake.cli.api.project.util import (
+    identifier_to_show_like_pattern,
+    unquote_identifier,
+)
+from snowflake.cli.api.utils.cursor import find_all_rows
 from snowflake.cli.plugins.nativeapp.constants import (
     ALLOWED_SPECIAL_COMMENTS,
     COMMENT_COL,
     LOOSE_FILES_MAGIC_VERSION,
+    PATCH_COL,
     SPECIAL_COMMENT,
     VERSION_COL,
 )
@@ -30,7 +36,7 @@ from snowflake.cli.plugins.nativeapp.policy import PolicyBase
 from snowflake.cli.plugins.stage.diff import DiffResult
 from snowflake.cli.plugins.stage.manager import StageManager
 from snowflake.connector import ProgrammingError
-from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.cursor import DictCursor, SnowflakeCursor
 
 UPGRADE_RESTRICTION_CODES = {93044, 93055, 93045, 93046}
 
@@ -136,24 +142,34 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
 
     def get_existing_version_info(self, version: str) -> Optional[dict]:
         """
-        Get an existing version, if defined, by the same name in an application package.
-        It executes a 'show versions like ... in application package' query and returns the result as single row, if one exists.
+        Get the latest patch on an existing version by name in the application package.
+        Executes 'show versions like ... in application package' query and returns
+        the latest patch in the version as a single row, if one exists. Otherwise,
+        returns None.
         """
         with self.use_role(self.package_role):
             try:
-                version_obj = self.show_specific_object(
-                    "versions",
-                    version,
-                    name_col=VERSION_COL,
-                    in_clause=f"in application package {self.package_name}",
+                query = f"show versions like {identifier_to_show_like_pattern(version)} in application package {self.package_name}"
+                cursor = self._execute_query(query, cursor_class=DictCursor)
+
+                if cursor.rowcount is None:
+                    raise SnowflakeSQLExecutionError(query)
+
+                matching_rows = find_all_rows(
+                    cursor, lambda row: row[VERSION_COL] == unquote_identifier(version)
                 )
+
+                if not matching_rows:
+                    return None
+
+                return max(matching_rows, key=lambda row: row[PATCH_COL])
+
             except ProgrammingError as err:
                 if err.msg.__contains__("does not exist or not authorized"):
                     raise ApplicationPackageDoesNotExistError(self.package_name)
                 else:
                     generic_sql_error_handler(err=err, role=self.package_role)
-
-            return version_obj
+                    return None
 
     def drop_application_before_upgrade(self, policy: PolicyBase, is_interactive: bool):
         """

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -1242,6 +1242,7 @@ def test_get_existing_version_info(mock_execute, temp_dir, mock_cursor):
                             "comment": "some comment",
                             "owner": "PACKAGE_ROLE",
                             "version": version,
+                            "patch": 0,
                         }
                     ],
                     [],


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
`NativeAppRunProcessor.get_existing_version_info` rewritten to return the most-recent patch row when trying to get information about a specific version.

A new integration test was added to ensure that 3 patches can be added to a version through the CLI.