### PR TITLE
Fix env merging of snowflake.yml and snowflake.local.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 gen_docs/
 /venv/
 .env
+.vscode
 
 ^app.zip
 ^snowflake.yml

--- a/src/snowflake/cli/api/utils/models.py
+++ b/src/snowflake/cli/api/utils/models.py
@@ -8,8 +8,8 @@ class EnvironWithDefinedDictFallback(Dict):
     def __getattr__(self, item):
         try:
             return self[item]
-        except KeyError:
-            raise AttributeError
+        except KeyError as e:
+            raise AttributeError(e)
 
     def __getitem__(self, item):
         if item in os.environ:

--- a/src/snowflake/cli/api/utils/models.py
+++ b/src/snowflake/cli/api/utils/models.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import os
+from typing import Any, Dict
 
 
-class EnvironWithDefinedDictFallback(dict):
+class EnvironWithDefinedDictFallback(Dict):
     def __getattr__(self, item):
-        return self[item]
+        try:
+            return self[item]
+        except KeyError:
+            raise AttributeError
 
     def __getitem__(self, item):
         if item in os.environ:
@@ -12,3 +18,6 @@ class EnvironWithDefinedDictFallback(dict):
 
     def __contains__(self, item):
         return item in os.environ or super().__contains__(item)
+
+    def update_from_dict(self, update_values: Dict[str, Any]):
+        return super().update(update_values)

--- a/tests/test_data/projects/sql_templating/snowflake.local.yml
+++ b/tests/test_data/projects/sql_templating/snowflake.local.yml
@@ -1,0 +1,2 @@
+env:
+  sf_var_override: "foo_value_override"

--- a/tests/test_data/projects/sql_templating/snowflake.yml
+++ b/tests/test_data/projects/sql_templating/snowflake.yml
@@ -1,3 +1,4 @@
 definition_version: "1.1"
 env:
   sf_var: "foo_value"
+  sf_var_override: "foo_value_original"

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -337,6 +337,17 @@ def test_uses_variables_from_snowflake_yml(
 
 
 @mock.patch("snowflake.cli.plugins.sql.commands.SqlManager._execute_string")
+def test_uses_variables_from_snowflake_local_yml(
+    mock_execute_query, project_directory, runner
+):
+    with project_directory("sql_templating"):
+        result = runner.invoke(["sql", "-q", "select &{ ctx.env.sf_var_override }"])
+
+    assert result.exit_code == 0
+    mock_execute_query.assert_called_once_with("select foo_value_override")
+
+
+@mock.patch("snowflake.cli.plugins.sql.commands.SqlManager._execute_string")
 def test_uses_variables_from_cli_are_added_outside_context(
     mock_execute_query, project_directory, runner
 ):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix env merging of snowflake.yml and snowflake.local.yml
Before the change, if I have env section in both snowflake.yml and snowflake.local.yml, env of snowflake.local.yml will clobber all of the env section in snowflake.yml.
Expected behavior is to clobber only the env variables defined in snowflake.local.yml.

This PR fixes this.
