### PR TITLE
Fix default interactive flag

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,7 +33,7 @@
 * Improved support for quoted identifiers.
 * Fixed creating patches with `snow app version create` when there are 2 or more existing patches on a version
 * Using `--format=json` adds trailing new line to avoid `%` being added by some terminals to signal no new line at the end of output.
-* Fixed `--interactive` flag to be enabled by default in interactive environments.
+* Fixed `--interactive` flag to be enabled by default in interactive environments and added the `--no-interactive` flag to be able to turn off prompting.
 
 # v2.3.1
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,7 @@
 * Improved support for quoted identifiers.
 * Fixed creating patches with `snow app version create` when there are 2 or more existing patches on a version
 * Using `--format=json` adds trailing new line to avoid `%` being added by some terminals to signal no new line at the end of output.
+* Fixed `--interactive` flag to be enabled by default in interactive environments.
 
 # v2.3.1
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -33,7 +33,6 @@ from snowflake.cli.plugins.nativeapp.teardown_processor import (
 )
 from snowflake.cli.plugins.nativeapp.utils import (
     get_first_paragraph_from_markdown_file,
-    is_tty_interactive,
     shallow_git_clone,
 )
 from snowflake.cli.plugins.nativeapp.version.commands import app as versions_app
@@ -154,7 +153,7 @@ def app_run(
         The command fails if no release directive exists for your Snowflake account for a given application package, which is determined from the project definition file. Default: unset.""",
         is_flag=True,
     ),
-    interactive: Optional[bool] = InteractiveOption,
+    interactive: bool = InteractiveOption,
     force: Optional[bool] = ForceOption,
     **options,
 ) -> CommandResult:
@@ -166,7 +165,7 @@ def app_run(
     is_interactive = False
     if force:
         policy = AllowAlwaysPolicy()
-    elif interactive or is_tty_interactive():
+    elif interactive:
         is_interactive = True
         policy = AskAlwaysPolicy()
     else:
@@ -221,7 +220,7 @@ def app_teardown(
         help=f"""Whether to drop all application objects owned by the application within the account. Default: false.""",
         show_default=False,
     ),
-    interactive: Optional[bool] = InteractiveOption,
+    interactive: bool = InteractiveOption,
     **options,
 ) -> CommandResult:
     """
@@ -231,8 +230,6 @@ def app_teardown(
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
-    if interactive is None:
-        interactive = is_tty_interactive()
     processor.process(interactive, force, cascade)
     return MessageResult(f"Teardown is now complete.")
 

--- a/src/snowflake/cli/plugins/nativeapp/common_flags.py
+++ b/src/snowflake/cli/plugins/nativeapp/common_flags.py
@@ -1,12 +1,18 @@
 import typer
 from snowflake.cli.plugins.nativeapp.utils import is_tty_interactive
 
+
+def interactive_callback(val):
+    if val is None:
+        return is_tty_interactive()
+    return val
+
+
 InteractiveOption = typer.Option(
-    is_tty_interactive(),
-    "--interactive",
-    "-i",
+    None,
     help=f"""When enabled, this option displays prompts even if the standard input and output are not terminal devices. Defaults to True in an interactive shell environment, and False otherwise.""",
-    is_flag=True,
+    callback=interactive_callback,
+    show_default=False,
 )
 
 ForceOption = typer.Option(

--- a/src/snowflake/cli/plugins/nativeapp/common_flags.py
+++ b/src/snowflake/cli/plugins/nativeapp/common_flags.py
@@ -1,10 +1,11 @@
 import typer
+from snowflake.cli.plugins.nativeapp.utils import is_tty_interactive
 
 InteractiveOption = typer.Option(
-    False,
+    is_tty_interactive(),
     "--interactive",
     "-i",
-    help=f"""When enabled, this option displays prompts even if the standard input and output are not terminal devices. Defaults to unset.""",
+    help=f"""When enabled, this option displays prompts even if the standard input and output are not terminal devices. Defaults to True in an interactive shell environment, and False otherwise.""",
     is_flag=True,
 )
 

--- a/src/snowflake/cli/plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/commands.py
@@ -18,7 +18,6 @@ from snowflake.cli.plugins.nativeapp.policy import (
     DenyAlwaysPolicy,
 )
 from snowflake.cli.plugins.nativeapp.run_processor import NativeAppRunProcessor
-from snowflake.cli.plugins.nativeapp.utils import is_tty_interactive
 from snowflake.cli.plugins.nativeapp.version.version_processor import (
     NativeAppVersionCreateProcessor,
     NativeAppVersionDropProcessor,
@@ -51,7 +50,7 @@ def create(
         help="When enabled, the Snowflake CLI skips checking if your project has any untracked or stages files in git. Default: unset.",
         is_flag=True,
     ),
-    interactive: Optional[bool] = InteractiveOption,
+    interactive: bool = InteractiveOption,
     force: Optional[bool] = ForceOption,
     **options,
 ) -> CommandResult:
@@ -64,7 +63,7 @@ def create(
     is_interactive = False
     if force:
         policy = AllowAlwaysPolicy()
-    elif interactive or is_tty_interactive():
+    elif interactive:
         is_interactive = True
         policy = AskAlwaysPolicy()
     else:
@@ -115,7 +114,7 @@ def drop(
         None,
         help="Version defined in an application package that you want to drop. Defaults to the version specified in the `manifest.yml` file.",
     ),
-    interactive: Optional[bool] = InteractiveOption,
+    interactive: bool = InteractiveOption,
     force: Optional[bool] = ForceOption,
     **options,
 ) -> CommandResult:
@@ -126,7 +125,7 @@ def drop(
     is_interactive = False
     if force:
         policy = AllowAlwaysPolicy()
-    elif interactive or is_tty_interactive():
+    elif interactive:
         is_interactive = True
         policy = AskAlwaysPolicy()
     else:

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -310,50 +310,76 @@
    application package.                                                           
                                                                                   
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
-  │ --version                         TEXT  The version defined in an existing   │
-  │                                         application package from which you   │
-  │                                         want to create an application        │
-  │                                         object. The application object and   │
-  │                                         application package names are        │
-  │                                         determined from the project          │
-  │                                         definition file.                     │
-  │                                         [default: None]                      │
-  │ --patch                           TEXT  The patch number under the given     │
-  │                                         `--version` defined in an existing   │
-  │                                         application package that should be   │
-  │                                         used to create an application        │
-  │                                         object. The application object and   │
-  │                                         application package names are        │
-  │                                         determined from the project          │
-  │                                         definition file.                     │
-  │                                         [default: None]                      │
-  │ --from-release-directive                Creates or upgrades an application   │
-  │                                         object to the version and patch      │
-  │                                         specified by the release directive   │
-  │                                         applicable to your Snowflake         │
-  │                                         account. The command fails if no     │
-  │                                         release directive exists for your    │
-  │                                         Snowflake account for a given        │
-  │                                         application package, which is        │
-  │                                         determined from the project          │
-  │                                         definition file. Default: unset.     │
-  │ --interactive             -i            When enabled, this option displays   │
-  │                                         prompts even if the standard input   │
-  │                                         and output are not terminal devices. │
-  │                                         Defaults to True in an interactive   │
-  │                                         shell environment, and False         │
-  │                                         otherwise.                           │
-  │ --force                                 When enabled, this option causes the │
-  │                                         command to implicitly approve any    │
-  │                                         prompts that arise. You should       │
-  │                                         enable this option if interactive    │
-  │                                         mode is not specified and if you     │
-  │                                         want perform potentially destructive │
-  │                                         actions. Defaults to unset.          │
-  │ --project                 -p      TEXT  Path where the Snowflake Native App  │
-  │                                         project resides. Defaults to current │
-  │                                         working directory.                   │
-  │ --help                    -h            Show this message and exit.          │
+  │ --version                                       TEXT  The version defined in │
+  │                                                       an existing            │
+  │                                                       application package    │
+  │                                                       from which you want to │
+  │                                                       create an application  │
+  │                                                       object. The            │
+  │                                                       application object and │
+  │                                                       application package    │
+  │                                                       names are determined   │
+  │                                                       from the project       │
+  │                                                       definition file.       │
+  │                                                       [default: None]        │
+  │ --patch                                         TEXT  The patch number under │
+  │                                                       the given `--version`  │
+  │                                                       defined in an existing │
+  │                                                       application package    │
+  │                                                       that should be used to │
+  │                                                       create an application  │
+  │                                                       object. The            │
+  │                                                       application object and │
+  │                                                       application package    │
+  │                                                       names are determined   │
+  │                                                       from the project       │
+  │                                                       definition file.       │
+  │                                                       [default: None]        │
+  │ --from-release-direct…                                Creates or upgrades an │
+  │                                                       application object to  │
+  │                                                       the version and patch  │
+  │                                                       specified by the       │
+  │                                                       release directive      │
+  │                                                       applicable to your     │
+  │                                                       Snowflake account. The │
+  │                                                       command fails if no    │
+  │                                                       release directive      │
+  │                                                       exists for your        │
+  │                                                       Snowflake account for  │
+  │                                                       a given application    │
+  │                                                       package, which is      │
+  │                                                       determined from the    │
+  │                                                       project definition     │
+  │                                                       file. Default: unset.  │
+  │ --interactive               --no-interactive          When enabled, this     │
+  │                                                       option displays        │
+  │                                                       prompts even if the    │
+  │                                                       standard input and     │
+  │                                                       output are not         │
+  │                                                       terminal devices.      │
+  │                                                       Defaults to True in an │
+  │                                                       interactive shell      │
+  │                                                       environment, and False │
+  │                                                       otherwise.             │
+  │ --force                                               When enabled, this     │
+  │                                                       option causes the      │
+  │                                                       command to implicitly  │
+  │                                                       approve any prompts    │
+  │                                                       that arise. You should │
+  │                                                       enable this option if  │
+  │                                                       interactive mode is    │
+  │                                                       not specified and if   │
+  │                                                       you want perform       │
+  │                                                       potentially            │
+  │                                                       destructive actions.   │
+  │                                                       Defaults to unset.     │
+  │ --project               -p                      TEXT  Path where the         │
+  │                                                       Snowflake Native App   │
+  │                                                       project resides.       │
+  │                                                       Defaults to current    │
+  │                                                       working directory.     │
+  │ --help                  -h                            Show this message and  │
+  │                                                       exit.                  │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
@@ -419,27 +445,30 @@
    defined in the project definition file.                                        
                                                                                   
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
-  │ --force                                  When enabled, this option causes    │
-  │                                          the command to implicitly approve   │
-  │                                          any prompts that arise. You should  │
-  │                                          enable this option if interactive   │
-  │                                          mode is not specified and if you    │
-  │                                          want perform potentially            │
-  │                                          destructive actions. Defaults to    │
-  │                                          unset.                              │
-  │ --cascade          --no-cascade          Whether to drop all application     │
-  │                                          objects owned by the application    │
-  │                                          within the account. Default: false. │
-  │ --interactive  -i                        When enabled, this option displays  │
-  │                                          prompts even if the standard input  │
-  │                                          and output are not terminal         │
-  │                                          devices. Defaults to True in an     │
-  │                                          interactive shell environment, and  │
-  │                                          False otherwise.                    │
-  │ --project      -p                  TEXT  Path where the Snowflake Native App │
-  │                                          project resides. Defaults to        │
-  │                                          current working directory.          │
-  │ --help         -h                        Show this message and exit.         │
+  │ --force                                      When enabled, this option       │
+  │                                              causes the command to           │
+  │                                              implicitly approve any prompts  │
+  │                                              that arise. You should enable   │
+  │                                              this option if interactive mode │
+  │                                              is not specified and if you     │
+  │                                              want perform potentially        │
+  │                                              destructive actions. Defaults   │
+  │                                              to unset.                       │
+  │ --cascade          --no-cascade              Whether to drop all application │
+  │                                              objects owned by the            │
+  │                                              application within the account. │
+  │                                              Default: false.                 │
+  │ --interactive      --no-interactive          When enabled, this option       │
+  │                                              displays prompts even if the    │
+  │                                              standard input and output are   │
+  │                                              not terminal devices. Defaults  │
+  │                                              to True in an interactive shell │
+  │                                              environment, and False          │
+  │                                              otherwise.                      │
+  │ --project      -p                      TEXT  Path where the Snowflake Native │
+  │                                              App project resides. Defaults   │
+  │                                              to current working directory.   │
+  │ --help         -h                            Show this message and exit.     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
@@ -512,31 +541,45 @@
   │                           [default: None]                                    │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
-  │ --patch                   TEXT  The patch number you want to create for an   │
-  │                                 existing version. Defaults to undefined if   │
-  │                                 it is not set, which means the Snowflake CLI │
-  │                                 either uses the patch specified in the       │
-  │                                 `manifest.yml` file or automatically         │
-  │                                 generates a new patch number.                │
-  │                                 [default: None]                              │
-  │ --skip-git-check                When enabled, the Snowflake CLI skips        │
-  │                                 checking if your project has any untracked   │
-  │                                 or stages files in git. Default: unset.      │
-  │ --interactive     -i            When enabled, this option displays prompts   │
-  │                                 even if the standard input and output are    │
-  │                                 not terminal devices. Defaults to True in an │
-  │                                 interactive shell environment, and False     │
-  │                                 otherwise.                                   │
-  │ --force                         When enabled, this option causes the command │
-  │                                 to implicitly approve any prompts that       │
-  │                                 arise. You should enable this option if      │
-  │                                 interactive mode is not specified and if you │
-  │                                 want perform potentially destructive         │
-  │                                 actions. Defaults to unset.                  │
-  │ --project         -p      TEXT  Path where the Snowflake Native App project  │
-  │                                 resides. Defaults to current working         │
-  │                                 directory.                                   │
-  │ --help            -h            Show this message and exit.                  │
+  │ --patch                                   TEXT  The patch number you want to │
+  │                                                 create for an existing       │
+  │                                                 version. Defaults to         │
+  │                                                 undefined if it is not set,  │
+  │                                                 which means the Snowflake    │
+  │                                                 CLI either uses the patch    │
+  │                                                 specified in the             │
+  │                                                 `manifest.yml` file or       │
+  │                                                 automatically generates a    │
+  │                                                 new patch number.            │
+  │                                                 [default: None]              │
+  │ --skip-git-check                                When enabled, the Snowflake  │
+  │                                                 CLI skips checking if your   │
+  │                                                 project has any untracked or │
+  │                                                 stages files in git.         │
+  │                                                 Default: unset.              │
+  │ --interactive         --no-interactive          When enabled, this option    │
+  │                                                 displays prompts even if the │
+  │                                                 standard input and output    │
+  │                                                 are not terminal devices.    │
+  │                                                 Defaults to True in an       │
+  │                                                 interactive shell            │
+  │                                                 environment, and False       │
+  │                                                 otherwise.                   │
+  │ --force                                         When enabled, this option    │
+  │                                                 causes the command to        │
+  │                                                 implicitly approve any       │
+  │                                                 prompts that arise. You      │
+  │                                                 should enable this option if │
+  │                                                 interactive mode is not      │
+  │                                                 specified and if you want    │
+  │                                                 perform potentially          │
+  │                                                 destructive actions.         │
+  │                                                 Defaults to unset.           │
+  │ --project         -p                      TEXT  Path where the Snowflake     │
+  │                                                 Native App project resides.  │
+  │                                                 Defaults to current working  │
+  │                                                 directory.                   │
+  │ --help            -h                            Show this message and exit.  │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
@@ -609,20 +652,26 @@
   │                           [default: None]                                    │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
-  │ --interactive  -i            When enabled, this option displays prompts even │
-  │                              if the standard input and output are not        │
-  │                              terminal devices. Defaults to True in an        │
-  │                              interactive shell environment, and False        │
-  │                              otherwise.                                      │
-  │ --force                      When enabled, this option causes the command to │
-  │                              implicitly approve any prompts that arise. You  │
-  │                              should enable this option if interactive mode   │
-  │                              is not specified and if you want perform        │
-  │                              potentially destructive actions. Defaults to    │
-  │                              unset.                                          │
-  │ --project      -p      TEXT  Path where the Snowflake Native App project     │
-  │                              resides. Defaults to current working directory. │
-  │ --help         -h            Show this message and exit.                     │
+  │ --interactive      --no-interactive          When enabled, this option       │
+  │                                              displays prompts even if the    │
+  │                                              standard input and output are   │
+  │                                              not terminal devices. Defaults  │
+  │                                              to True in an interactive shell │
+  │                                              environment, and False          │
+  │                                              otherwise.                      │
+  │ --force                                      When enabled, this option       │
+  │                                              causes the command to           │
+  │                                              implicitly approve any prompts  │
+  │                                              that arise. You should enable   │
+  │                                              this option if interactive mode │
+  │                                              is not specified and if you     │
+  │                                              want perform potentially        │
+  │                                              destructive actions. Defaults   │
+  │                                              to unset.                       │
+  │ --project      -p                      TEXT  Path where the Snowflake Native │
+  │                                              App project resides. Defaults   │
+  │                                              to current working directory.   │
+  │ --help         -h                            Show this message and exit.     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -340,7 +340,9 @@
   │ --interactive             -i            When enabled, this option displays   │
   │                                         prompts even if the standard input   │
   │                                         and output are not terminal devices. │
-  │                                         Defaults to unset.                   │
+  │                                         Defaults to True in an interactive   │
+  │                                         shell environment, and False         │
+  │                                         otherwise.                           │
   │ --force                                 When enabled, this option causes the │
   │                                         command to implicitly approve any    │
   │                                         prompts that arise. You should       │
@@ -431,7 +433,9 @@
   │ --interactive  -i                        When enabled, this option displays  │
   │                                          prompts even if the standard input  │
   │                                          and output are not terminal         │
-  │                                          devices. Defaults to unset.         │
+  │                                          devices. Defaults to True in an     │
+  │                                          interactive shell environment, and  │
+  │                                          False otherwise.                    │
   │ --project      -p                  TEXT  Path where the Snowflake Native App │
   │                                          project resides. Defaults to        │
   │                                          current working directory.          │
@@ -520,7 +524,9 @@
   │                                 or stages files in git. Default: unset.      │
   │ --interactive     -i            When enabled, this option displays prompts   │
   │                                 even if the standard input and output are    │
-  │                                 not terminal devices. Defaults to unset.     │
+  │                                 not terminal devices. Defaults to True in an │
+  │                                 interactive shell environment, and False     │
+  │                                 otherwise.                                   │
   │ --force                         When enabled, this option causes the command │
   │                                 to implicitly approve any prompts that       │
   │                                 arise. You should enable this option if      │
@@ -605,7 +611,9 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --interactive  -i            When enabled, this option displays prompts even │
   │                              if the standard input and output are not        │
-  │                              terminal devices. Defaults to unset.            │
+  │                              terminal devices. Defaults to True in an        │
+  │                              interactive shell environment, and False        │
+  │                              otherwise.                                      │
   │ --force                      When enabled, this option causes the command to │
   │                              implicitly approve any prompts that arise. You  │
   │                              should enable this option if interactive mode   │


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * I've added or updated automated unit tests to verify correctness of my new code.
   * I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

Fixing `InteractiveOption` to default to `is_tty_interactive()` instead of `False`.

Also added the `--no-interactive` flag to be able to turn prompting off in an interactive shell.

### Manual test

Running `snow app teardown` in different combinations in a TTY shell:

|Command|Behavior|
|---|---|
|`snow app teardown`|Prompt|
|`snow app teardown --interactive`|Prompt|
|`snow app teardown --no-interactive`|No prompt|

Before the change:

|Command|Behavior|
|---|---|
|`snow app teardown`|No prompt|
|`snow app teardown --interactive`|Prompt|
