### PR TITLE
[NADE][Bugfix] Add None check for raw_imports

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
@@ -89,11 +89,12 @@ def __snowflake_internal_create_extension_fn_registration_callback():
 
     def __snowflake_internal_imports_union_to_str_type(raw_imports):
         final_imports = []
-        for raw_import in raw_imports:
-            if isinstance(raw_import, str):
-                final_imports.append(raw_import)
-            else:
-                final_imports.append(raw_import[0])
+        if raw_imports:
+            for raw_import in raw_imports:
+                if isinstance(raw_import, str):
+                    final_imports.append(raw_import)
+                else:
+                    final_imports.append(raw_import[0])
         return final_imports
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
There is a bug with the current implementation where the extension function information fetched from the Snowpark py file may not have any raw_imports, and this field is None by default. In this case, we need to add an additional check to only iterate when raw_imports is not None. 