### PR TITLE
Handle missing snowflake-snowpark-python package dependency

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
@@ -50,6 +50,8 @@ def __snowflake_internal_create_extension_fn_registration_callback():
         return extension_fn.object_name
 
     def __snowflake_internal_create_package_list(extension_fn):
+        if not extension_fn.all_packages.strip():
+            return []
         return [pkg_spec.strip() for pkg_spec in extension_fn.all_packages.split(",")]
 
     def __snowflake_internal_make_extension_fn_signature(extension_fn):

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -44,7 +44,7 @@ from snowflake.cli.plugins.stage.diff import to_stage_path
 DEFAULT_TIMEOUT = 30
 TEMPLATE_PATH = Path(__file__).parent / "callback_source.py.jinja"
 SNOWPARK_LIB_NAME = "snowflake-snowpark-python"
-SNOWPARK_LIB_REGEX = rf"'{SNOWPARK_LIB_NAME}((<|<=|!=|==|>=|>|~=|===)[a-zA-Z0-9_.*+!-]+)?'"  # support PEP 508, even though not all of it is supported in Snowflake yet
+SNOWPARK_LIB_REGEX = rf"'{SNOWPARK_LIB_NAME}\s*((<|<=|!=|==|>=|>|~=|===)\s*[a-zA-Z0-9_.*+!-]+)?'"  # support PEP 508, even though not all of it is supported in Snowflake yet
 STAGE_PREFIX = "@"
 
 
@@ -278,7 +278,7 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         snowpark_lib_found = False
         snowpark_lib_regex = re.compile(SNOWPARK_LIB_REGEX)
         for pkg in extension_fn.packages:
-            if snowpark_lib_regex.fullmatch(ensure_string_literal(pkg)):
+            if snowpark_lib_regex.fullmatch(ensure_string_literal(pkg.strip())):
                 snowpark_lib_found = True
                 break
         if not snowpark_lib_found:
@@ -407,7 +407,7 @@ def generate_create_sql_ddl_statement(
         )
 
     if extension_fn.packages:
-        create_query += f"\nPACKAGES=({', '.join(ensure_all_string_literals(extension_fn.packages))})"
+        create_query += f"\nPACKAGES=({', '.join(ensure_all_string_literals([pkg.strip() for pkg in extension_fn.packages]))})"
 
     if extension_fn.external_access_integrations:
         create_query += f"\nEXTERNAL_ACCESS_INTEGRATIONS=({', '.join(ensure_all_string_literals(extension_fn.external_access_integrations))})"

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -276,7 +276,7 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         for pkg in extension_fn.packages:
             if pkg == SNOWPARK_LIB_NAME or pkg.startswith(SNOWPARK_LIB_NAME + "=="):
                 snowpark_lib_found = True
-        if snowpark_lib_found:
+        if not snowpark_lib_found:
             extension_fn.packages.append(SNOWPARK_LIB_NAME)
 
         if extension_fn.imports is None:

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -42,6 +42,7 @@ from snowflake.cli.plugins.stage.diff import to_stage_path
 
 DEFAULT_TIMEOUT = 30
 TEMPLATE_PATH = Path(__file__).parent / "callback_source.py.jinja"
+SNOWPARK_LIB_NAME = "snowflake-snowpark-python"
 STAGE_PREFIX = "@"
 
 
@@ -270,6 +271,13 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         # Compute the fully qualified handler
         # If user defined their udf as @udf(lambda: x, ...) then extension_fn.handler is <lambda>.
         extension_fn.handler = f"{py_file.stem}.{extension_fn.handler}"
+
+        snowpark_lib_found = False
+        for pkg in extension_fn.packages:
+            if pkg == SNOWPARK_LIB_NAME or pkg.startswith(SNOWPARK_LIB_NAME + "=="):
+                snowpark_lib_found = True
+        if snowpark_lib_found:
+            extension_fn.packages.append(SNOWPARK_LIB_NAME)
 
         if extension_fn.imports is None:
             extension_fn.imports = []

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -44,7 +44,7 @@ from snowflake.cli.plugins.stage.diff import to_stage_path
 DEFAULT_TIMEOUT = 30
 TEMPLATE_PATH = Path(__file__).parent / "callback_source.py.jinja"
 SNOWPARK_LIB_NAME = "snowflake-snowpark-python"
-SNOWPARK_LIB_REGEX = rf"'{SNOWPARK_LIB_NAME}((<|<=|!=|==|>=|>|~=|===)[a-zA-Z0-9_.*+!-]+)?'"  # support PEP 508, even though not all of it is support in Snowflake yet
+SNOWPARK_LIB_REGEX = rf"'{SNOWPARK_LIB_NAME}((<|<=|!=|==|>=|>|~=|===)[a-zA-Z0-9_.*+!-]+)?'"  # support PEP 508, even though not all of it is supported in Snowflake yet
 STAGE_PREFIX = "@"
 
 

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -174,6 +174,27 @@
   TO APPLICATION ROLE APP_VIEWER;
   '''
 # ---
+# name: test_package_normalization[package_decl14]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python  ==  0.15.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
 # name: test_package_normalization[package_decl1]
   '''
   -- stagepath/main.py

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -49,38 +49,6 @@
   
   '''
 # ---
-# name: test_generate_create_sql_ddl_statements_w_existing_snowpark_dependency
-  '''
-  CREATE OR REPLACE
-  PROCEDURE DATA.my_function(first int DEFAULT 42)
-  RETURNS int
-  LANGUAGE PYTHON
-  RUNTIME_VERSION=3.11
-  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip')
-  PACKAGES=('snowflake-snowpark-python')
-  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
-  SECRETS=('key1'=secret_one, 'key2'=integration_two)
-  HANDLER='my_function_handler'
-  EXECUTE AS OWNER;
-  
-  '''
-# ---
-# name: test_generate_create_sql_ddl_statements_w_existing_snowpark_dependency.1
-  '''
-  CREATE OR REPLACE
-  PROCEDURE DATA.my_function(first int DEFAULT 42)
-  RETURNS int
-  LANGUAGE PYTHON
-  RUNTIME_VERSION=3.11
-  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip')
-  PACKAGES=('snowflake-snowpark-python==0.15.0')
-  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
-  SECRETS=('key1'=secret_one, 'key2'=integration_two)
-  HANDLER='my_function_handler'
-  EXECUTE AS OWNER;
-  
-  '''
-# ---
 # name: test_generate_create_sql_ddl_statements_w_select_entries
   '''
   CREATE OR REPLACE
@@ -95,6 +63,300 @@
 # ---
 # name: test_generate_grant_sql_ddl_statements
   '''
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl0]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl10]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python===0.15.0-rc1')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl11]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python===0.15.0-rc1')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl12]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python<<0.15.0', 'snowflake-snowpark-python')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl13]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python2', 'snowflake-snowpark-python')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl1]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl2]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('other-package', 'snowflake-snowpark-python')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl3]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python==0.15.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl4]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python==0.15.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl5]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python<0.16.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl6]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python<=0.17.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl7]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python>=0.14.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl8]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python>0.13.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_ADMIN;
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
+  TO APPLICATION ROLE APP_VIEWER;
+  '''
+# ---
+# name: test_package_normalization[package_decl9]
+  '''
+  -- stagepath/main.py
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
+  PACKAGES=('snowflake-snowpark-python===0.15.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='main.my_function_handler'
+  EXECUTE AS OWNER;
+  
   GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_ADMIN;
   GRANT USAGE ON PROCEDURE DATA.my_function(int)

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -49,6 +49,38 @@
   
   '''
 # ---
+# name: test_generate_create_sql_ddl_statements_w_existing_snowpark_dependency
+  '''
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip')
+  PACKAGES=('snowflake-snowpark-python')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='my_function_handler'
+  EXECUTE AS OWNER;
+  
+  '''
+# ---
+# name: test_generate_create_sql_ddl_statements_w_existing_snowpark_dependency.1
+  '''
+  CREATE OR REPLACE
+  PROCEDURE DATA.my_function(first int DEFAULT 42)
+  RETURNS int
+  LANGUAGE PYTHON
+  RUNTIME_VERSION=3.11
+  IMPORTS=('/path/to/import1.py', '/path/to/import2.zip')
+  PACKAGES=('snowflake-snowpark-python==0.15.0')
+  EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
+  SECRETS=('key1'=secret_one, 'key2'=integration_two)
+  HANDLER='my_function_handler'
+  EXECUTE AS OWNER;
+  
+  '''
+# ---
 # name: test_generate_create_sql_ddl_statements_w_select_entries
   '''
   CREATE OR REPLACE
@@ -81,7 +113,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('package_one==1.0.2', 'package_two')
+  PACKAGES=('package_one==1.0.2', 'package_two', 'snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -98,7 +130,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/', '/stagepath/data.py', '/stagepath/extra_import1.zip', '/stagepath/some_dir_str', '/stagepath/withslash.py', '@dummy_stage_str')
-  PACKAGES=('package_one==1.0.2', 'package_two')
+  PACKAGES=('package_one==1.0.2', 'package_two', 'snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='data.my_function_handler'
@@ -133,7 +165,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('package_one==1.0.2', 'package_two')
+  PACKAGES=('package_one==1.0.2', 'package_two', 'snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -154,7 +186,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/', '/stagepath/data.py', '/stagepath/extra_import1.zip', '/stagepath/some_dir_str', '/stagepath/withslash.py', '@dummy_stage_str')
-  PACKAGES=('package_one==1.0.2', 'package_two')
+  PACKAGES=('package_one==1.0.2', 'package_two', 'snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='data.my_function_handler'

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -163,6 +163,16 @@ def test_generate_create_sql_ddl_statements_w_select_entries(
     assert generate_create_sql_ddl_statement(native_app_extension_function) == snapshot
 
 
+def test_generate_create_sql_ddl_statements_w_existing_snowpark_dependency(
+    native_app_extension_function, snapshot
+):
+    native_app_extension_function.packages = ["snowflake-snowpark-python"]
+    assert generate_create_sql_ddl_statement(native_app_extension_function) == snapshot
+
+    native_app_extension_function.packages = ["snowflake-snowpark-python==0.15.0"]
+    assert generate_create_sql_ddl_statement(native_app_extension_function) == snapshot
+
+
 # --------------------------------------------------------
 # ------- generate_grant_sql_ddl_statements --------------
 # --------------------------------------------------------

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -437,6 +437,7 @@ def test_process_with_collected_functions(
         ["'snowflake-snowpark-python===0.15.0-rc1'"],
         ["snowflake-snowpark-python<<0.15.0"],  # not PEP 508 compliant
         ["snowflake-snowpark-python2"],  # not a match
+        ["   snowflake-snowpark-python  ==  0.15.0   "],  # whitespace is ignored
     ],
 )
 @mock.patch(


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

Sometimes the Snowpark library adds `snowflake-snowpark-python` as a package dependency, and sometimes it does not (e.g. for a UDF). A UDF does require this package, so modified the generation logic to include it regardless.

### Testing

- Added unit tests
- Manually verified that this fixes the issue encountered in the sample app