### PR TITLE
Clean up phase state on exception

### DIFF
--- a/src/snowflake/cli/api/console/console.py
+++ b/src/snowflake/cli/api/console/console.py
@@ -57,11 +57,12 @@ class CliConsole(AbstractConsole):
         self._print(self._format_message(enter_message, Output.PHASE))
         self._in_phase = True
 
-        yield self.step
-
-        self._in_phase = False
-        if exit_message:
-            self._print(self._format_message(exit_message, Output.PHASE))
+        try:
+            yield self.step
+        finally:
+            self._in_phase = False
+            if exit_message:
+                self._print(self._format_message(exit_message, Output.PHASE))
 
     def step(self, message: str):
         """Displays a message to output.

--- a/tests/api/console/test_cli_console_output.py
+++ b/tests/api/console/test_cli_console_output.py
@@ -64,3 +64,13 @@ def test_phase_nesting_not_allowed(cli_console):
         with pytest.raises(CliConsoleNestingProhibitedError):
             with cli_console.phase("Enter 2"):
                 pass
+
+
+def test_phase_is_cleaned_up_on_exception(cli_console):
+    with pytest.raises(RuntimeError):
+        with cli_console.phase("Enter 1"):
+            raise RuntimeError("Phase failed")
+
+    # If the phase is cleaned up correctly, this will no raise any exception
+    with cli_console.phase("Enter 2") as step:
+        pass


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
The current CliConsole isn't cleaned up on exceptions being thrown in the `yield`ed code. This causes the phase-tracking state to remain after the phase has ended.
