### PR TITLE
Removed ArtifactMapping data class in favour of PathMapping

### DIFF
--- a/src/snowflake/cli/api/project/schemas/native_app/native_app.py
+++ b/src/snowflake/cli/api/project/schemas/native_app/native_app.py
@@ -41,3 +41,20 @@ class NativeApp(UpdatableModel):
         if not re.match(SCHEMA_AND_NAME, input_value):
             raise ValueError("Incorrect value for source_stage value of native_app")
         return input_value
+
+    @field_validator("artifacts")
+    @classmethod
+    def transform_artifacts(
+        cls, orig_artifacts: List[Union[PathMapping, str]]
+    ) -> List[PathMapping]:
+        transformed_artifacts = []
+        if orig_artifacts is None:
+            return transformed_artifacts
+
+        for artifact in orig_artifacts:
+            if isinstance(artifact, PathMapping):
+                transformed_artifacts.append(artifact)
+            else:
+                transformed_artifacts.append(PathMapping(src=artifact))
+
+        return transformed_artifacts

--- a/src/snowflake/cli/api/project/schemas/native_app/path_mapping.py
+++ b/src/snowflake/cli/api/project/schemas/native_app/path_mapping.py
@@ -25,7 +25,7 @@ class PathMapping(UpdatableModel):
     @classmethod
     def transform_processors(
         cls, input_values: Optional[List[Union[str, Dict, ProcessorMapping]]]
-    ):
+    ) -> List[ProcessorMapping]:
         if input_values is None:
             return []
 

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -17,6 +17,7 @@ from snowflake.cli.api.project.definition import (
     default_role,
 )
 from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
+from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.util import (
     extract_schema,
     to_identifier,
@@ -25,11 +26,9 @@ from snowflake.cli.api.project.util import (
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.connection.util import make_snowsight_url
 from snowflake.cli.plugins.nativeapp.artifacts import (
-    ArtifactMapping,
     BundleMap,
     build_bundle,
     resolve_without_follow,
-    translate_artifact,
 )
 from snowflake.cli.plugins.nativeapp.codegen.compiler import (
     NativeAppCompiler,
@@ -158,8 +157,8 @@ class NativeAppManager(SqlExecutionMixin):
         return self._project_definition
 
     @cached_property
-    def artifacts(self) -> List[ArtifactMapping]:
-        return [translate_artifact(item) for item in self.definition.artifacts]
+    def artifacts(self) -> List[PathMapping]:
+        return self.definition.artifacts
 
     @cached_property
     def deploy_root(self) -> Path:

--- a/tests/project/__snapshots__/test_config.ambr
+++ b/tests/project/__snapshots__/test_config.ambr
@@ -72,8 +72,18 @@
     'native_app': dict({
       'application': None,
       'artifacts': list([
-        'setup.sql',
-        'README.md',
+        dict({
+          'dest': None,
+          'processors': list([
+          ]),
+          'src': 'setup.sql',
+        }),
+        dict({
+          'dest': None,
+          'processors': list([
+          ]),
+          'src': 'README.md',
+        }),
       ]),
       'deploy_root': 'output/deploy/',
       'generated_root': '__generated/',
@@ -97,8 +107,18 @@
         'warehouse': None,
       }),
       'artifacts': list([
-        'setup.sql',
-        'app/README.md',
+        dict({
+          'dest': None,
+          'processors': list([
+          ]),
+          'src': 'setup.sql',
+        }),
+        dict({
+          'dest': None,
+          'processors': list([
+          ]),
+          'src': 'app/README.md',
+        }),
         dict({
           'dest': 'ui/',
           'processors': list([
@@ -137,8 +157,18 @@
         'warehouse': None,
       }),
       'artifacts': list([
-        'setup.sql',
-        'app/README.md',
+        dict({
+          'dest': None,
+          'processors': list([
+          ]),
+          'src': 'setup.sql',
+        }),
+        dict({
+          'dest': None,
+          'processors': list([
+          ]),
+          'src': 'app/README.md',
+        }),
         dict({
           'dest': 'ui/',
           'processors': list([

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -11,6 +11,7 @@ from snowflake.cli.api.project.definition import (
     load_project_definition,
 )
 from snowflake.cli.api.project.errors import SchemaValidationError
+from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.schemas.project_definition import ProjectDefinition
 
 
@@ -29,7 +30,10 @@ def test_napp_project_1(project_definition_files):
 def test_na_minimal_project(project_definition_files: List[Path]):
     project = load_project_definition(project_definition_files)
     assert project.native_app.name == "minimal"
-    assert project.native_app.artifacts == ["setup.sql", "README.md"]
+    assert project.native_app.artifacts == [
+        PathMapping(src="setup.sql"),
+        PathMapping(src="README.md"),
+    ]
 
     from os import getenv as original_getenv
 


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

Following the move to Pydantic to parse project definition files, the `ArtifactMapping` class became redundant, since `PathMapping` serves the same purpose. Additionally, new fields added to the `PathMapping` class were not present on the `ArtifactMapping` class, creating a divergence. This change eliminates the redundancy, and simplifies the `BundleMap` contract as a result.