### PR TITLE
[Bug fix] Interactive teardown does not abort by default

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
@@ -130,12 +130,14 @@ class NativeAppTeardownProcessor(NativeAppManager, NativeAppCommandProcessor):
                 )
             elif interactive:
                 if interactive:
-                    api_integration = typer.prompt(
-                        f"The following objects are owned by application {self.app_name}:\n{application_objects_str}\n\nWould you like to drop these objects in addition to the application? [y/n/ABORT]"
+                    user_response = typer.prompt(
+                        f"The following objects are owned by application {self.app_name}:\n{application_objects_str}\n\nWould you like to drop these objects in addition to the application? [y/n/ABORT]",
+                        show_default=False,
+                        default="ABORT",
                     )
-                    if api_integration in ["y", "yes", "Y", "Yes", "YES"]:
+                    if user_response in ["y", "yes", "Y", "Yes", "YES"]:
                         cascade = True
-                    elif api_integration in ["n", "no", "N", "No", "NO"]:
+                    elif user_response in ["n", "no", "N", "No", "NO"]:
                         cascade = False
                     else:
                         raise typer.Abort()


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
The teardown processor incorrectly uses the `typer.Prompt` API: it does not specify a default value for the user response when asking if we should cascade. As a result, the default value of `None` is used, which causes Typer to loop until 'yes' or 'no' are entered. This change fixes this behaviour so that hitting the enter key on the teardown cascade prompt aborts as expected.

### Testing

Verified manually. The tests mock the Typer behaviour, so there is no easy way to test the change in our automated test framework. We'd have to model the user's input instead, which is a bigger change. I've updated the manual test plan to make sure we cover this behaviour, which will make prevent regressions in the short term until we can update the automated testing strategy.
