### PR TITLE
[SNOW-1456015] Add support for `snow app deploy --no-recursive`

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -249,7 +249,7 @@ def app_deploy(
     ),
     recursive: Optional[bool] = typer.Option(
         None,
-        "--recursive",
+        "--recursive/--no-recursive",
         "-r",
         help=f"""Whether to traverse and deploy files from subdirectories. If set, the command deploys all files and subdirectories; otherwise, only files in the current directory are deployed.""",
     ),

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -81,21 +81,24 @@
   │                          all local changes to the stage.                     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
-  │ --prune          --no-prune          Whether to delete specified files from  │
-  │                                      the stage if they don't exist locally.  │
-  │                                      If set, the command deletes files that  │
-  │                                      exist in the stage, but not in the      │
-  │                                      local filesystem.                       │
-  │                                      [default: no-prune]                     │
-  │ --recursive  -r                      Whether to traverse and deploy files    │
-  │                                      from subdirectories. If set, the        │
-  │                                      command deploys all files and           │
-  │                                      subdirectories; otherwise, only files   │
-  │                                      in the current directory are deployed.  │
-  │ --project    -p                TEXT  Path where the Snowflake Native App     │
-  │                                      project resides. Defaults to current    │
-  │                                      working directory.                      │
-  │ --help       -h                      Show this message and exit.             │
+  │ --prune          --no-prune              Whether to delete specified files   │
+  │                                          from the stage if they don't exist  │
+  │                                          locally. If set, the command        │
+  │                                          deletes files that exist in the     │
+  │                                          stage, but not in the local         │
+  │                                          filesystem.                         │
+  │                                          [default: no-prune]                 │
+  │ --recursive  -r  --no-recursive          Whether to traverse and deploy      │
+  │                                          files from subdirectories. If set,  │
+  │                                          the command deploys all files and   │
+  │                                          subdirectories; otherwise, only     │
+  │                                          files in the current directory are  │
+  │                                          deployed.                           │
+  │                                          [default: no-recursive]             │
+  │ --project    -p                    TEXT  Path where the Snowflake Native App │
+  │                                          project resides. Defaults to        │
+  │                                          current working directory.          │
+  │ --help       -h                          Show this message and exit.         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │

--- a/tests_integration/nativeapp/test_deploy.py
+++ b/tests_integration/nativeapp/test_deploy.py
@@ -22,7 +22,7 @@ USER_NAME = f"user_{uuid.uuid4().hex}"
 TEST_ENV = generate_user_env(USER_NAME)
 
 
-BOX_LINE_PATTERN = re.compile(r"\s*│(?P<content>.*)│\s*")
+BOX_LINE_PATTERN = re.compile(r"\s*\u2502(?P<content>.*)\u2502\s*")
 
 
 def extract_error_message(raw_output: str) -> Optional[str]:
@@ -31,9 +31,13 @@ def extract_error_message(raw_output: str) -> Optional[str]:
     error_lines: List[str] = []
     for raw_line in raw_lines:
         line = raw_line.strip()
-        if line.startswith("╭─ Error"):
+        if (
+            line.startswith("\u250c\u2500") or line.startswith("╭─")
+        ) and "Error" in line:  # top-left corner
             in_box = True
-        elif in_box and line.startswith("╰─"):
+        elif in_box and (
+            line.startswith("\u2514\u2500") or line.startswith("╰─")
+        ):  # bottom-left corner
             return " ".join(error_lines)
         elif in_box:
             match = BOX_LINE_PATTERN.match(line)

--- a/tests_integration/nativeapp/test_deploy.py
+++ b/tests_integration/nativeapp/test_deploy.py
@@ -285,6 +285,14 @@ def test_nativeapp_deploy_directory(
 
     with pushd(Path(os.getcwd(), project_dir)):
         touch("app/dir/file.txt")
+        result = runner.invoke_with_connection(
+            ["app", "deploy", "app/dir", "--no-recursive"],
+            env=TEST_ENV,
+        )
+        print("Result output:", result.output)
+        assert result.exit_code == 1
+        assert "-r" in result.output
+
         result = runner.invoke_with_connection_json(
             ["app", "deploy", "app/dir", "-r"],
             env=TEST_ENV,


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * [X] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

The `snow app deploy` command accidentally disabled the use of `--no-recursive` because it includes a shorthand notation (`-r`) for the `--recursive` flag, which disabled the default flag handling behaviour in Typer. This change adds back the `--no-recursive` flag.

### Testing

In addition to automated tests, verified that `--no-recursive` and `--recursive/-r` have the expected behaviour by executing various `deploy` commands on a sample app with local changes. Verified the error messages and stage status after each one.