### PR TITLE
[SNOW-1371918] Make snow app deploy behave more intuitively

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
 * Improved detection of conflicts between artifact rules for native application projects
 * Fixed URL generation for applications, streamlits, and notebooks that use a quoted identifier with spaces.
-* `snow app deploy` now scans specified directories for changes even if there is no artifact rule matching that directory
+* Passing a directory to `snow app deploy` will now deploy any of its subfolders specified in the application's artifact rules
 
 
 # v2.4.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
 * Improved detection of conflicts between artifact rules for native application projects
 * Fixed URL generation for applications, streamlits, and notebooks that use a quoted identifier with spaces.
-* Passing a directory to `snow app deploy` will now deploy any of its subfolders specified in the application's artifact rules
+* Passing a directory to `snow app deploy` will now deploy any contained file or subfolder specified in the application's artifact rules
 
 
 # v2.4.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Passing a directory to `snow app deploy` will now deploy any contained file or subfolder specified in the application's artifact rules
 
 # v2.5.0
 ## Backward incompatibility
@@ -51,8 +52,6 @@
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
 * Improved detection of conflicts between artifact rules for native application projects
 * Fixed URL generation for applications, streamlits, and notebooks that use a quoted identifier with spaces.
-* Passing a directory to `snow app deploy` will now deploy any contained file or subfolder specified in the application's artifact rules
-
 
 # v2.4.0
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,6 +51,8 @@
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
 * Improved detection of conflicts between artifact rules for native application projects
 * Fixed URL generation for applications, streamlits, and notebooks that use a quoted identifier with spaces.
+* `snow app deploy` now scans specified directories for changes even if there is no artifact rule matching that directory
+
 
 # v2.4.0
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -194,6 +194,12 @@ class _ArtifactPathMap:
         """
         return self.__src_to_dest.get(src, [])
 
+    def all_sources(self) -> Iterable[Path]:
+        """
+        Returns all source paths associated with this map, in insertion order.
+        """
+        return self.__src_to_dest.keys()
+
     def __iter__(self) -> Iterator[Tuple[Path, Path]]:
         """
         Returns all (source, destination) pairs known to this map, in insertion order.
@@ -448,7 +454,7 @@ class BundleMap:
         Returns:
           An iterator over all artifact mapping source paths.
         """
-        for src in self._src_to_dest.keys():
+        for src in self._artifact_map.all_sources():
             yield self._to_output_src(src, absolute)
 
     def _absolute_src(self, src: Path) -> Path:

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -402,6 +402,9 @@ class BundleMap:
         """
         Converts a source path to its corresponding deploy root path. If the input path is relative to the project root,
         a path relative to the deploy root is returned. If the input path is absolute, an absolute path is returned.
+        Note that the provided source path must be part of a mapping. If the source path is not part of any mapping,
+        an empty list is returned. For example, if `app/*` is specified as the source of a mapping,
+        `to_deploy_paths(Path("app"))` will not yield any result.
 
         Returns:
             The deploy root paths for the given source path, or an empty list if no such path exists.

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -435,6 +435,19 @@ class BundleMap:
 
         return output_destinations
 
+    def all_sources(self, absolute: bool = False) -> Iterator[Path]:
+        """
+        Yields each registered artifact source in the project.
+
+        Arguments:
+            self: this instance
+            absolute (bool): Specifies whether the yielded paths should be joined with the absolute project root.
+        Returns:
+          An iterator over all artifact mapping source paths.
+        """
+        for src in self._src_to_dest.keys():
+            yield self._to_output_src(src, absolute)
+
     def _absolute_src(self, src: Path) -> Path:
         if src.is_absolute():
             resolved_src = resolve_without_follow(src)

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -300,7 +300,7 @@ def app_deploy(
             recursive = False
 
     if has_files and prune:
-        raise ClickException("--prune cannot be used when files are also specified")
+        raise ClickException("--prune cannot be used when paths are also specified")
 
     manager = NativeAppManager(
         project_definition=cli_context.project_definition,

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
+from click import ClickException
 from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.commands.decorators import (
     with_project_definition,
@@ -268,7 +269,7 @@ def app_teardown(
 def app_deploy(
     prune: Optional[bool] = typer.Option(
         default=None,
-        help=f"""Whether to delete specified files from the stage if they don't exist locally. If set, the command deletes files that exist in the stage, but not in the local filesystem.""",
+        help=f"""Whether to delete specified files from the stage if they don't exist locally. If set, the command deletes files that exist in the stage, but not in the local filesystem. This option cannot be used when files are specified.""",
     ),
     recursive: Optional[bool] = typer.Option(
         None,
@@ -297,6 +298,9 @@ def app_deploy(
             prune = False
         if recursive is None:
             recursive = False
+
+    if has_files and prune:
+        raise ClickException("--prune cannot be used when files are also specified")
 
     manager = NativeAppManager(
         project_definition=cli_context.project_definition,

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -414,9 +414,10 @@ class NativeAppManager(SqlExecutionMixin):
                 deploy_paths = bundle_map.to_deploy_paths(resolved_path)
                 if not deploy_paths:
                     if resolved_path.is_dir() and recursive:
-                        # There are no dirNot direct artifact mapping found for this
-                        # path. Check to see if there are subpaths of this directory
-                        # that are matches
+                        # No direct artifact mapping found for this path. Check to see
+                        # if there are subpaths of this directory that are matches. We
+                        # loop over sources because it's likely a much smaller list
+                        # than the project directory.
                         for src in bundle_map.all_sources(absolute=True):
                             if resolved_path in src.parents:
                                 # There is a source that contains this path, get its dest path(s)

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -400,7 +400,6 @@ class NativeAppManager(SqlExecutionMixin):
         )
         diff: DiffResult = compute_stage_diff(self.deploy_root, stage_fqn)
 
-        files_not_removed = []
         if local_paths_to_sync:
             # Deploying specific files/directories
             resolved_paths_to_sync = [
@@ -414,6 +413,16 @@ class NativeAppManager(SqlExecutionMixin):
                 verify_exists(resolved_path)
                 deploy_paths = bundle_map.to_deploy_paths(resolved_path)
                 if not deploy_paths:
+                    if resolved_path.is_dir() and recursive:
+                        # There are no dirNot direct artifact mapping found for this
+                        # path. Check to see if there are subpaths of this directory
+                        # that are matches
+                        for src in bundle_map.all_sources(absolute=True):
+                            if resolved_path in src.parents:
+                                # There is a source that contains this path, get its dest path(s)
+                                deploy_paths.extend(bundle_map.to_deploy_paths(src))
+
+                if not deploy_paths:
                     raise ClickException(f"No artifact found for {resolved_path}")
                 deploy_paths_to_sync.extend(deploy_paths)
 
@@ -424,8 +433,7 @@ class NativeAppManager(SqlExecutionMixin):
         else:
             # Full deploy
             if not recursive:
-                deploy_files = [p for p in self.deploy_root.resolve().iterdir()]
-                verify_no_directories(deploy_files)
+                verify_no_directories(self.deploy_root.resolve().iterdir())
 
         if not prune:
             files_not_removed = [str(path) for path in diff.only_on_stage]

--- a/src/snowflake/cli/plugins/nativeapp/utils.py
+++ b/src/snowflake/cli/plugins/nativeapp/utils.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from sys import stdin, stdout
-from typing import List, Optional, Union
+from typing import Iterable, Optional, Union
 
 from click import ClickException
 
@@ -85,7 +85,7 @@ def shallow_git_clone(url: Union[str, os.PathLike], to_path: Union[str, os.PathL
     return repo
 
 
-def verify_no_directories(paths_to_sync: List[Path]):
+def verify_no_directories(paths_to_sync: Iterable[Path]):
     for path in paths_to_sync:
         if path.is_dir():
             raise ClickException(

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -67,7 +67,7 @@
 # name: test_help_messages[app.deploy]
   '''
                                                                                   
-   Usage: default app deploy [OPTIONS] [FILES]...                                 
+   Usage: default app deploy [OPTIONS] [PATHS]...                                 
                                                                                   
    Creates an application package in your Snowflake account and syncs the local   
    changes to the stage without creating or updating the application. Running     
@@ -75,11 +75,14 @@
    for `snow app deploy --prune --recursive`.                                     
                                                                                   
   ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-  │   files      [FILES]...  Paths, relative to the the project root, of files   │
-  │                          you want to upload to a stage. The paths must match │
-  │                          one of the artifacts src pattern entries in         │
-  │                          snowflake.yml. If unspecified, the command syncs    │
-  │                          all local changes to the stage.                     │
+  │   paths      [PATHS]...  Paths, relative to the the project root, of files   │
+  │                          or directories you want to upload to a stage. If a  │
+  │                          file is specified, it must match one of the         │
+  │                          artifacts src pattern entries in snowflake.yml. If  │
+  │                          a directory is specified, it will be searched for   │
+  │                          subfolders or files to deploy based on artifacts    │
+  │                          src pattern entries. If unspecified, the command    │
+  │                          syncs all local changes to the stage.               │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --prune          --no-prune              Whether to delete specified files   │
@@ -88,7 +91,7 @@
   │                                          deletes files that exist in the     │
   │                                          stage, but not in the local         │
   │                                          filesystem. This option cannot be   │
-  │                                          used when files are specified.      │
+  │                                          used when paths are specified.      │
   │                                          [default: no-prune]                 │
   │ --recursive  -r  --no-recursive          Whether to traverse and deploy      │
   │                                          files from subdirectories. If set,  │

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -87,7 +87,8 @@
   │                                          locally. If set, the command        │
   │                                          deletes files that exist in the     │
   │                                          stage, but not in the local         │
-  │                                          filesystem.                         │
+  │                                          filesystem. This option cannot be   │
+  │                                          used when files are specified.      │
   │                                          [default: no-prune]                 │
   │ --recursive  -r  --no-recursive          Whether to traverse and deploy      │
   │                                          files from subdirectories. If set,  │

--- a/tests_integration/nativeapp/test_deploy.py
+++ b/tests_integration/nativeapp/test_deploy.py
@@ -499,9 +499,16 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
                 snowflake_yml.read_text(), yaml.BaseLoader
             )
             project_definition_file["native_app"]["artifacts"].append("src")
+            project_definition_file["native_app"]["artifacts"].append(
+                "lib/parent/child"
+            )
             snowflake_yml.write_text(yaml.dump(project_definition_file))
 
             touch(str(project_dir / "src/main.py"))
+
+            touch(str(project_dir / "lib/parent/child/a.py"))
+            touch(str(project_dir / "lib/parent/child/b.py"))
+            touch(str(project_dir / "lib/parent/child/c/c.py"))
 
             result = runner.invoke_with_connection_json(
                 ["app", "deploy", "-r", "app"],
@@ -521,6 +528,51 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
             )
             assert contains_row_with(stage_files.json, {"name": "stage/README.md"})
             assert not_contains_row_with(stage_files.json, {"name": "src/main.py"})
+
+            result = runner.invoke_with_connection_json(
+                ["app", "deploy", "-r", "lib/parent/child/c"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+            assert contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/c/c.py"}
+            )
+            assert not_contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/a.py"}
+            )
+            assert not_contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/b.py"}
+            )
+
+            result = runner.invoke_with_connection_json(
+                ["app", "deploy", "lib/parent/child/a.py"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+            assert contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/c/c.py"}
+            )
+            assert contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/a.py"}
+            )
+            assert not_contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/b.py"}
+            )
+
+            result = runner.invoke_with_connection_json(
+                ["app", "deploy", "lib", "-r"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+            assert contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/c/c.py"}
+            )
+            assert contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/a.py"}
+            )
+            assert contains_row_with(
+                stage_files.json, {"name": "lib/parent/child/b.py"}
+            )
 
         finally:
             result = runner.invoke_with_connection_json(


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * [X] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

`snow app deploy`, when invoked with directories, current a matching artifact deployment rule for each parameter. This is not very intuitive. For example, when a user specifies:

```
- src: app/*
- dest: ./
```
in their `snowflake.yml`, `snow app deploy -r app` results in an error. This change makes the command deploy all files that have been changed within the specified directory instead.
