### PR TITLE
[SNOW-1465370] Support deannotating class definitions

### DIFF
--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_extension_function_utils.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_extension_function_utils.ambr
@@ -24,6 +24,27 @@
   @custom
   def helper():
       pass
+  
+  
+  @custom
+  #: @udtf(
+  #:     name="alt_int",
+  #:     replace=True,
+  #:     output_schema=StructType([StructField("number", IntegerType())]),
+  #:     input_types=[IntegerType()],
+  #: )
+  #: @module.annotation
+  class Alternator:
+      def __init__(self):
+          self._positive = True
+  
+      def process(self, n):
+          for i in range(n):
+              if self._positive:
+                  yield (1,)
+              else:
+                  yield (-1,)
+              self._positive = not self._positive
   '''
 # ---
 # name: test_deannotate_module_source_preserves_specified_annotations.1
@@ -51,6 +72,27 @@
   @custom
   def helper():
       pass
+  
+  
+  #: @custom
+  #: @udtf(
+  #:     name="alt_int",
+  #:     replace=True,
+  #:     output_schema=StructType([StructField("number", IntegerType())]),
+  #:     input_types=[IntegerType()],
+  #: )
+  @module.annotation
+  class Alternator:
+      def __init__(self):
+          self._positive = True
+  
+      def process(self, n):
+          for i in range(n):
+              if self._positive:
+                  yield (1,)
+              else:
+                  yield (-1,)
+              self._positive = not self._positive
   '''
 # ---
 # name: test_deannotate_module_source_removes_all_annotations
@@ -78,5 +120,26 @@
   @custom
   def helper():
       pass
+  
+  
+  #: @custom
+  #: @udtf(
+  #:     name="alt_int",
+  #:     replace=True,
+  #:     output_schema=StructType([StructField("number", IntegerType())]),
+  #:     input_types=[IntegerType()],
+  #: )
+  #: @module.annotation
+  class Alternator:
+      def __init__(self):
+          self._positive = True
+  
+      def process(self, n):
+          for i in range(n):
+              if self._positive:
+                  yield (1,)
+              else:
+                  yield (-1,)
+              self._positive = not self._positive
   '''
 # ---


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

UDTF/UDAF require annotated classes as handlers. These handlers also need to be deannotated during the bundle phase, otherwise the Python code will not work in a Snowpark cloud environment. This change generalizes the deannotation logic to handle both function and class definitions.

### Testing

- Updated unit tests to capture the new behaviour
- Manually verified the updated snapshots to make sure the behaviour was as intended
- Manually verified the change with a representative sample app
- Integ tests for Snowpark annotation processing are WIP and will be covered in a subsequent PR.
