### PR TITLE
[SNOW-1465372] Strip version numbers from the Snowpark lib during codegen

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -417,7 +417,7 @@ def generate_create_sql_ddl_statement(
         )
 
     if extension_fn.packages:
-        create_query += f"\nPACKAGES=({', '.join(extension_fn.packages)})"
+        create_query += f"\nPACKAGES=({', '.join(ensure_all_string_literals([pkg.strip() for pkg in extension_fn.packages]))})"
 
     if extension_fn.external_access_integrations:
         create_query += f"\nEXTERNAL_ACCESS_INTEGRATIONS=({', '.join(ensure_all_string_literals(extension_fn.external_access_integrations))})"

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -44,8 +44,9 @@ DEFAULT_TIMEOUT = 30
 TEMPLATE_PATH = Path(__file__).parent / "callback_source.py.jinja"
 SNOWPARK_LIB_NAME = "snowflake-snowpark-python"
 SNOWPARK_LIB_REGEX = re.compile(
+    # support PEP 508, even though not all of it is supported in Snowflake yet
     rf"'{SNOWPARK_LIB_NAME}\s*((<|<=|!=|==|>=|>|~=|===)\s*[a-zA-Z0-9_.*+!-]+)?'"
-)  # support PEP 508, even though not all of it is supported in Snowflake yet
+)
 STAGE_PREFIX = "@"
 
 

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -43,7 +43,9 @@ from snowflake.cli.plugins.stage.diff import to_stage_path
 DEFAULT_TIMEOUT = 30
 TEMPLATE_PATH = Path(__file__).parent / "callback_source.py.jinja"
 SNOWPARK_LIB_NAME = "snowflake-snowpark-python"
-SNOWPARK_LIB_REGEX = rf"'{SNOWPARK_LIB_NAME}\s*((<|<=|!=|==|>=|>|~=|===)\s*[a-zA-Z0-9_.*+!-]+)?'"  # support PEP 508, even though not all of it is supported in Snowflake yet
+SNOWPARK_LIB_REGEX = re.compile(
+    rf"'{SNOWPARK_LIB_NAME}\s*((<|<=|!=|==|>=|>|~=|===)\s*[a-zA-Z0-9_.*+!-]+)?'"
+)  # support PEP 508, even though not all of it is supported in Snowflake yet
 STAGE_PREFIX = "@"
 
 
@@ -266,13 +268,10 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         # If user defined their udf as @udf(lambda: x, ...) then extension_fn.handler is <lambda>.
         extension_fn.handler = f"{py_file.stem}.{extension_fn.handler}"
 
-        snowpark_lib_found = False
-        snowpark_lib_regex = re.compile(SNOWPARK_LIB_REGEX)
-        for pkg in extension_fn.packages:
-            if snowpark_lib_regex.fullmatch(ensure_string_literal(pkg.strip())):
-                snowpark_lib_found = True
-                break
-        if not snowpark_lib_found:
+        extension_fn.packages = [
+            self._normalize_package_name(pkg) for pkg in extension_fn.packages
+        ]
+        if SNOWPARK_LIB_NAME not in extension_fn.packages:
             extension_fn.packages.append(SNOWPARK_LIB_NAME)
 
         if extension_fn.imports is None:
@@ -282,6 +281,23 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
             py_file=py_file,
             deploy_root=deploy_root,
         )
+
+    def _normalize_package_name(self, pkg: str) -> str:
+        """
+        Returns a normalized version of the provided package name, as a Snowflake SQL string literal. Since the
+        Snowpark library can sometimes add a spurious version to its own package name, we strip this here too so
+        that the native application does not accidentally rely on stale packages once the snowpark library is updated
+        in the cloud.
+
+        Args:
+            pkg (str): The package name to normalize.
+        Returns:
+            A normalized version of the package name, as a Snowflake SQL string literal.
+        """
+        normalized_package_name = ensure_string_literal(pkg.strip())
+        if SNOWPARK_LIB_REGEX.fullmatch(normalized_package_name):
+            return SNOWPARK_LIB_NAME
+        return normalized_package_name
 
     def collect_extension_functions(
         self, bundle_map: BundleMap, processor_mapping: Optional[ProcessorMapping]

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -271,8 +271,9 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         extension_fn.packages = [
             self._normalize_package_name(pkg) for pkg in extension_fn.packages
         ]
-        if SNOWPARK_LIB_NAME not in extension_fn.packages:
-            extension_fn.packages.append(SNOWPARK_LIB_NAME)
+        snowpark_lib_name = ensure_string_literal(SNOWPARK_LIB_NAME)
+        if snowpark_lib_name not in extension_fn.packages:
+            extension_fn.packages.append(snowpark_lib_name)
 
         if extension_fn.imports is None:
             extension_fn.imports = []
@@ -296,7 +297,7 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         """
         normalized_package_name = ensure_string_literal(pkg.strip())
         if SNOWPARK_LIB_REGEX.fullmatch(normalized_package_name):
-            return SNOWPARK_LIB_NAME
+            return ensure_string_literal(SNOWPARK_LIB_NAME)
         return normalized_package_name
 
     def collect_extension_functions(
@@ -415,7 +416,7 @@ def generate_create_sql_ddl_statement(
         )
 
     if extension_fn.packages:
-        create_query += f"\nPACKAGES=({', '.join(ensure_all_string_literals([pkg.strip() for pkg in extension_fn.packages]))})"
+        create_query += f"\nPACKAGES=({', '.join(extension_fn.packages)})"
 
     if extension_fn.external_access_integrations:
         create_query += f"\nEXTERNAL_ACCESS_INTEGRATIONS=({', '.join(ensure_all_string_literals(extension_fn.external_access_integrations))})"

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -181,7 +181,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python===0.15.0-rc1')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -203,7 +203,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python===0.15.0-rc1')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -269,7 +269,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python  ==  0.15.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -335,7 +335,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python==0.15.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -357,7 +357,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python==0.15.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -379,7 +379,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python<0.16.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -401,7 +401,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python<=0.17.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -423,7 +423,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python>=0.14.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -445,7 +445,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python>0.13.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'
@@ -467,7 +467,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip', '/stagepath/main.py')
-  PACKAGES=('snowflake-snowpark-python===0.15.0')
+  PACKAGES=('snowflake-snowpark-python')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='main.my_function_handler'

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -121,7 +121,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip')
-  PACKAGES=('package_one==1.0.2', 'package_two')
+  PACKAGES=(package_one==1.0.2, package_two)
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='my_function_handler'

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -121,7 +121,7 @@
   LANGUAGE PYTHON
   RUNTIME_VERSION=3.11
   IMPORTS=('/path/to/import1.py', '/path/to/import2.zip')
-  PACKAGES=(package_one==1.0.2, package_two)
+  PACKAGES=('package_one==1.0.2', 'package_two')
   EXTERNAL_ACCESS_INTEGRATIONS=('integration_one', 'integration_two')
   SECRETS=('key1'=secret_one, 'key2'=integration_two)
   HANDLER='my_function_handler'


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

The Snowpark library sometimes appends its current version to the reported package dependencies. This is too strict for native apps, since they are expected to outlast Snowpark library upgrades. This change normalizes the Snowpark library package and removes that version if it's present. In the case where a user specified that version, we'd strip it as well, but arguably that is correct behaviour for this specific package due to strict backwards compatibility requirements.
