### PR TITLE
Propagate bundle map to all uses of the deployment logic

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -181,8 +181,9 @@ def app_run(
         project_definition=cli_context.project_definition,
         project_root=cli_context.project_root,
     )
-    processor.build_bundle()
+    bundle_map = processor.build_bundle()
     processor.process(
+        bundle_map=bundle_map,
         policy=policy,
         version=version,
         patch=patch,
@@ -279,8 +280,13 @@ def app_deploy(
         project_root=cli_context.project_root,
     )
 
-    mapped_files = manager.build_bundle()
-    manager.deploy(prune, recursive, files, mapped_files)
+    bundle_map = manager.build_bundle()
+    manager.deploy(
+        bundle_map=bundle_map,
+        prune=prune,
+        recursive=recursive,
+        local_paths_to_sync=files,
+    )
 
     return MessageResult(
         f"Deployed successfully. Application package and stage are up-to-date."

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -331,11 +331,11 @@ class NativeAppManager(SqlExecutionMixin):
 
     def sync_deploy_root_with_stage(
         self,
+        bundle_map: BundleMap,
         role: str,
         prune: bool,
         recursive: bool,
         local_paths_to_sync: List[Path] | None = None,
-        bundle_map: Optional[BundleMap] = None,
     ) -> DiffResult:
         """
         Ensures that the files on our remote stage match the artifacts we have in
@@ -551,10 +551,10 @@ class NativeAppManager(SqlExecutionMixin):
 
     def deploy(
         self,
+        bundle_map: BundleMap,
         prune: bool,
         recursive: bool,
         local_paths_to_sync: List[Path] | None = None,
-        bundle_map: Optional[BundleMap] = None,
     ) -> DiffResult:
         """app deploy process"""
 
@@ -567,7 +567,11 @@ class NativeAppManager(SqlExecutionMixin):
 
             # 3. Upload files from deploy root local folder to the above stage
             diff = self.sync_deploy_root_with_stage(
-                self.package_role, prune, recursive, local_paths_to_sync, bundle_map
+                bundle_map=bundle_map,
+                role=self.package_role,
+                prune=prune,
+                recursive=recursive,
+                local_paths_to_sync=local_paths_to_sync,
             )
 
         return diff

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -377,8 +377,6 @@ class NativeAppManager(SqlExecutionMixin):
 
         files_not_removed = []
         if local_paths_to_sync:
-            assert bundle_map is not None
-
             # Deploying specific files/directories
             resolved_paths_to_sync = [
                 resolve_without_follow(p) for p in local_paths_to_sync

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -14,6 +14,7 @@ from snowflake.cli.api.project.util import (
     unquote_identifier,
 )
 from snowflake.cli.api.utils.cursor import find_all_rows
+from snowflake.cli.plugins.nativeapp.artifacts import BundleMap
 from snowflake.cli.plugins.nativeapp.constants import (
     ALLOWED_SPECIAL_COMMENTS,
     COMMENT_COL,
@@ -278,6 +279,7 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
 
     def process(
         self,
+        bundle_map: BundleMap,
         policy: PolicyBase,
         version: Optional[str] = None,
         patch: Optional[int] = None,
@@ -312,5 +314,5 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
             )
             return
 
-        diff = self.deploy(prune=True, recursive=True)
+        diff = self.deploy(bundle_map=bundle_map, prune=True, recursive=True)
         self._create_dev_app(diff)

--- a/src/snowflake/cli/plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/commands.py
@@ -80,8 +80,9 @@ def create(
     )
 
     # We need build_bundle() to (optionally) find version in manifest.yml and create an application package
-    processor.build_bundle()
+    bundle_map = processor.build_bundle()
     processor.process(
+        bundle_map=bundle_map,
         version=version,
         patch=patch,
         policy=policy,

--- a/src/snowflake/cli/plugins/nativeapp/version/version_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/version_processor.py
@@ -14,7 +14,10 @@ from snowflake.cli.api.utils.cursor import (
     find_all_rows,
     find_first_row,
 )
-from snowflake.cli.plugins.nativeapp.artifacts import find_version_info_in_manifest_file
+from snowflake.cli.plugins.nativeapp.artifacts import (
+    BundleMap,
+    find_version_info_in_manifest_file,
+)
 from snowflake.cli.plugins.nativeapp.constants import VERSION_COL
 from snowflake.cli.plugins.nativeapp.exceptions import (
     ApplicationPackageDoesNotExistError,
@@ -148,6 +151,7 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
 
     def process(
         self,
+        bundle_map: BundleMap,
         version: Optional[str],
         patch: Optional[int],
         policy: PolicyBase,
@@ -202,7 +206,10 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
 
             # Upload files from deploy root local folder to the above stage
             self.sync_deploy_root_with_stage(
-                self.package_role, prune=True, recursive=True
+                bundle_map=bundle_map,
+                role=self.package_role,
+                prune=True,
+                recursive=True,
             )
 
         # Warn if the version exists in a release directive(s)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,11 @@ from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.output.types import QueryResult
 from snowflake.cli.app import loggers
 
-pytest_plugins = ["tests.testing_utils.fixtures", "tests.project.fixtures"]
+pytest_plugins = [
+    "tests.testing_utils.fixtures",
+    "tests.project.fixtures",
+    "tests.nativeapp.fixtures",
+]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/nativeapp/fixtures.py
+++ b/tests/nativeapp/fixtures.py
@@ -1,0 +1,9 @@
+import unittest.mock as mock
+
+import pytest
+from snowflake.cli.plugins.nativeapp.artifacts import BundleMap
+
+
+@pytest.fixture()
+def mock_bundle_map():
+    yield mock.Mock(spec=BundleMap)

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.project.definition_manager import DefinitionManager
+from snowflake.cli.plugins.nativeapp.artifacts import BundleMap
 from snowflake.cli.plugins.nativeapp.constants import (
     LOOSE_FILES_MAGIC_VERSION,
     NAME_COL,
@@ -88,7 +89,10 @@ def test_sync_deploy_root_with_stage(
 
     native_app_manager = _get_na_manager()
     assert mock_diff_result.has_changes()
-    native_app_manager.sync_deploy_root_with_stage("new_role", True, True)
+    mock_bundle_map = mock.Mock(spec=BundleMap)
+    native_app_manager.sync_deploy_root_with_stage(
+        bundle_map=mock_bundle_map, role="new_role", prune=True, recursive=True
+    )
 
     expected = [
         mock.call("select current_role()", cursor_class=DictCursor),
@@ -151,7 +155,10 @@ def test_sync_deploy_root_with_stage_prune(
     )
     native_app_manager = _get_na_manager()
 
-    native_app_manager.sync_deploy_root_with_stage("role", prune, True)
+    mock_bundle_map = mock.Mock(spec=BundleMap)
+    native_app_manager.sync_deploy_root_with_stage(
+        bundle_map=mock_bundle_map, role="new_role", prune=prune, recursive=True
+    )
 
     if expected_warn:
         files_str = "\n".join(only_on_stage_files)

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -1092,7 +1092,7 @@ def test_upgrade_app_recreate_app(
     "policy_param", [allow_always_policy, ask_always_policy, deny_always_policy]
 )
 def test_upgrade_app_from_version_throws_usage_error_one(
-    mock_existing, policy_param, temp_dir
+    mock_existing, policy_param, temp_dir, mock_bundle_map
 ):
 
     current_working_directory = os.getcwd()
@@ -1104,7 +1104,12 @@ def test_upgrade_app_from_version_throws_usage_error_one(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(UsageError):
-        run_processor.process(policy=policy_param, version="v1", is_interactive=True)
+        run_processor.process(
+            bundle_map=mock_bundle_map,
+            policy=policy_param,
+            version="v1",
+            is_interactive=True,
+        )
 
 
 # Test upgrade app method for version AND no existing app package from version info
@@ -1116,7 +1121,7 @@ def test_upgrade_app_from_version_throws_usage_error_one(
     "policy_param", [allow_always_policy, ask_always_policy, deny_always_policy]
 )
 def test_upgrade_app_from_version_throws_usage_error_two(
-    mock_existing, policy_param, temp_dir
+    mock_existing, policy_param, temp_dir, mock_bundle_map
 ):
 
     current_working_directory = os.getcwd()
@@ -1128,7 +1133,12 @@ def test_upgrade_app_from_version_throws_usage_error_two(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(UsageError):
-        run_processor.process(policy=policy_param, version="v1", is_interactive=True)
+        run_processor.process(
+            bundle_map=mock_bundle_map,
+            policy=policy_param,
+            version="v1",
+            is_interactive=True,
+        )
 
 
 # Test upgrade app method for version AND existing app info AND user wants to drop app AND drop succeeds AND app is created successfully
@@ -1152,6 +1162,7 @@ def test_upgrade_app_recreate_app_from_version(
     policy_param,
     temp_dir,
     mock_cursor,
+    mock_bundle_map,
 ):
     mock_get_existing_app_info.return_value = {
         "name": "myapp",
@@ -1219,7 +1230,12 @@ def test_upgrade_app_recreate_app_from_version(
     )
 
     run_processor = _get_na_run_processor()
-    run_processor.process(policy=policy_param, version="v1", is_interactive=True)
+    run_processor.process(
+        bundle_map=mock_bundle_map,
+        policy=policy_param,
+        version="v1",
+        is_interactive=True,
+    )
     assert mock_execute.mock_calls == expected
 
 

--- a/tests/nativeapp/test_version_create_processor.py
+++ b/tests/nativeapp/test_version_create_processor.py
@@ -217,7 +217,10 @@ def test_add_new_patch_custom(mock_execute, temp_dir, mock_cursor):
     "policy_param", [allow_always_policy, ask_always_policy, deny_always_policy]
 )
 def test_process_no_version_from_user_no_version_in_manifest(
-    mock_version_info_in_manifest, policy_param, temp_dir
+    mock_version_info_in_manifest,
+    policy_param,
+    temp_dir,
+    mock_bundle_map,
 ):
     current_working_directory = os.getcwd()
     create_named_file(
@@ -229,6 +232,7 @@ def test_process_no_version_from_user_no_version_in_manifest(
     processor = _get_version_create_processor()
     with pytest.raises(ClickException):
         processor.process(
+            bundle_map=mock_bundle_map,
             version=None,
             patch=None,
             policy=policy_param,
@@ -246,7 +250,10 @@ def test_process_no_version_from_user_no_version_in_manifest(
     "policy_param", [allow_always_policy, ask_always_policy, deny_always_policy]
 )
 def test_process_no_version_exists_throws_bad_option_exception_one(
-    mock_existing_version_info, policy_param, temp_dir
+    mock_existing_version_info,
+    policy_param,
+    temp_dir,
+    mock_bundle_map,
 ):
     current_working_directory = os.getcwd()
     create_named_file(
@@ -258,6 +265,7 @@ def test_process_no_version_exists_throws_bad_option_exception_one(
     processor = _get_version_create_processor()
     with pytest.raises(BadOptionUsage):
         processor.process(
+            bundle_map=mock_bundle_map,
             version="v1",
             patch="12",
             policy=policy_param,
@@ -275,7 +283,10 @@ def test_process_no_version_exists_throws_bad_option_exception_one(
     "policy_param", [allow_always_policy, ask_always_policy, deny_always_policy]
 )
 def test_process_no_version_exists_throws_bad_option_exception_two(
-    mock_existing_version_info, policy_param, temp_dir
+    mock_existing_version_info,
+    policy_param,
+    temp_dir,
+    mock_bundle_map,
 ):
     current_working_directory = os.getcwd()
     create_named_file(
@@ -287,6 +298,7 @@ def test_process_no_version_exists_throws_bad_option_exception_two(
     processor = _get_version_create_processor()
     with pytest.raises(BadOptionUsage):
         processor.process(
+            bundle_map=mock_bundle_map,
             version="v1",
             patch="12",
             policy=policy_param,
@@ -333,6 +345,7 @@ def test_process_no_existing_release_directives_or_versions(
     policy_param,
     temp_dir,
     mock_cursor,
+    mock_bundle_map,
 ):
     version = "V1"
     side_effects, expected = mock_execute_helper(
@@ -356,6 +369,7 @@ def test_process_no_existing_release_directives_or_versions(
 
     processor = _get_version_create_processor()
     processor.process(
+        bundle_map=mock_bundle_map,
         version=version,
         patch=None,
         policy=policy_param,
@@ -415,6 +429,7 @@ def test_process_no_existing_release_directives_w_existing_version(
     policy_param,
     temp_dir,
     mock_cursor,
+    mock_bundle_map,
 ):
     version = "V1"
     mock_existing_version_info.return_value = {
@@ -444,6 +459,7 @@ def test_process_no_existing_release_directives_w_existing_version(
 
     processor = _get_version_create_processor()
     processor.process(
+        bundle_map=mock_bundle_map,
         version=version,
         patch=12,
         policy=policy_param,
@@ -507,6 +523,7 @@ def test_process_existing_release_directives_user_does_not_proceed(
     expected_code,
     temp_dir,
     mock_cursor,
+    mock_bundle_map,
 ):
     version = "V1"
     mock_existing_version_info.return_value = {"version": version, "patch": 0}
@@ -536,6 +553,7 @@ def test_process_existing_release_directives_user_does_not_proceed(
     processor = _get_version_create_processor()
     with pytest.raises(typer.Exit):
         result = processor.process(
+            bundle_map=mock_bundle_map,
             version=version,
             patch=12,
             policy=policy_param,
@@ -601,6 +619,7 @@ def test_process_existing_release_directives_w_existing_version_two(
     is_interactive_param,
     temp_dir,
     mock_cursor,
+    mock_bundle_map,
 ):
     version = "V1"
     mock_existing_version_info.return_value = {
@@ -634,6 +653,7 @@ def test_process_existing_release_directives_w_existing_version_two(
 
     processor = _get_version_create_processor()
     processor.process(
+        bundle_map=mock_bundle_map,
         version=version,
         patch=12,
         policy=policy_param,


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

This is a pure refactoring that is intended to prepare for a future code change. The general idea is that whenever we perform a bundle operation, we should propagate the BundleMap produced to the deployment logic so that it can be queried. This will be useful when trying to reason about changes files (during the diff operation) later on. Currently the bundle map is only required when specific paths are deployed. With this change, it's always a requirement argument.

### Testing

- Updated the existing tests for the API change. However, since the bundle map itself is not used yet outside of the current logic that requires it, no new tests need to be added just yet.
- Manually ran through the NADE test plan to make sure nothing was accidentally broken.
