### PR TITLE
Fix invalid escape sequences and enable lint rule

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@
 * Fixed ZIP packaging of Snowpark project dependencies containing implicit namespace packages like `snowflake`.
 * Deploying function/procedure with `--replace` flag now copies all grants
 * Fixed MFA caching
+* Fixed `DeprerationWarning`/`SyntaxWarning` due to invalid escape sequences
 
 # v2.4.0
 ## Backward incompatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ select = [
   "F401",   # unused imports
   "F403",   # star imports
   "FA100",  # Missing from __future__ import annotations
+  "W605",   # Invalid escape sequences
 ]
 
 [tool.pytest.ini_options]

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -457,7 +457,7 @@ PatternOption = typer.Option(
     "--pattern",
     help=(
         "Regex pattern for filtering files by name."
-        ' For example --pattern ".*\.txt" will filter only files with .txt extension.'
+        r' For example --pattern ".*\.txt" will filter only files with .txt extension.'
     ),
     show_default=False,
     callback=_pattern_option_callback,

--- a/src/snowflake/cli/plugins/snowpark/models.py
+++ b/src/snowflake/cli/plugins/snowpark/models.py
@@ -133,7 +133,7 @@ class WheelMetadata:
     @staticmethod
     def to_wheel_name_format(package_name: str) -> str:
         # https://peps.python.org/pep-0491/#escaping-and-unicode
-        return re.sub("[^\w\d.]+", "_", package_name, re.UNICODE)
+        return re.sub(r"[^\w\d.]+", "_", package_name, re.UNICODE)
 
 
 def get_package_name(name: str) -> str:

--- a/src/snowflake/cli/plugins/snowpark/package_utils.py
+++ b/src/snowflake/cli/plugins/snowpark/package_utils.py
@@ -59,7 +59,7 @@ def parse_requirements(
         for line in requirements_file.read_text(
             file_size_limit_mb=DEFAULT_SIZE_LIMIT_MB
         ).splitlines():
-            line = re.sub("\s*#.*", "", line).strip()
+            line = re.sub(r"\s*#.*", "", line).strip()
             if line:
                 reqs.append(Requirement.parse(line))
     return reqs

--- a/tests/api/test_secure_path.py
+++ b/tests/api/test_secure_path.py
@@ -57,7 +57,7 @@ def _read_logs(logs_path: Path) -> str:
 def _assert_count_matching_logs(
     save_logs, expected_count, log_prefix, filename, log_suffix=""
 ):
-    regex = f"INFO \[snowflake\.cli\.api\.secure_path\] {log_prefix} \S+{filename}{log_suffix}"
+    regex = rf"INFO \[snowflake\.cli\.api\.secure_path\] {log_prefix} \S+{filename}{log_suffix}"
     logs = _read_logs(save_logs).splitlines()
     count = sum(1 for line in logs if re.search(regex, line) is not None)
     assert count == expected_count
@@ -210,7 +210,7 @@ def test_permissions(temp_dir, save_logs):
 def test_mkdir(temp_dir, save_logs, _widen_umask_for_testing):
     dir1 = SecurePath(temp_dir) / "dir1"
     dir2 = SecurePath(temp_dir) / "dir2" / "a" / "b" / "c" / "d"
-    dir2_regex = "[\/]".join(["dir2", "a", "b", "c", "d"])
+    dir2_regex = r"[\/]".join(["dir2", "a", "b", "c", "d"])
 
     dir1.mkdir()
     _assert_count_matching_logs(save_logs, 1, "Creating directory", "dir1")
@@ -262,7 +262,7 @@ def test_move(temp_dir, save_logs):
     assert moved_file.path.exists() and not file.exists()
     assert moved_file.path == Path("moved_file.txt")
     _assert_count_matching_logs(
-        save_logs, 1, "Moving", "file.txt", " to \S+moved_file.txt"
+        save_logs, 1, "Moving", "file.txt", r" to \S+moved_file.txt"
     )
 
     file = SecurePath(_get_new_file())
@@ -275,7 +275,7 @@ def test_move(temp_dir, save_logs):
     assert moved_file.exists() and not file.exists()
     assert moved_file.path.resolve() == (Path("dir") / "file.txt").resolve()
     _assert_count_matching_logs(
-        save_logs, 1, "Moving", "file.txt", " to \S+dir[\/]file.txt"
+        save_logs, 1, "Moving", "file.txt", r" to \S+dir[\/]file.txt"
     )
 
     file = SecurePath(_get_new_file())
@@ -289,7 +289,7 @@ def test_move(temp_dir, save_logs):
     assert moved_dir.exists() and not dir_.exists()
     assert moved_dir.path == Path("moved_dir")
     _check_dir_moved("moved_dir")
-    _assert_count_matching_logs(save_logs, 1, "Moving", "dir", " to \S+moved_dir")
+    _assert_count_matching_logs(save_logs, 1, "Moving", "dir", r" to \S+moved_dir")
 
     dir_ = SecurePath(_get_new_dir())
     moved_dir = dir_.move("moved_dir")
@@ -297,7 +297,7 @@ def test_move(temp_dir, save_logs):
     assert moved_dir.path == Path("moved_dir") / "dir"
     _check_dir_moved(Path("moved_dir") / "dir")
     _assert_count_matching_logs(
-        save_logs, 1, "Moving", "dir", " to \S+moved_dir[\/]dir"
+        save_logs, 1, "Moving", "dir", r" to \S+moved_dir[\/]dir"
     )
 
     dir_ = SecurePath(_get_new_dir())
@@ -326,10 +326,10 @@ def test_copy_file(temp_dir, save_logs, _widen_umask_for_testing):
     assert_file_permissions_are_strict(copied_file.path)
 
     _assert_count_matching_logs(
-        save_logs, 1, "Copying file", "file.txt", " into \S+file.copy.txt"
+        save_logs, 1, "Copying file", "file.txt", r" into \S+file.copy.txt"
     )
     _assert_count_matching_logs(
-        save_logs, 1, "Copying file", "file.txt", " into \S+a_directory[\/]file.txt"
+        save_logs, 1, "Copying file", "file.txt", r" into \S+a_directory[\/]file.txt"
     )
 
 
@@ -499,7 +499,7 @@ def test_rm(temp_dir, save_logs):
     with pytest.raises(DirectoryIsNotEmptyError):
         SecurePath(full_dir).rmdir()
     SecurePath(full_dir).rmdir(recursive=True)
-    _assert_count_matching_logs(save_logs, 1, "Removing directory", "base[\/]full")
+    _assert_count_matching_logs(save_logs, 1, "Removing directory", r"base[\/]full")
 
     with pytest.raises(FileNotFoundError):
         SecurePath(full_dir).rmdir(recursive=True)


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
Fixes all the `DeprerationWarning`/`SyntaxWarning` (depending on your version of Python) due to backslashes in strings that aren't valid Python escapes. These strings are used as regexes, where the literal backslash is significant, so we should mark them as raw strings.
