### PR TITLE
Prevent accidentally clobbering artifacts in native app projects

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@
 * Fixed MFA caching
 * Fixed `DeprerationWarning`/`SyntaxWarning` due to invalid escape sequences
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
+* Improved detection of problematic artifact rules for native application projects
 
 # v2.4.0
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@
 * Fixed MFA caching
 * Fixed `DeprerationWarning`/`SyntaxWarning` due to invalid escape sequences
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
-* Improved detection of problematic artifact rules for native application projects
+* Improved detection of conflicts between artifact rules for native application projects
 
 # v2.4.0
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -118,7 +118,7 @@ class _ArtifactPathMap:
         self.__src_to_dest: Dict[Path, List[Path]] = {}
         self.__dest_to_src: Dict[Path, List[Path]] = {}
 
-        # This dictionary accumulates keys for each directory or file to be  created in
+        # This dictionary accumulates keys for each directory or file to be created in
         # the deploy root for any artifact mapping rule being processed. This includes
         # children of directories that are copied to the deploy root. Having this
         # information available is critical to detect possible clashes between rules.

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -126,7 +126,10 @@ class _ArtifactPathMap:
 
     def put(self, src: Path, dest: Path, dest_is_dir: bool) -> None:
         """
-        Adds a new source-destination mapping pair to this map, if necessary.
+        Adds a new source-destination mapping pair to this map, if necessary. Note that
+        this is internal logic that assumes that src-dest pairs have already been preprocessed
+        by the enclosing BundleMap (for example, only file -> file and
+        directory -> directory mappings are possible here due to the preprocessing step).
 
         Arguments:
             src {Path} -- the source path, in canonical form.

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -117,6 +117,11 @@ class _ArtifactPathMap:
         # built-in dict instances are ordered as of Python 3.7
         self.__src_to_dest: Dict[Path, List[Path]] = {}
         self.__dest_to_src: Dict[Path, List[Path]] = {}
+
+        # This dictionary accumulates keys for each directory or file to be  created in
+        # the deploy root for any artifact mapping rule being processed. This includes
+        # children of directories that are copied to the deploy root. Having this
+        # information available is critical to detect possible clashes between rules.
         self._dest_is_dir: Dict[Path, bool] = {}
 
     def put(self, src: Path, dest: Path, dest_is_dir: bool) -> None:
@@ -160,7 +165,7 @@ class _ArtifactPathMap:
                 for f in files:
                     self._update_dest_is_dir(canonical_dest_subdir / f, is_dir=False)
 
-        # make sure we check of dest_is_dir consistency regardless of whether the
+        # make sure we check for dest_is_dir consistency regardless of whether the
         # insertion happened. This update can fail, so we need to do it first to
         # avoid applying partial updates to the underlying data storage.
         self._update_dest_is_dir(dest, dest_is_dir)

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -304,7 +304,7 @@ class BundleMap:
         """
         self._add_mapping(mapping.src, mapping.dest)
 
-    def _yield_all(
+    def _expand_artifact_mapping(
         self,
         src: Path,
         dest: Path,
@@ -369,7 +369,7 @@ class BundleMap:
           An iterator over all matching deployed artifacts.
         """
         for src, dest in self._artifact_map:
-            for deployed_src, deployed_dest in self._yield_all(
+            for deployed_src, deployed_dest in self._expand_artifact_mapping(
                 src,
                 dest,
                 absolute=absolute,

--- a/tests_integration/nativeapp/test_bundle.py
+++ b/tests_integration/nativeapp/test_bundle.py
@@ -301,7 +301,8 @@ def test_nativeapp_bundle_throws_error_on_too_many_files_to_dest(template_setup)
         )
         assert result.exit_code == 1
         assert_that_result_failed_with_message_containing(
-            result, "Multiple files were mapped to one output file."
+            result,
+            "Multiple file or directories were mapped to one output destination.",
         )
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

Artifact rules could allow artifacts to be clobbered in certain cases. This change introduces two fixes that, combined, prevent these invalid rules from being accepted. First, additional checks are introduced to verify overlap between rules. Second, in order to make sure valid cases are processed correctly, the logic has been modified to keep track of individual insertion order for (src, dest) pairs. This way, we can guarantee that the deploy root will contain the correct files after the bundle step.

### Testing

- Added unit tests to cover the new behaviour
- Manually invoked the CLI using the cases fixed here to verify the deploy root directory. Some of the behaviour that becomes allowed as part of this change will require a follow-up change to remove dir symlinking in order to be enabled, however. Currently, adding new files to a previously-deployed dir can be disallowed because the directory is a symlink back into the source directory.
