### PR TITLE
URLencode paths for snowsight URLs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@
 * Fixed `DeprerationWarning`/`SyntaxWarning` due to invalid escape sequences
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
 * Improved detection of conflicts between artifact rules for native application projects
+* Fixed URL generation for applications that use a quoted identifier with spaces.
 
 # v2.4.0
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,7 +40,7 @@
 * Fixed `DeprerationWarning`/`SyntaxWarning` due to invalid escape sequences
 * Improved error message in `snow spcs image-registry login` when docker is not installed.
 * Improved detection of conflicts between artifact rules for native application projects
-* Fixed URL generation for applications that use a quoted identifier with spaces.
+* Fixed URL generation for applications, streamlits, and notebooks that use a quoted identifier with spaces.
 
 # v2.4.0
 ## Backward incompatibility

--- a/src/snowflake/cli/api/identifiers.py
+++ b/src/snowflake/cli/api/identifiers.py
@@ -20,7 +20,7 @@ from click import ClickException
 from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.exceptions import FQNInconsistencyError, FQNNameError
 from snowflake.cli.api.project.schemas.identifier_model import ObjectIdentifierBaseModel
-from snowflake.cli.api.project.util import VALID_IDENTIFIER_REGEX, unquote_identifier
+from snowflake.cli.api.project.util import VALID_IDENTIFIER_REGEX, identifier_for_url
 
 
 class FQN:
@@ -62,7 +62,7 @@ class FQN:
 
     @property
     def url_identifier(self) -> str:
-        return ".".join(unquote_identifier(part) for part in self.identifier.split("."))
+        return ".".join(identifier_for_url(part) for part in self.identifier.split("."))
 
     def __str__(self):
         return self.identifier

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -18,6 +18,7 @@ import codecs
 import os
 import re
 from typing import Optional
+from urllib.parse import quote
 
 IDENTIFIER = r'((?:"[^"]*(?:""[^"]*)*")|(?:[A-Za-z_][\w$]{0,254}))'
 IDENTIFIER_NO_LENGTH = r'((?:"[^"]*(?:""[^"]*)*")|(?:[A-Za-z_][\w$]*))'
@@ -32,6 +33,13 @@ SINGLE_QUOTED_STRING_LITERAL_REGEX = r"'((?:\\.|''|[^'\n])+?)'"
 UNQUOTED_IDENTIFIER_REGEX = r"([a-zA-Z_])([a-zA-Z0-9_$]{0,254})"
 QUOTED_IDENTIFIER_REGEX = r'"((""|[^"]){0,255})"'
 VALID_IDENTIFIER_REGEX = f"(?:{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})"
+
+
+def encode_uri_component(s: str) -> str:
+    """
+    Implementation of JavaScript's encodeURIComponent.
+    """
+    return quote(s, safe="!~*'()")
 
 
 def clean_identifier(input_: str):
@@ -106,14 +114,21 @@ def append_to_identifier(identifier: str, suffix: str) -> str:
 
 def unquote_identifier(identifier: str) -> str:
     """
-    Returns a version of this identifier that can be used inside of a URL,
-    inside of a string for a LIKE clause, or to match an identifier passed
-    back as a value from a SQL statement.
+    Returns a version of this identifier that can be used inside of a
+    string for a LIKE clause, or to match an identifier passed back as
+    a value from a SQL statement.
     """
     if match := re.fullmatch(QUOTED_IDENTIFIER_REGEX, identifier):
         return match.group(1).replace('""', '"')
     # unquoted identifiers are internally represented as uppercase
     return identifier.upper()
+
+
+def identifier_for_url(identifier: str) -> str:
+    """
+    Returns a version of this identifier that can be used as part of a URL.
+    """
+    return encode_uri_component(unquote_identifier(identifier))
 
 
 def is_valid_string_literal(literal: str) -> bool:

--- a/src/snowflake/cli/plugins/connection/util.py
+++ b/src/snowflake/cli/plugins/connection/util.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import logging
+from urllib.parse import quote
 
 from click.exceptions import ClickException
 from snowflake.connector import SnowflakeConnection
 from snowflake.connector.cursor import DictCursor
 
 LOCAL_DEPLOYMENT: str = "us-west-2"
+SAFE_PATH_CHARS = "/#"
 
 log = logging.getLogger(__name__)
 
@@ -112,7 +114,9 @@ def get_snowsight_host(conn: SnowflakeConnection) -> str:
 def make_snowsight_url(conn: SnowflakeConnection, path: str) -> str:
     """Returns a URL on the correct Snowsight instance for the connected account."""
     snowsight_host = get_snowsight_host(conn)
-    deployment = get_context(conn)
-    account = get_account(conn)
-    path_with_slash = path if path.startswith("/") else f"/{path}"
-    return f"{snowsight_host}/{deployment}/{account}{path_with_slash}"
+    deployment = quote(get_context(conn))
+    account = quote(get_account(conn))
+    path_without_slash = quote(
+        path[1:] if path.startswith("/") else path, safe=SAFE_PATH_CHARS
+    )
+    return f"{snowsight_host}/{deployment}/{account}/{path_without_slash}"

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -35,6 +35,7 @@ from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.util import (
     extract_schema,
+    identifier_for_url,
     to_identifier,
     unquote_identifier,
 )
@@ -487,7 +488,7 @@ class NativeAppManager(SqlExecutionMixin):
 
     def get_snowsight_url(self) -> str:
         """Returns the URL that can be used to visit this app via Snowsight."""
-        name = unquote_identifier(self.app_name)
+        name = identifier_for_url(self.app_name)
         return make_snowsight_url(self._conn, f"/#/apps/application/{name}")
 
     def create_app_package(self) -> None:

--- a/tests/api/test_fqn.py
+++ b/tests/api/test_fqn.py
@@ -47,7 +47,7 @@ def test_quoted_identifier():
         ),
         (
             FQN(name='"quoted name"', database="database_name", schema="schema_name"),
-            "DATABASE_NAME.SCHEMA_NAME.quoted name",
+            "DATABASE_NAME.SCHEMA_NAME.quoted%20name",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,7 @@ def test_pip_fail_message(mock_installer, correct_requirements_txt, caplog):
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "identifier, expected",
     [
         ("my_app", "MY_APP"),
         ('"My App"', "My%20App"),
@@ -177,8 +177,8 @@ def test_pip_fail_message(mock_installer, correct_requirements_txt, caplog):
         ('"Mailorder *App* is /cool/"', "Mailorder%20*App*%20is%20%2Fcool%2F"),
     ],
 )
-def test_identifier_for_url(input, expected):
-    assert identifier_for_url(input) == expected
+def test_identifier_for_url(identifier, expected):
+    assert identifier_for_url(identifier) == expected
 
 
 @patch("snowflake.cli.plugins.connection.util.get_account")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,6 +167,20 @@ def test_pip_fail_message(mock_installer, correct_requirements_txt, caplog):
     assert "pip failed with return code 42" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("my_app", "MY_APP"),
+        ('"My App"', "My%20App"),
+        ("SYSTEM$GET", "SYSTEM%24GET"),
+        ("mailorder_!@#$%^&*()/_app", "MAILORDER_!%40%23%24%25%5E%26*()%2F_APP"),
+        ('"Mailorder *App* is /cool/"', "Mailorder%20*App*%20is%20%2Fcool%2F"),
+    ],
+)
+def test_identifier_for_url(input, expected):
+    assert identifier_for_url(input) == expected
+
+
 @patch("snowflake.cli.plugins.connection.util.get_account")
 @patch("snowflake.cli.plugins.connection.util.get_context")
 @patch("snowflake.cli.plugins.connection.util.get_snowsight_host")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 import snowflake.cli.plugins.snowpark.models
 import snowflake.cli.plugins.snowpark.package.utils
+from snowflake.cli.api.project.util import identifier_for_url
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.utils import path_utils
 from snowflake.cli.plugins.connection.util import make_snowsight_url
@@ -180,14 +181,14 @@ def test_pip_fail_message(mock_installer, correct_requirements_txt, caplog):
         ),
         (
             "host",
-            "some+account",
-            "Quoted App Name",
-            "https://app.snowflake.com/host/some%2Baccount/Quoted%20App%20Name",
+            identifier_for_url("some$account"),
+            identifier_for_url('"Quoted App Name"'),
+            "https://app.snowflake.com/host/SOME%24ACCOUNT/Quoted%20App%20Name",
         ),
         (
             "a",
             "b",
-            "/some/path/on the server",
+            f"""/some/path/{identifier_for_url('"on the server"')}""",
             "https://app.snowflake.com/a/b/some/path/on%20the%20server",
         ),
         (


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added an `identifier_for_url` utility which, combined with `make_snowsight_url`, allows us to build URLs based on quoted identifiers that use esoteric characters (like spaces). I have tested that these URLs are successfully resolved by Snowsight when the application is looked up:

```
% snow app init --name 'My ()Friendly() App' my_friendly_app
% cd my_friendly_app
% snow app run
[...]
https://app.snowflake.com/<redacted>/<redacted>/#/apps/application/My%20()Friendly()%20App_cgorrie
% snow app open
# manually verified the visited URL opens up the deployed application
% snow app teardown
```