### PR TITLE
Temporarily fix handing of python file paths on Windows during Snowpark decorator processing

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
@@ -169,7 +169,7 @@ try:
     import importlib
     with contextlib.redirect_stdout(None):
         with contextlib.redirect_stderr(None):
-            __snowflake_internal_spec = importlib.util.spec_from_file_location("<string>", "{{py_file}}")
+            __snowflake_internal_spec = importlib.util.spec_from_file_location("<string>", r"{{py_file}}")
             __snowflake_internal_module = importlib.util.module_from_spec(__snowflake_internal_spec)
             __snowflake_internal_spec.loader.exec_module(__snowflake_internal_module)
 except Exception as exc:  # Catch any error


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
This is a short-term fix for a blocking bug during setup script generation on Windows. Since the paths are not correctly escape, any '\' character is treated as an escape sequence, and the generation step fails. This fix will unblock 2.5.0 with minimal risk. We'll work on a better fix for the next patch release, or the next major release, whichever comes first.

### Testing
Manually tested this fix on Windows. Verified that MacOS still works.