### PR TITLE
Add project definition version to telemetry

### DIFF
--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -264,7 +264,7 @@ class _CliGlobalContextManager:
     def project_definition(self) -> Optional[Dict]:
         return self._project_definition
 
-    def set_project_definition(self, value: Dict):
+    def set_project_definition(self, value: ProjectDefinition):
         self._project_definition = value
 
     @property

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -505,10 +505,10 @@ def project_type_option(project_name: str):
 
     def _callback(project_path: Optional[str]):
         dm = DefinitionManager(project_path)
-        project_definition = getattr(dm.project_definition, project_name, None)
+        project_definition = dm.project_definition
         project_root = dm.project_root
 
-        if not project_definition:
+        if not getattr(project_definition, project_name, None):
             raise NoProjectDefinitionError(
                 project_type=project_name, project_file=project_path
             )

--- a/src/snowflake/cli/app/telemetry.py
+++ b/src/snowflake/cli/app/telemetry.py
@@ -76,16 +76,16 @@ def _find_command_info() -> TelemetryDict:
         CLITelemetryField.COMMAND_OUTPUT_TYPE: ctx.params.get(
             "format", OutputFormat.TABLE
         ).value,
-        CLITelemetryField.PROJECT_DEFINITION_VERSION: _get_definition_version(),
+        CLITelemetryField.PROJECT_DEFINITION_VERSION: str(_get_definition_version()),
     }
 
 
-def _get_definition_version() -> str:
+def _get_definition_version() -> str | None:
     from snowflake.cli.api.cli_global_context import cli_context
 
     if cli_context.project_definition:
         return cli_context.project_definition.definition_version
-    return "no_definition"
+    return None
 
 
 def command_info() -> str:

--- a/src/snowflake/cli/app/telemetry.py
+++ b/src/snowflake/cli/app/telemetry.py
@@ -51,6 +51,8 @@ class CLITelemetryField(Enum):
     EVENT = "event"
     ERROR_MSG = "error_msg"
     ERROR_TYPE = "error_type"
+    # Project context
+    PROJECT_DEFINITION_VERSION = "project_definition_version"
 
 
 class TelemetryEvent(Enum):
@@ -74,7 +76,16 @@ def _find_command_info() -> TelemetryDict:
         CLITelemetryField.COMMAND_OUTPUT_TYPE: ctx.params.get(
             "format", OutputFormat.TABLE
         ).value,
+        CLITelemetryField.PROJECT_DEFINITION_VERSION: _get_definition_version(),
     }
+
+
+def _get_definition_version() -> str:
+    from snowflake.cli.api.cli_global_context import cli_context
+
+    if cli_context.project_definition:
+        return cli_context.project_definition.definition_version
+    return "no_definition"
 
 
 def command_info() -> str:

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -153,7 +153,7 @@ def app_bundle(
     Prepares a local folder with configured app artifacts.
     """
     manager = NativeAppManager(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     manager.build_bundle()
@@ -201,7 +201,7 @@ def app_run(
         policy = DenyAlwaysPolicy()
 
     processor = NativeAppRunProcessor(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     bundle_map = processor.build_bundle()
@@ -230,7 +230,7 @@ def app_open(
     once it has been installed in your account.
     """
     manager = NativeAppManager(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     if manager.get_existing_app_info():
@@ -258,7 +258,7 @@ def app_teardown(
     Attempts to drop both the application object and application package as defined in the project definition file.
     """
     processor = NativeAppTeardownProcessor(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     processor.process(interactive, force, cascade)
@@ -310,7 +310,7 @@ def app_deploy(
         raise ClickException("--prune cannot be used when paths are also specified")
 
     manager = NativeAppManager(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
 
@@ -335,7 +335,7 @@ def app_validate(**options):
     Validates a deployed Snowflake Native App's setup script.
     """
     manager = NativeAppManager(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     if cli_context.output_format == OutputFormat.JSON:

--- a/src/snowflake/cli/plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/commands.py
@@ -89,7 +89,7 @@ def create(
         git_policy = AllowAlwaysPolicy()
 
     processor = NativeAppVersionCreateProcessor(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
 
@@ -115,7 +115,7 @@ def version_list(
     Lists all versions defined in an application package.
     """
     processor = NativeAppRunProcessor(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     cursor = processor.get_all_existing_versions()
@@ -147,7 +147,7 @@ def drop(
         policy = DenyAlwaysPolicy()
 
     processor = NativeAppVersionDropProcessor(
-        project_definition=cli_context.project_definition,
+        project_definition=cli_context.project_definition.native_app,
         project_root=cli_context.project_root,
     )
     processor.process(version, policy, is_interactive)

--- a/src/snowflake/cli/plugins/snowpark/commands.py
+++ b/src/snowflake/cli/plugins/snowpark/commands.py
@@ -128,7 +128,7 @@ def deploy(
     By default, if any of the objects exist already the commands will fail unless `--replace` flag is provided.
     All deployed objects use the same artifact which is deployed only once.
     """
-    snowpark = cli_context.project_definition
+    snowpark = cli_context.project_definition.snowpark
     paths = SnowparkPackagePaths.for_snowpark_project(
         project_root=SecurePath(cli_context.project_root),
         snowpark_project_definition=snowpark,
@@ -400,7 +400,7 @@ def build(
         ignore_anaconda = True
     snowpark_paths = SnowparkPackagePaths.for_snowpark_project(
         project_root=SecurePath(cli_context.project_root),
-        snowpark_project_definition=cli_context.project_definition,
+        snowpark_project_definition=cli_context.project_definition.snowpark,
     )
     log.info("Building package using sources from: %s", snowpark_paths.source.path)
 

--- a/src/snowflake/cli/plugins/streamlit/commands.py
+++ b/src/snowflake/cli/plugins/streamlit/commands.py
@@ -122,7 +122,7 @@ def streamlit_deploy(
     environment.yml and any other pages or folders, if present. If you don’t specify a stage name, the `streamlit`
     stage is used. If the specified stage does not exist, the command creates it.
     """
-    streamlit: Streamlit = cli_context.project_definition
+    streamlit: Streamlit = cli_context.project_definition.streamlit
     if not streamlit:
         return MessageResult("No streamlit were specified in project definition.")
 

--- a/test_external_plugins/multilingual_hello_command_group/src/snowflakecli/test_plugins/multilingual_hello/commands.py
+++ b/test_external_plugins/multilingual_hello_command_group/src/snowflakecli/test_plugins/multilingual_hello/commands.py
@@ -13,19 +13,14 @@
 # limitations under the License.
 
 import typer
-from snowflake.cli.api.commands.decorators import (
-    global_options_with_connection,
-    with_output,
-)
-from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
+from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import CommandResult, SingleQueryResult
 from snowflakecli.test_plugins.multilingual_hello.hello_language import HelloLanguage
 from snowflakecli.test_plugins.multilingual_hello.manager import (
     MultilingualHelloManager,
 )
 
-app = typer.Typer(
-    context_settings=DEFAULT_CONTEXT_SETTINGS,
+app = SnowTyper(
     name="multilingual-hello",
     help="Says hello in various languages",
 )
@@ -40,9 +35,7 @@ def _hello(
     return SingleQueryResult(cursor)
 
 
-@app.command("hello-en")
-@with_output
-@global_options_with_connection
+@app.command("hello-en", requires_connection=True)
 def hello_en(
     name: str = typer.Argument(help="Your name"),
     **options,
@@ -53,9 +46,7 @@ def hello_en(
     return _hello(name, HelloLanguage.en)
 
 
-@app.command("hello-fr")
-@with_output
-@global_options_with_connection
+@app.command("hello-fr", requires_connection=True)
 def hello_fr(
     name: str = typer.Argument(help="Your name"),
     **options,
@@ -66,9 +57,7 @@ def hello_fr(
     return _hello(name, HelloLanguage.fr)
 
 
-@app.command("hello")
-@with_output
-@global_options_with_connection
+@app.command("hello", requires_connection=True)
 def hello(
     name: str = typer.Argument(help="Your name"),
     language: HelloLanguage = typer.Option(..., "--language", help="Your language"),

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -53,7 +53,7 @@ def test_executing_command_sends_telemetry_data(
             "command_flags": {"diag_log_path": "DEFAULT", "format": "DEFAULT"},
             "command_output_type": "TABLE",
             "type": "executing_command",
-            "project_definition_version": "no_definition",
+            "project_definition_version": "None",
             "config_feature_flags": {
                 "dummy_flag": "True",
                 "foo": "False",


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added `definition_version` information in telemetry dict. This required to change `cli_context.project_definition` to be a full project definition instead of streamlit/snowpark/native_app section.
