### PR TITLE
[SNOW-1362197] Abort teardown if we don't drop application

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 
 ## Fixes and improvements
 * Passing a directory to `snow app deploy` will now deploy any contained file or subfolder specified in the application's artifact rules
+* Fixed case where `snow app teardown` could leave behind orphan applications if they were not created by the Snowflake CLI
 
 # v2.5.0
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/teardown_processor.py
@@ -88,7 +88,7 @@ class NativeAppTeardownProcessor(NativeAppManager, NativeAppCommandProcessor):
 
         needs_confirm = True
 
-        # 1. If existing application package is not found, exit gracefully
+        # 1. If existing application is not found, exit gracefully
         show_obj_row = self.get_existing_app_info()
         if show_obj_row is None:
             cc.warning(
@@ -124,7 +124,9 @@ class NativeAppTeardownProcessor(NativeAppManager, NativeAppCommandProcessor):
             )
             if not should_drop_object:
                 cc.message(f"Did not drop application object {self.app_name}.")
-                return  # The user desires to keep the app, therefore exit gracefully
+                # The user desires to keep the app, therefore we can't proceed since it would
+                # leave behind an orphan app when we get to dropping the package
+                raise typer.Abort()
 
         # 4. Check for application objects owned by the application
         application_objects = self.get_objects_owned_by_application()

--- a/tests/nativeapp/test_teardown_processor.py
+++ b/tests/nativeapp/test_teardown_processor.py
@@ -16,6 +16,7 @@ import os
 from unittest import mock
 
 import pytest
+import typer
 from click import Abort
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli.plugins.nativeapp.constants import (
@@ -331,7 +332,8 @@ def test_drop_application_user_prohibits_drop(
     )
 
     teardown_processor = _get_na_teardown_processor()
-    teardown_processor.drop_application(auto_yes=False)
+    with pytest.raises(typer.Abort):
+        teardown_processor.drop_application(auto_yes=False)
     mock_get_existing_app_info.assert_called_once()
     mock_is_correct_owner.assert_called_once()
     mock_drop_generic_object.assert_not_called()


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * [X] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
If we find that the app isn't "owned" by the CLI (i.e. the object's comment isn't what we expect it to be), and the user says that they don't want to drop that app, abort the teardown since dropping the package afterwards would leave the app orphaned and non-functional.

No need to handle `--force` any differently since passing `--force` forces dropping the app anyways. With the current CLI flags, it's no longer possible to create orphan apps.

Denying the drop:
![image](https://github.com/snowflakedb/snowflake-cli/assets/171080004/766555f2-3961-4cfc-9cdc-71588d0a3ae9)

Forcing the drop:
![image](https://github.com/snowflakedb/snowflake-cli/assets/171080004/02b0a3a2-1e30-4aaf-b453-d4771c5138c6)


