### PR TITLE
Fix bugs with templating env section, and case sensitivity on Windows

### DIFF
--- a/src/snowflake/cli/api/utils/models.py
+++ b/src/snowflake/cli/api/utils/models.py
@@ -17,8 +17,26 @@ from __future__ import annotations
 import os
 from typing import Any, Dict
 
+from snowflake.cli.api.exceptions import InvalidTemplate
+
+
+def _validate_env(current_env: dict):
+    if not isinstance(current_env, dict):
+        raise InvalidTemplate(
+            "env section in project definition file should be a mapping"
+        )
+    for variable, value in current_env.items():
+        if value is None or isinstance(value, (dict, list)):
+            raise InvalidTemplate(
+                f"Variable {variable} in env section or project definition file should be a scalar"
+            )
+
 
 class EnvironWithDefinedDictFallback(Dict):
+    def __init__(self, dict_input: dict):
+        _validate_env(dict_input)
+        super().__init__(dict_input)
+
     def __getattr__(self, item):
         try:
             return self[item]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix bugs related to env section of project definition file:
- Verified that env section is a yaml mapping.
- Verified that each env variable only contains scalar.
- Fixed a Windows bug related to case sensitivity, affecting sql commands only: Because we are copying os.environ to a dict, all Windows env variables become uppercase, forcing windows users to always use uppercase to reference their env variables, even if they defined them as lowercase on windows (Windows env variables are case insensitive).

To reproduce on Windows Powershell:
```
$env:test='test_value'
"select '&{ ctx.env.test }'" # this will result in an error.
```