### PR TITLE
[NADE][Bugfix] Convert to stagepaths before writing to SQL files

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -510,7 +510,9 @@ def edit_setup_script_with_exec_imm_sql(
             sql_file_relative_path = sql_file.relative_to(
                 deploy_root
             )  # Path on stage, without the leading slash
-            file.write(f"EXECUTE IMMEDIATE FROM '/{sql_file_relative_path}';\n")
+            file.write(
+                f"EXECUTE IMMEDIATE FROM '/{to_stage_path(sql_file_relative_path)}';\n"
+            )
 
     # Find the setup script in the deploy root.
     setup_file_path = find_setup_script_file(deploy_root=deploy_root)
@@ -524,5 +526,7 @@ def edit_setup_script_with_exec_imm_sql(
     generated_file_relative_path = generated_file_path.relative_to(deploy_root)
     with open(setup_file_path, "w", encoding="utf-8") as file:
         file.write(code)
-        file.write(f"\nEXECUTE IMMEDIATE FROM '/{generated_file_relative_path}';")
+        file.write(
+            f"\nEXECUTE IMMEDIATE FROM '/{to_stage_path(generated_file_relative_path)}';"
+        )
         file.write(f"\n")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
On windows, there is currently a bug where appending relative file paths to a sql file that will be uploaded to a Snowflake stage is done incorrectly. 
E.g. if a file `__generated.sql` exists in a path `some\path\__generated\__generated.sql`, then the correct string to append to the sql file should be `EXECUTE IMMEDIATE FROM '/__generated/__generated.sql';`, but the bug currently causes this: `EXECUTE IMMEDIATE FROM '/__generated\__generated.sql';`. This PR is to correct the bug.
