### PR TITLE
Add support for --env overrides from command line for templating

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,10 @@
   * Format of the argument: `--env key1=value1 --env key2=value2`.
   * Overrides `env` variables values when used in templating.
   * Can be referenced in templating through `ctx.env.<key_name>`.
+  * Templating will read env vars in this order of priority (highest priority to lowest priority):
+    * vars from `--env` command line argument.
+    * vars from shell environment variables.
+    * vars from `env` section of project definition file.
 
 ## Fixes and improvements
 * Passing a directory to `snow app deploy` will now deploy any contained file or subfolder specified in the application's artifact rules

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,11 @@
 * Added `--auto-compress` flag to `snow stage copy` command enabling use of gzip to compress files during upload.
 * Added new `native_app.application.post_deploy` section to `snowflake.yml` schema to execute actions after the application has been deployed via `snow app run`.
   * Added the `sql_script` hook type to run SQL scripts with template support.
+* Added support for `--env` command line arguments for templating.
+  * Available for commands that make use of the project definition file.
+  * Format of the argument: `--env key1=value1 --env key2=value2`.
+  * Overrides `env` variables values when used in templating.
+  * Can be referenced in templating through `ctx.env.<key_name>`.
 
 ## Fixes and improvements
 * Passing a directory to `snow app deploy` will now deploy any contained file or subfolder specified in the application's artifact rules

--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -227,7 +227,7 @@ class _CliGlobalContextManager:
         self._project_definition = None
         self._project_root = None
         self._project_path_arg = None
-        self._project_env_overrides_args = []
+        self._project_env_overrides_args = {}
         self._typer_pre_execute_commands = []
         self._template_context = None
         self._silent: bool = False
@@ -285,10 +285,12 @@ class _CliGlobalContextManager:
         self._project_path_arg = project_path_arg
 
     @property
-    def project_env_overrides_args(self) -> list[str]:
+    def project_env_overrides_args(self) -> dict[str, str]:
         return self._project_env_overrides_args
 
-    def set_project_env_overrides_args(self, project_env_overrides_args: list[str]):
+    def set_project_env_overrides_args(
+        self, project_env_overrides_args: dict[str, str]
+    ):
         self._project_env_overrides_args = project_env_overrides_args
 
     @property

--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Callable, Optional
 
 from snowflake.cli.api.exceptions import InvalidSchemaError
 from snowflake.cli.api.output.formats import OutputFormat
@@ -226,6 +226,9 @@ class _CliGlobalContextManager:
         self._experimental = False
         self._project_definition = None
         self._project_root = None
+        self._project_path_arg = None
+        self._project_env_overrides_args = []
+        self._typer_pre_execute_commands = []
         self._template_context = None
         self._silent: bool = False
 
@@ -261,7 +264,7 @@ class _CliGlobalContextManager:
         self._experimental = value
 
     @property
-    def project_definition(self) -> Optional[Dict]:
+    def project_definition(self) -> Optional[ProjectDefinition]:
         return self._project_definition
 
     def set_project_definition(self, value: ProjectDefinition):
@@ -275,11 +278,34 @@ class _CliGlobalContextManager:
         self._project_root = project_root
 
     @property
+    def project_path_arg(self) -> Optional[str]:
+        return self._project_path_arg
+
+    def set_project_path_arg(self, project_path_arg: str):
+        self._project_path_arg = project_path_arg
+
+    @property
+    def project_env_overrides_args(self) -> list[str]:
+        return self._project_env_overrides_args
+
+    def set_project_env_overrides_args(self, project_env_overrides_args: list[str]):
+        self._project_env_overrides_args = project_env_overrides_args
+
+    @property
     def template_context(self) -> dict:
         return self._template_context
 
     def set_template_context(self, template_context: dict):
         self._template_context = template_context
+
+    @property
+    def typer_pre_execute_commands(self) -> list[Callable[[], None]]:
+        return self._typer_pre_execute_commands
+
+    def add_typer_pre_execute_commands(
+        self, typer_pre_execute_command: Callable[[], None]
+    ):
+        self._typer_pre_execute_commands.append(typer_pre_execute_command)
 
     @property
     def connection_context(self) -> _ConnectionContext:

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -566,7 +566,7 @@ def project_env_overrides_option():
     return typer.Option(
         [],
         "--env",
-        help="String in format of key=value. Overrides env variables used for templating.",
+        help="String in format of key=value. Overrides variables from env section used for templating.",
         callback=_callback(lambda: project_env_overrides_callback),
         show_default=False,
     )

--- a/src/snowflake/cli/api/commands/snow_typer.py
+++ b/src/snowflake/cli/api/commands/snow_typer.py
@@ -25,6 +25,7 @@ from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
 )
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
+from snowflake.cli.api.commands.typer_pre_execute import run_pre_execute_commands
 from snowflake.cli.api.exceptions import CommandReturnTypeError
 from snowflake.cli.api.output.types import CommandResult
 from snowflake.cli.api.sanitizers import sanitize_for_terminal
@@ -116,6 +117,7 @@ class SnowTyper(typer.Typer):
         from snowflake.cli.app.telemetry import log_command_usage
 
         log.debug("Executing command pre execution callback")
+        run_pre_execute_commands()
         log_command_usage()
 
     @staticmethod

--- a/src/snowflake/cli/api/commands/typer_pre_execute.py
+++ b/src/snowflake/cli/api/commands/typer_pre_execute.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+
+from snowflake.cli.api.cli_global_context import cli_context_manager
+
+
+def register_pre_execute_command(command: Callable[[], None]) -> None:
+    cli_context_manager.add_typer_pre_execute_commands(command)
+
+
+def run_pre_execute_commands() -> None:
+    for command in cli_context_manager.typer_pre_execute_commands:
+        command()

--- a/src/snowflake/cli/api/project/definition.py
+++ b/src/snowflake/cli/api/project/definition.py
@@ -38,10 +38,10 @@ from snowflake.cli.api.utils.types import Context, Definition
 DEFAULT_USERNAME = "unknown_user"
 
 
-def _get_merged_definitions(paths: List[Path]) -> Definition:
+def _get_merged_definitions(paths: List[Path]) -> Optional[Definition]:
     spaths: List[SecurePath] = [SecurePath(p) for p in paths]
     if len(spaths) == 0:
-        raise ValueError("Need at least one definition file.")
+        return None
 
     with spaths[0].open("r", read_file_limit_mb=DEFAULT_SIZE_LIMIT_MB) as base_yml:
         definition = yaml.load(base_yml.read(), Loader=yaml.loader.BaseLoader) or {}

--- a/src/snowflake/cli/api/project/definition.py
+++ b/src/snowflake/cli/api/project/definition.py
@@ -14,14 +14,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
 import yaml
 from snowflake.cli.api.cli_global_context import cli_context
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
-from snowflake.cli.api.project.schemas.project_definition import ProjectDefinition
+from snowflake.cli.api.project.schemas.project_definition import (
+    ProjectDefinition,
+    ProjectProperties,
+)
 from snowflake.cli.api.project.util import (
     append_to_identifier,
     clean_identifier,
@@ -34,26 +36,6 @@ from snowflake.cli.api.utils.dict_utils import deep_merge_dicts
 from snowflake.cli.api.utils.types import Context, Definition
 
 DEFAULT_USERNAME = "unknown_user"
-
-
-@dataclass
-class ProjectProperties:
-    """
-    This class stores 2 objects representing the project definition:
-
-    The raw_project_definition object:
-    - Only contains data structures like dict, list, and scalars.
-    - The purpose of the raw_project_defintion object is to represent the same structure as the yaml project definition file.
-    - This can be used as a templating context when users reference variables in the project definition file.
-
-    The project_definition object:
-    - This is a transformed object type through Pydantic, which has been normalized.
-    - This object could have slightly different structure than what the users see in their yaml project definition files.
-    - This should be used for the business logic of snow CLI modules.
-    """
-
-    project_definition: ProjectDefinition
-    raw_project_definition: Definition
 
 
 def _get_merged_definitions(paths: List[Path]) -> Definition:
@@ -85,13 +67,7 @@ def load_project(
     Templating is also applied after the merging process.
     """
     merged_definitions = _get_merged_definitions(paths)
-    rendered_definition = render_definition_template(
-        merged_definitions, context_overrides or {}
-    )
-
-    return ProjectProperties(
-        ProjectDefinition(**rendered_definition), rendered_definition
-    )
+    return render_definition_template(merged_definitions, context_overrides or {})
 
 
 def generate_local_override_yml(

--- a/src/snowflake/cli/api/project/definition_manager.py
+++ b/src/snowflake/cli/api/project/definition_manager.py
@@ -22,7 +22,6 @@ from typing import List, Optional
 from snowflake.cli.api.exceptions import MissingConfiguration
 from snowflake.cli.api.project.definition import ProjectProperties, load_project
 from snowflake.cli.api.project.schemas.project_definition import ProjectDefinition
-from snowflake.cli.api.utils.rendering import CONTEXT_KEY
 from snowflake.cli.api.utils.types import Context
 
 
@@ -131,6 +130,4 @@ class DefinitionManager:
 
     @functools.cached_property
     def template_context(self) -> Context:
-        definition = self._project_properties.raw_project_definition
-
-        return {CONTEXT_KEY: definition}
+        return self._project_properties.project_context

--- a/src/snowflake/cli/api/project/definition_manager.py
+++ b/src/snowflake/cli/api/project/definition_manager.py
@@ -42,7 +42,11 @@ class DefinitionManager:
     project_root: Path
     _project_config_paths: List[Path]
 
-    def __init__(self, project_arg: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        project_arg: Optional[str] = None,
+        context_overrides: Optional[Context] = None,
+    ) -> None:
         project_root = Path(
             os.path.abspath(project_arg) if project_arg else os.getcwd()
         )
@@ -53,6 +57,7 @@ class DefinitionManager:
 
         self.project_root = project_root
         self._project_config_paths = self._find_definition_files(self.project_root)
+        self._context_overrides = context_overrides
 
     @staticmethod
     def _find_definition_files(project_root: Path) -> List[Path]:
@@ -118,7 +123,7 @@ class DefinitionManager:
 
     @functools.cached_property
     def _project_properties(self) -> ProjectProperties:
-        return load_project(self._project_config_paths)
+        return load_project(self._project_config_paths, self._context_overrides)
 
     @functools.cached_property
     def project_definition(self) -> ProjectDefinition:

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -22,7 +22,7 @@ from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.snowpark.snowpark import Snowpark
 from snowflake.cli.api.project.schemas.streamlit.streamlit import Streamlit
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
-from snowflake.cli.api.utils.models import EnvironWithDefinedDictFallback
+from snowflake.cli.api.utils.models import ProjectEnvironment
 
 
 class _BaseDefinition(UpdatableModel):
@@ -58,17 +58,21 @@ class _DefinitionV10(_BaseDefinition):
 
 
 class _DefinitionV11(_DefinitionV10):
-    env: Optional[Dict] = Field(
+    env: Union[Dict[str, str], ProjectEnvironment, None] = Field(
         title="Environment specification for this project.",
         default=None,
         validation_alias="env",
+        union_mode="smart",
     )
 
     @field_validator("env")
     @classmethod
-    def _convert_env(cls, env: Optional[Dict]) -> EnvironWithDefinedDictFallback:
-        variables = EnvironWithDefinedDictFallback(env if env else {})
-        return variables
+    def _convert_env(
+        cls, env: Union[Dict, ProjectEnvironment, None]
+    ) -> ProjectEnvironment:
+        if isinstance(env, ProjectEnvironment):
+            return env
+        return ProjectEnvironment(default_env=(env or {}), override_env={})
 
 
 class ProjectDefinition(_DefinitionV11):

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
 from packaging.version import Version
@@ -23,6 +24,25 @@ from snowflake.cli.api.project.schemas.snowpark.snowpark import Snowpark
 from snowflake.cli.api.project.schemas.streamlit.streamlit import Streamlit
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
 from snowflake.cli.api.utils.models import ProjectEnvironment
+from snowflake.cli.api.utils.types import Context
+
+
+@dataclass
+class ProjectProperties:
+    """
+    This class stores 2 objects representing the snowflake project:
+
+    The project_context object:
+    - Used as the context for templating when users reference variables in the project definition file.
+
+    The project_definition object:
+    - This is a transformed object type through Pydantic, which has been normalized.
+    - This object could have slightly different structure than what the users see in their yaml project definition files.
+    - This should be used for the business logic of snow CLI modules.
+    """
+
+    project_definition: ProjectDefinition
+    project_context: Context
 
 
 class _BaseDefinition(UpdatableModel):

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -228,7 +228,7 @@ def _validate_env_section(env_section: dict):
     for variable, value in env_section.items():
         if value is None or isinstance(value, (dict, list)):
             raise InvalidTemplate(
-                f"Variable {variable} in env section or project definition file should be a scalar"
+                f"Variable {variable} in env section of project definition file should be a scalar"
             )
 
 

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -233,7 +233,7 @@ def _validate_env_section(env_section: dict):
 
 
 def render_definition_template(
-    original_definition: Definition, context_overrides: Context
+    original_definition: Optional[Definition], context_overrides: Context
 ) -> ProjectProperties:
     """
     Takes a definition file as input. An arbitrary structure containing dict|list|scalars,
@@ -254,6 +254,9 @@ def render_definition_template(
     environment_overrides = ProjectEnvironment(
         default_env={}, override_env=override_env
     )
+
+    if definition is None:
+        return ProjectProperties(None, {CONTEXT_KEY: {"env": environment_overrides}})
 
     project_context = {CONTEXT_KEY: definition}
 

--- a/src/snowflake/cli/api/utils/models.py
+++ b/src/snowflake/cli/api/utils/models.py
@@ -17,20 +17,7 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, Optional
 
-from snowflake.cli.api.exceptions import InvalidTemplate
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
-
-
-def _validate_env(current_env: dict):
-    if not isinstance(current_env, dict):
-        raise InvalidTemplate(
-            "env section in project definition file should be a mapping"
-        )
-    for variable, value in current_env.items():
-        if value is None or isinstance(value, (dict, list)):
-            raise InvalidTemplate(
-                f"Variable {variable} in env section or project definition file should be a scalar"
-            )
 
 
 class ProjectEnvironment(UpdatableModel):
@@ -50,7 +37,6 @@ class ProjectEnvironment(UpdatableModel):
     def __init__(
         self, default_env: Dict[str, Any], override_env: Optional[Dict[str, Any]] = None
     ):
-        _validate_env(default_env)
         super().__init__(self, default_env=default_env, override_env=override_env or {})
 
     def __getitem__(self, item):
@@ -59,6 +45,12 @@ class ProjectEnvironment(UpdatableModel):
         if item in os.environ:
             return os.environ[item]
         return self.default_env[item]
+
+    def get(self, item, default=None):
+        try:
+            return self[item]
+        except KeyError:
+            return default
 
     def __contains__(self, item) -> bool:
         try:

--- a/src/snowflake/cli/api/utils/rendering.py
+++ b/src/snowflake/cli/api/utils/rendering.py
@@ -63,10 +63,31 @@ def _env_bootstrap(env: Environment) -> Environment:
     return env
 
 
+class IgnoreAttrEnvironment(Environment):
+    """
+    extend Environment class and ignore attributes during rendering.
+    This ensures that attributes of classes
+    do not get used during rendering (e.g. __class__, get, etc).
+    Only dict items can be used for rendering.
+    """
+
+    def getattr(self, obj, attribute):  # noqa: A003
+        try:
+            return obj[attribute]
+        except (TypeError, LookupError, AttributeError):
+            return self.undefined(obj=obj, name=attribute)
+
+    def getitem(self, obj, argument):
+        try:
+            return obj[argument]
+        except (AttributeError, TypeError, LookupError):
+            return self.undefined(obj=obj, name=argument)
+
+
 def get_snowflake_cli_jinja_env() -> Environment:
     _random_block = "___very___unique___block___to___disable___logic___blocks___"
     return _env_bootstrap(
-        Environment(
+        IgnoreAttrEnvironment(
             loader=loaders.BaseLoader(),
             keep_trailing_newline=True,
             variable_start_string=_YML_TEMPLATE_START,
@@ -81,7 +102,7 @@ def get_snowflake_cli_jinja_env() -> Environment:
 def get_sql_cli_jinja_env():
     _random_block = "___very___unique___block___to___disable___logic___blocks___"
     return _env_bootstrap(
-        Environment(
+        IgnoreAttrEnvironment(
             loader=loaders.BaseLoader(),
             keep_trailing_newline=True,
             variable_start_string="&{",
@@ -108,7 +129,7 @@ def jinja_render_from_file(
         None if file path is provided, else returns the rendered string.
     """
     env = _env_bootstrap(
-        Environment(
+        IgnoreAttrEnvironment(
             loader=loaders.FileSystemLoader(template_path.parent),
             keep_trailing_newline=True,
             undefined=StrictUndefined,

--- a/src/snowflake/cli/plugins/nativeapp/init.py
+++ b/src/snowflake/cli/plugins/nativeapp/init.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 from click.exceptions import ClickException
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
+from snowflake.cli.api.exceptions import MissingConfiguration
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli.api.project.util import (
     is_valid_identifier,
@@ -197,6 +198,10 @@ def _validate_and_update_snowflake_yml(target_directory: Path, project_identifie
     """
     # 1. Determine if a snowflake.yml file exists, at the very least
     definition_manager = DefinitionManager(target_directory)
+    if not definition_manager.has_definition_file:
+        raise MissingConfiguration(
+            "Cannot find project definition (snowflake.yml). Please provide a path to the project or run this command in a valid project directory."
+        )
 
     # 2. Change the project name in snowflake.yml if necessary
     _replace_snowflake_yml_name_with_project(

--- a/src/snowflake/cli/plugins/sql/commands.py
+++ b/src/snowflake/cli/plugins/sql/commands.py
@@ -18,9 +18,9 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
+from snowflake.cli.api.commands.decorators import with_project_definition
 from snowflake.cli.api.commands.flags import (
     parse_key_value_variables,
-    project_definition_option,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.output.types import CommandResult, MultipleResults, QueryResult
@@ -30,15 +30,8 @@ from snowflake.cli.plugins.sql.manager import SqlManager
 app = SnowTyperFactory()
 
 
-def _parse_key_value(key_value_str: str):
-    parts = key_value_str.split("=")
-    if len(parts) < 2:
-        raise ValueError("Passed key-value pair does not comform with key=value format")
-
-    return parts[0], "=".join(parts[1:])
-
-
 @app.command(name="sql", requires_connection=True, no_args_is_help=True)
+@with_project_definition(is_optional=True)
 def execute_sql(
     query: Optional[str] = typer.Option(
         None,
@@ -69,7 +62,6 @@ def execute_sql(
         help="String in format of key=value. If provided the SQL content will "
         "be treated as template and rendered using provided data.",
     ),
-    _: Optional[str] = project_definition_option(optional=True),
     **options,
 ) -> CommandResult:
     """

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -48,8 +48,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
-  │ --env              TEXT  String in format of key=value. Overrides env        │
-  │                          variables used for templating.                      │
+  │ --env              TEXT  String in format of key=value. Overrides variables  │
+  │                          from env section used for templating.               │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Global configuration ───────────────────────────────────────────────────────╮
@@ -110,8 +110,8 @@
   │                                          project resides. Defaults to        │
   │                                          current working directory.          │
   │ --env                              TEXT  String in format of key=value.      │
-  │                                          Overrides env variables used for    │
-  │                                          templating.                         │
+  │                                          Overrides variables from env        │
+  │                                          section used for templating.        │
   │ --help       -h                          Show this message and exit.         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -266,8 +266,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
-  │ --env              TEXT  String in format of key=value. Overrides env        │
-  │                          variables used for templating.                      │
+  │ --env              TEXT  String in format of key=value. Overrides variables  │
+  │                          from env section used for templating.               │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -415,8 +415,9 @@
   │                                                        working directory.    │
   │ --env                                         TEXT     String in format of   │
   │                                                        key=value. Overrides  │
-  │                                                        env variables used    │
-  │                                                        for templating.       │
+  │                                                        variables from env    │
+  │                                                        section used for      │
+  │                                                        templating.           │
   │ --help                -h                               Show this message and │
   │                                                        exit.                 │
   ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -508,8 +509,8 @@
   │                                              App project resides. Defaults   │
   │                                              to current working directory.   │
   │ --env                                  TEXT  String in format of key=value.  │
-  │                                              Overrides env variables used    │
-  │                                              for templating.                 │
+  │                                              Overrides variables from env    │
+  │                                              section used for templating.    │
   │ --help         -h                            Show this message and exit.     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -577,8 +578,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
-  │ --env              TEXT  String in format of key=value. Overrides env        │
-  │                          variables used for templating.                      │
+  │ --env              TEXT  String in format of key=value. Overrides variables  │
+  │                          from env section used for templating.               │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -694,8 +695,9 @@
   │                                                    current working           │
   │                                                    directory.                │
   │ --env                                     TEXT     String in format of       │
-  │                                                    key=value. Overrides env  │
-  │                                                    variables used for        │
+  │                                                    key=value. Overrides      │
+  │                                                    variables from env        │
+  │                                                    section used for          │
   │                                                    templating.               │
   │ --help            -h                               Show this message and     │
   │                                                    exit.                     │
@@ -791,8 +793,8 @@
   │                                              App project resides. Defaults   │
   │                                              to current working directory.   │
   │ --env                                  TEXT  String in format of key=value.  │
-  │                                              Overrides env variables used    │
-  │                                              for templating.                 │
+  │                                              Overrides variables from env    │
+  │                                              section used for templating.    │
   │ --help         -h                            Show this message and exit.     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -860,8 +862,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
-  │ --env              TEXT  String in format of key=value. Overrides env        │
-  │                          variables used for templating.                      │
+  │ --env              TEXT  String in format of key=value. Overrides variables  │
+  │                          from env section used for templating.               │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -3022,8 +3024,8 @@
   │                                         resides. Defaults to current working │
   │                                         directory.                           │
   │ --env                             TEXT  String in format of key=value.       │
-  │                                         Overrides env variables used for     │
-  │                                         templating.                          │
+  │                                         Overrides variables from env section │
+  │                                         used for templating.                 │
   │ --help                    -h            Show this message and exit.          │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -3096,8 +3098,8 @@
   │                          changes to metadata                                 │
   │ --project  -p      TEXT  Path where the Snowpark project resides. Defaults   │
   │                          to current working directory.                       │
-  │ --env              TEXT  String in format of key=value. Overrides env        │
-  │                          variables used for templating.                      │
+  │ --env              TEXT  String in format of key=value. Overrides variables  │
+  │                          from env section used for templating.               │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -6474,8 +6476,8 @@
   │                           [default: None]                                    │
   │ --project   -p      TEXT  Path where Snowflake project resides. Defaults to  │
   │                           current working directory.                         │
-  │ --env               TEXT  String in format of key=value. Overrides env       │
-  │                           variables used for templating.                     │
+  │ --env               TEXT  String in format of key=value. Overrides variables │
+  │                           from env section used for templating.              │
   │ --help      -h            Show this message and exit.                        │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -7239,8 +7241,8 @@
   │ --open                   Whether to open the Streamlit app in a browser.     │
   │ --project  -p      TEXT  Path where the Streamlit app project resides.       │
   │                          Defaults to current working directory.              │
-  │ --env              TEXT  String in format of key=value. Overrides env        │
-  │                          variables used for templating.                      │
+  │ --env              TEXT  String in format of key=value. Overrides variables  │
+  │                          from env section used for templating.               │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -48,6 +48,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
+  │ --env              TEXT  String in format of key=value. Overrides env        │
+  │                          variables used for templating.                      │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Global configuration ───────────────────────────────────────────────────────╮
@@ -107,6 +109,9 @@
   │ --project    -p                    TEXT  Path where the Snowflake Native App │
   │                                          project resides. Defaults to        │
   │                                          current working directory.          │
+  │ --env                              TEXT  String in format of key=value.      │
+  │                                          Overrides env variables used for    │
+  │                                          templating.                         │
   │ --help       -h                          Show this message and exit.         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -261,6 +266,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
+  │ --env              TEXT  String in format of key=value. Overrides env        │
+  │                          variables used for templating.                      │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -406,6 +413,10 @@
   │                                                        project resides.      │
   │                                                        Defaults to current   │
   │                                                        working directory.    │
+  │ --env                                         TEXT     String in format of   │
+  │                                                        key=value. Overrides  │
+  │                                                        env variables used    │
+  │                                                        for templating.       │
   │ --help                -h                               Show this message and │
   │                                                        exit.                 │
   ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -496,6 +507,9 @@
   │ --project      -p                      TEXT  Path where the Snowflake Native │
   │                                              App project resides. Defaults   │
   │                                              to current working directory.   │
+  │ --env                                  TEXT  String in format of key=value.  │
+  │                                              Overrides env variables used    │
+  │                                              for templating.                 │
   │ --help         -h                            Show this message and exit.     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -563,6 +577,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
+  │ --env              TEXT  String in format of key=value. Overrides env        │
+  │                          variables used for templating.                      │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -677,6 +693,10 @@
   │                                                    resides. Defaults to      │
   │                                                    current working           │
   │                                                    directory.                │
+  │ --env                                     TEXT     String in format of       │
+  │                                                    key=value. Overrides env  │
+  │                                                    variables used for        │
+  │                                                    templating.               │
   │ --help            -h                               Show this message and     │
   │                                                    exit.                     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -770,6 +790,9 @@
   │ --project      -p                      TEXT  Path where the Snowflake Native │
   │                                              App project resides. Defaults   │
   │                                              to current working directory.   │
+  │ --env                                  TEXT  String in format of key=value.  │
+  │                                              Overrides env variables used    │
+  │                                              for templating.                 │
   │ --help         -h                            Show this message and exit.     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -837,6 +860,8 @@
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --project  -p      TEXT  Path where the Snowflake Native App project         │
   │                          resides. Defaults to current working directory.     │
+  │ --env              TEXT  String in format of key=value. Overrides env        │
+  │                          variables used for templating.                      │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -2996,6 +3021,9 @@
   │ --project                 -p      TEXT  Path where the Snowpark project      │
   │                                         resides. Defaults to current working │
   │                                         directory.                           │
+  │ --env                             TEXT  String in format of key=value.       │
+  │                                         Overrides env variables used for     │
+  │                                         templating.                          │
   │ --help                    -h            Show this message and exit.          │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -3068,6 +3096,8 @@
   │                          changes to metadata                                 │
   │ --project  -p      TEXT  Path where the Snowpark project resides. Defaults   │
   │                          to current working directory.                       │
+  │ --env              TEXT  String in format of key=value. Overrides env        │
+  │                          variables used for templating.                      │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -6444,6 +6474,8 @@
   │                           [default: None]                                    │
   │ --project   -p      TEXT  Path where Snowflake project resides. Defaults to  │
   │                           current working directory.                         │
+  │ --env               TEXT  String in format of key=value. Overrides env       │
+  │                           variables used for templating.                     │
   │ --help      -h            Show this message and exit.                        │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
@@ -7207,6 +7239,8 @@
   │ --open                   Whether to open the Streamlit app in a browser.     │
   │ --project  -p      TEXT  Path where the Streamlit app project resides.       │
   │                          Defaults to current working directory.              │
+  │ --env              TEXT  String in format of key=value. Overrides env        │
+  │                          variables used for templating.                      │
   │ --help     -h            Show this message and exit.                         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮

--- a/tests/__snapshots__/test_sql.ambr
+++ b/tests/__snapshots__/test_sql.ambr
@@ -23,8 +23,8 @@
   │                           [default: None]                                    │
   │ --project   -p      TEXT  Path where Snowflake project resides. Defaults to  │
   │                           current working directory.                         │
-  │ --env               TEXT  String in format of key=value. Overrides env       │
-  │                           variables used for templating.                     │
+  │ --env               TEXT  String in format of key=value. Overrides variables │
+  │                           from env section used for templating.              │
   │ --help      -h            Show this message and exit.                        │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮

--- a/tests/__snapshots__/test_sql.ambr
+++ b/tests/__snapshots__/test_sql.ambr
@@ -23,6 +23,8 @@
   │                           [default: None]                                    │
   │ --project   -p      TEXT  Path where Snowflake project resides. Defaults to  │
   │                           current working directory.                         │
+  │ --env               TEXT  String in format of key=value. Overrides env       │
+  │                           variables used for templating.                     │
   │ --help      -h            Show this message and exit.                        │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -295,11 +295,25 @@ def test_resolve_variables_blank_is_ok():
             "Could not find template variable ctx.streamlit.name",
         ),
         ({"app": "<% ctx.foo %>"}, "Could not find template variable ctx.foo"),
+        ({"app": "<% ctx.env.get %>"}, "Could not find template variable ctx.env.get"),
+        (
+            {"app": "<% ctx.env.__class__ %>"},
+            "Could not find template variable ctx.env.__class__",
+        ),
+        (
+            {"app": "<% ctx.native_app.__class__ %>"},
+            "Could not find template variable ctx.native_app.__class__",
+        ),
+        (
+            {"app": "<% ctx.native_app.schema %>"},
+            "Could not find template variable ctx.native_app.schema",
+        ),
     ],
 )
 def test_resolve_variables_fails_if_referencing_unknown_variable(env, msg):
     definition = {
         "definition_version": "1.1",
+        "native_app": {"name": "test_name", "artifacts": []},
         "env": env,
     }
     with pytest.raises(InvalidTemplate) as err:

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -414,7 +414,7 @@ def test_invalid_type_for_env_variable():
 
     assert (
         err.value.message
-        == "Variable test_env in env section or project definition file should be a scalar"
+        == "Variable test_env in env section of project definition file should be a scalar"
     )
 
 

--- a/tests_integration/test_sql_templating.py
+++ b/tests_integration/test_sql_templating.py
@@ -64,3 +64,39 @@ def test_sql_env_value_from_cli_param_overriding_os_env(runner, snowflake_sessio
 
     assert result.exit_code == 0
     assert result.json == [{"'VALUE_FROM_CLI'": "value_from_cli"}]
+
+
+@pytest.mark.integration
+def test_sql_env_value_from_cli_duplicate_arg(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        [
+            "sql",
+            "-q",
+            "select '&{ctx.env.Test}'",
+            "--env",
+            "Test=firstArg",
+            "--env",
+            "Test=secondArg",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert result.json == [{"'SECONDARG'": "secondArg"}]
+
+
+@pytest.mark.integration
+def test_sql_env_value_from_cli_multiple_args(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        [
+            "sql",
+            "-q",
+            "select '&{ctx.env.Test1}-&{ctx.env.Test2}'",
+            "--env",
+            "Test1=test1",
+            "--env",
+            "Test2=test2",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert result.json == [{"'TEST1-TEST2'": "test1-test2"}]

--- a/tests_integration/test_sql_templating.py
+++ b/tests_integration/test_sql_templating.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.mark.integration
+def test_sql_env_value_from_cli_param(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", "select '&{ctx.env.test}'", "--env", "test=value_from_cli"]
+    )
+
+    assert result.exit_code == 0
+    assert result.json == [{"'VALUE_FROM_CLI'": "value_from_cli"}]
+
+
+@pytest.mark.integration
+def test_sql_env_value_from_cli_param_that_is_blank(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", "select '&{ctx.env.test}'", "--env", "test="]
+    )
+
+    assert result.exit_code == 0
+    assert result.json == [{"''": ""}]
+
+
+@pytest.mark.integration
+def test_sql_undefined_env_causing_error(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", "select '&{ctx.env.test}'"]
+    )
+
+    assert result.exit_code == 1
+    assert "SQL template rendering error" in result.output
+
+
+@pytest.mark.integration
+def test_sql_env_value_from_os_env(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", "select '&{ctx.env.test}'"], env={"test": "value_from_os_env"}
+    )
+
+    assert result.exit_code == 0
+    assert result.json == [{"'VALUE_FROM_OS_ENV'": "value_from_os_env"}]
+
+
+@pytest.mark.integration
+def test_sql_env_value_from_cli_param_overriding_os_env(runner, snowflake_session):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", "select '&{ctx.env.test}'", "--env", "test=value_from_cli"],
+        env={"test": "value_from_os_env"},
+    )
+
+    assert result.exit_code == 0
+    assert result.json == [{"'VALUE_FROM_CLI'": "value_from_cli"}]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Add support for CLI argument --env to allow users to overwrite env variables for templating.
User can provide multiple --env variables (e.g. --env x=1 --env y=a)
User can set empty variable (--env x=) or (--env x='')
Order of template resolution priority:
1) --env vars from cli
2) os env variables
3) env variables defined in project definition file.

This does not alter environment variables.
