### PR TITLE
Make windows an explicit check in PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
    * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
    * [ ] I've added or updated automated unit tests to verify correctness of my new code.
    * [ ] I've added or updated integration tests to verify correctness of my new code.
-   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
+   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
+   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
    * [ ] I've confirmed that my changes are up-to-date with the target branch.
    * [ ] I've described my changes in the release notes.
    * [ ] I've described my changes in the section below.


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

We have had a few misses and near misses on Windows lately. I think it's a good idea to call out Windows testing explicitly in PRs. Submitters should of course continue to use judgement, as always. Windows-specific may not apply to all PRs, but it's a good reminder to think about the blast radius of a change on different operating systems.
