### PR TITLE
Introduce VerboseCursor for printing queries before execution

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
 * Fixes markup escaping errors in `snow sql` that may occur when users use unintentionally markup-like escape tags.
 * Fixed case where `snow app teardown` could leave behind orphan applications if they were not created by the Snowflake CLI
 * Improve terminal output sanitization to avoid ASCII escape codes.
+* The `snow sql` command will show query text before executing it.
 
 # v2.5.0
 ## Backward incompatibility

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -22,6 +22,7 @@ from textwrap import dedent
 from typing import Iterable, Optional, Tuple
 
 from snowflake.cli.api.cli_global_context import cli_context
+from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.exceptions import (
     DatabaseNotProvidedError,
@@ -212,3 +213,9 @@ class SqlExecutionMixin:
             lambda row: row[name_col] == unquote_identifier(unqualified_name),
         )
         return show_obj_row
+
+
+class VerboseCursor(SnowflakeCursor):
+    def execute(self, command: str, *args, **kwargs):
+        cli_console.message(command)
+        super().execute(command, *args, **kwargs)

--- a/src/snowflake/cli/app/printing.py
+++ b/src/snowflake/cli/app/printing.py
@@ -34,7 +34,6 @@ from snowflake.cli.api.output.types import (
     MessageResult,
     MultipleResults,
     ObjectResult,
-    QueryResult,
 )
 from snowflake.cli.api.sanitizers import sanitize_for_terminal
 
@@ -76,8 +75,6 @@ def _get_table():
 
 
 def _print_multiple_table_results(obj: CollectionResult):
-    if isinstance(obj, QueryResult):
-        rich_print(obj.query)
     items = obj.result
     try:
         first_item = next(items)

--- a/src/snowflake/cli/plugins/sql/manager.py
+++ b/src/snowflake/cli/plugins/sql/manager.py
@@ -23,7 +23,7 @@ from typing import Dict, Iterable, List, Tuple
 from click import ClickException, UsageError
 from jinja2 import UndefinedError
 from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
-from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.cli.api.sql_execution import SqlExecutionMixin, VerboseCursor
 from snowflake.cli.api.utils.rendering import snowflake_sql_jinja_render
 from snowflake.cli.plugins.sql.snowsql_templating import transpile_snowsql_templates
 from snowflake.connector.cursor import SnowflakeCursor
@@ -87,4 +87,6 @@ class SqlManager(SqlExecutionMixin):
         )
         single_statement = len(statements) == 1
 
-        return single_statement, self._execute_string("\n".join(statements))
+        return single_statement, self._execute_string(
+            "\n".join(statements), cursor_class=VerboseCursor
+        )

--- a/tests/object/__snapshots__/test_object.ambr
+++ b/tests/object/__snapshots__/test_object.ambr
@@ -1,7 +1,6 @@
 # serializer version: 1
 # name: test_describe[compute-pool-compute_pool_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -13,7 +12,6 @@
 # ---
 # name: test_describe[database-database_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -25,7 +23,6 @@
 # ---
 # name: test_describe[function-function_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -37,7 +34,6 @@
 # ---
 # name: test_describe[git-repository-git_repository_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -49,7 +45,6 @@
 # ---
 # name: test_describe[integration-integration_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -61,7 +56,6 @@
 # ---
 # name: test_describe[network-rule-network_rule_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -73,7 +67,6 @@
 # ---
 # name: test_describe[procedure-procedure_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -85,7 +78,6 @@
 # ---
 # name: test_describe[role-role_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -97,7 +89,6 @@
 # ---
 # name: test_describe[schema-schema_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -109,7 +100,6 @@
 # ---
 # name: test_describe[secret-secret_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -121,7 +111,6 @@
 # ---
 # name: test_describe[service-service_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -133,7 +122,6 @@
 # ---
 # name: test_describe[stage-stage_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -145,7 +133,6 @@
 # ---
 # name: test_describe[stream-stream_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -157,7 +144,6 @@
 # ---
 # name: test_describe[streamlit-streamlit_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -169,7 +155,6 @@
 # ---
 # name: test_describe[table-table_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -181,7 +166,6 @@
 # ---
 # name: test_describe[task-task_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -193,7 +177,6 @@
 # ---
 # name: test_describe[user-user_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -205,7 +188,6 @@
 # ---
 # name: test_describe[view-view_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -217,7 +199,6 @@
 # ---
 # name: test_describe[warehouse-warehouse_example]
   '''
-  SELECT A MOCK QUERY
   +-----------------------------+
   | name | type        | kind   |
   |------+-------------+--------|
@@ -237,7 +218,6 @@
 # ---
 # name: test_drop[compute-pool-compute_pool_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -248,7 +228,6 @@
 # ---
 # name: test_drop[database-database_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -259,7 +238,6 @@
 # ---
 # name: test_drop[function-function_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -270,7 +248,6 @@
 # ---
 # name: test_drop[git-repository-git_repository_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -281,7 +258,6 @@
 # ---
 # name: test_drop[image-repository-image_repository_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -292,7 +268,6 @@
 # ---
 # name: test_drop[integration-integration_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -303,7 +278,6 @@
 # ---
 # name: test_drop[network-rule-network_rule_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -314,7 +288,6 @@
 # ---
 # name: test_drop[procedure-procedure_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -325,7 +298,6 @@
 # ---
 # name: test_drop[role-role_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -336,7 +308,6 @@
 # ---
 # name: test_drop[schema-schema_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -347,7 +318,6 @@
 # ---
 # name: test_drop[secret-secret_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -358,7 +328,6 @@
 # ---
 # name: test_drop[service-service_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -369,7 +338,6 @@
 # ---
 # name: test_drop[stage-stage_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -380,7 +348,6 @@
 # ---
 # name: test_drop[stream-stream_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -391,7 +358,6 @@
 # ---
 # name: test_drop[streamlit-streamlit_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -402,7 +368,6 @@
 # ---
 # name: test_drop[table-table_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -413,7 +378,6 @@
 # ---
 # name: test_drop[task-task_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -424,7 +388,6 @@
 # ---
 # name: test_drop[user-user_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -435,7 +398,6 @@
 # ---
 # name: test_drop[view-view_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|
@@ -446,7 +408,6 @@
 # ---
 # name: test_drop[warehouse-warehouse_example]
   '''
-  SELECT A MOCK QUERY
   +--------+
   | status |
   |--------|

--- a/tests/output/test_format_silent_enforcement.py
+++ b/tests/output/test_format_silent_enforcement.py
@@ -21,7 +21,6 @@ import pytest
 def test_table_result_with_silent_enabled(runner):
     expected_output = dedent(
         """\
-        SELECT A MOCK QUERY
         +---------------------------------------------------------------------+
         | string | number | array     | object          | date                |
         |--------+--------+-----------+-----------------+---------------------|
@@ -42,7 +41,6 @@ def test_table_result_with_silent_disabled(runner):
         Enter
           Faker. Teeny Tiny step: UNO UNO
         Exit
-        SELECT A MOCK QUERY
         +---------------------------------------------------------------------+
         | string | number | array     | object          | date                |
         |--------+--------+-----------+-----------------+---------------------|

--- a/tests/output/test_printing.py
+++ b/tests/output/test_printing.py
@@ -113,7 +113,6 @@ def test_print_markup_tags_in_output_do_not_raise_errors(capsys, mock_cursor):
 
     assert get_output(capsys) == dedent(
         """\
-    SELECT A MOCK QUERY
     +------------------------------------------------+
     | CONCAT('[INST]','FOO', 'TRANSCRIPT','[/INST]') |
     |------------------------------------------------|
@@ -135,14 +134,12 @@ def test_print_multi_results_table(capsys, _create_mock_cursor):
 
     assert get_output(capsys) == dedent(
         """\
-    SELECT A MOCK QUERY
     +---------------------------------------------------------------------+
     | string | number | array     | object          | date                |
     |--------+--------+-----------+-----------------+---------------------|
     | string | 42     | ['array'] | {'k': 'object'} | 2022-03-21 00:00:00 |
     | string | 43     | ['array'] | {'k': 'object'} | 2022-03-21 00:00:00 |
     +---------------------------------------------------------------------+
-    SELECT A MOCK QUERY
     +---------------------------------------------------------------------+
     | string | number | array     | object          | date                |
     |--------+--------+-----------+-----------------+---------------------|
@@ -193,14 +190,12 @@ def test_print_different_multi_results_table(capsys, mock_cursor):
 
     assert get_output(capsys) == dedent(
         """\
-    SELECT A MOCK QUERY
     +-----------------+
     | string | number |
     |--------+--------|
     | string | 42     |
     | string | 43     |
     +-----------------+
-    SELECT A MOCK QUERY
     +---------------------------------------------------+
     | array     | object          | date                |
     |-----------+-----------------+---------------------|
@@ -224,7 +219,6 @@ def test_print_different_data_sources_table(capsys, _create_mock_cursor):
 
     assert get_output(capsys) == dedent(
         """\
-    SELECT A MOCK QUERY
     +---------------------------------------------------------------------+
     | string | number | array     | object          | date                |
     |--------+--------+-----------+-----------------+---------------------|

--- a/tests/stage/__snapshots__/test_stage.ambr
+++ b/tests/stage/__snapshots__/test_stage.ambr
@@ -291,7 +291,6 @@
 # name: test_stage_print_result_for_get_all_files_from_stage
   '''
   Use `--recursive` flag, which copy files recursively with directory structure. This will be the default behavior in the future.
-  SELECT A MOCK QUERY
   +-----------------------------------------+
   | file      | size | status     | message |
   |-----------+------+------------+---------|
@@ -316,7 +315,6 @@
 # ---
 # name: test_stage_print_result_for_put_directory
   '''
-  SELECT A MOCK QUERY
   +------------------------------------------------------------------------------+
   |         |         |         |         | source_ | target_ |         |        |
   |         |         | source_ | target_ | compres | compres |         | messag |

--- a/tests_e2e/test_error_handling.py
+++ b/tests_e2e/test_error_handling.py
@@ -62,7 +62,7 @@ def test_error_traceback_disabled_without_debug(snowcli, test_root_path):
     )
 
     assert result_debug.returncode == 1
-    assert not result_debug.stdout
+    assert result_debug.stdout == "select foo\n"
     assert traceback_msg in result_debug.stderr
 
 

--- a/tests_integration/test_sql.py
+++ b/tests_integration/test_sql.py
@@ -145,3 +145,14 @@ def test_trailing_comments_queries(runner, snowflake_session, test_root_path):
             {"1": 1},
         ],
     ]
+
+
+@pytest.mark.integration
+def test_sql_execute_query_prints_query(runner):
+    result = runner.invoke_with_connection(
+        ["sql", "-q", "select 1 as A; select 2 as B"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "select 1 as A" in result.output
+    assert "select 2 as B" in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
#1145 reported that query text is not printed until query is executed. I changed this by using `VerboseCursor` in `snow sql` command. This changes output of other commands (removes printing queries). I think this a good changes because we don't need to print queries for commands like `snow stage copy`.
