### PR TITLE
SNOW-1509249 Hide diff output when running `snow app validate`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@
 * Improve terminal output sanitization to avoid ASCII escape codes.
 * The `snow sql` command will show query text before executing it.
 * Improved stage diff output in `snow app` commands
+* Hid the diff from `snow app validate` output since it was redundant
 
 # v2.5.0
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -361,10 +361,11 @@ class NativeAppManager(SqlExecutionMixin):
             )
 
         # Perform a diff operation and display results to the user for informational purposes
-        cc.step(
-            "Performing a diff between the Snowflake stage and your local deploy_root ('%s') directory."
-            % self.deploy_root.resolve()
-        )
+        if print_diff:
+            cc.step(
+                "Performing a diff between the Snowflake stage and your local deploy_root ('%s') directory."
+                % self.deploy_root.resolve()
+            )
         diff: DiffResult = compute_stage_diff(self.deploy_root, stage_fqn)
 
         if local_paths_to_sync:

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -630,7 +630,7 @@ class NativeAppManager(SqlExecutionMixin):
                 recursive=True,
                 stage_fqn=stage_fqn,
                 validate=False,
-                # print_diff=False,
+                print_diff=False,
             )
         prefixed_stage_fqn = StageManager.get_standard_stage_prefix(stage_fqn)
         try:

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -324,6 +324,7 @@ class NativeAppManager(SqlExecutionMixin):
         recursive: bool,
         stage_fqn: str,
         local_paths_to_sync: List[Path] | None = None,
+        print_diff: bool = True,
     ) -> DiffResult:
         """
         Ensures that the files on our remote stage match the artifacts we have in
@@ -337,6 +338,7 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn (str): The name of the stage to diff against and upload to.
             local_paths_to_sync (List[Path], optional): List of local paths to sync. Defaults to None to sync all
              local paths. Note that providing an empty list here is equivalent to None.
+            print_diff (bool): Whether to print the diff between the local files and the remote stage. Defaults to True
 
         Returns:
             A `DiffResult` instance describing the changes that were performed.
@@ -411,7 +413,8 @@ class NativeAppManager(SqlExecutionMixin):
                     f"The following files exist only on the stage:\n{files_not_removed_str}\n\nUse the --prune flag to delete them from the stage."
                 )
 
-        print_diff_to_console(diff, bundle_map)
+        if print_diff:
+            print_diff_to_console(diff, bundle_map)
 
         # Upload diff-ed files to application package stage
         if diff.has_changes():
@@ -568,6 +571,7 @@ class NativeAppManager(SqlExecutionMixin):
         stage_fqn: Optional[str] = None,
         local_paths_to_sync: List[Path] | None = None,
         validate: bool = True,
+        print_diff: bool = True,
     ) -> DiffResult:
         """app deploy process"""
 
@@ -587,6 +591,7 @@ class NativeAppManager(SqlExecutionMixin):
                 recursive=recursive,
                 stage_fqn=stage_fqn,
                 local_paths_to_sync=local_paths_to_sync,
+                print_diff=print_diff,
             )
 
         if validate:
@@ -625,6 +630,7 @@ class NativeAppManager(SqlExecutionMixin):
                 recursive=True,
                 stage_fqn=stage_fqn,
                 validate=False,
+                # print_diff=False,
             )
         prefixed_stage_fqn = StageManager.get_standard_stage_prefix(stage_fqn)
         try:

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1072,6 +1072,7 @@ def test_validate_use_scratch_stage(
         recursive=True,
         stage_fqn=native_app_manager.scratch_stage_fqn,
         validate=False,
+        print_diff=False,
     )
     assert mock_execute.mock_calls == expected
 
@@ -1137,6 +1138,7 @@ def test_validate_failing_drops_scratch_stage(
         recursive=True,
         stage_fqn=native_app_manager.scratch_stage_fqn,
         validate=False,
+        print_diff=False,
     )
     assert mock_execute.mock_calls == expected
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Since `snow app validate` throws away the scratch stage every time, the diff will always show that all files are being uploaded, which isn't necessary to show to the user in this case.

Before:
![image](https://github.com/snowflakedb/snowflake-cli/assets/171080004/6770cce6-36b0-4398-a444-31fabf173479)

After:
![image](https://github.com/snowflakedb/snowflake-cli/assets/171080004/ebb563ed-ef44-4d4b-a25f-8e0800ce6037)

Validation on `snow app bundle` (and `snow app run`) still shows the diff, since it uses the app's main stage:
![image](https://github.com/snowflakedb/snowflake-cli/assets/171080004/a52b496f-1676-4998-8985-b4a0d5538d04)

Not adding tests since
1. It's a simple change
2. The mocking required to get unit tests working also mocks out the call to `sync_deploy_root_with_stage`, which is where `print_diff_to_console` is called
3. In integration tests, `capsys` can't capture `cc.message`. I'm not sure why but now's not the time to investigate