### PR TITLE
Improve message for Pydantic model errors and move exception translation up to fix Pydantic Union issue.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,7 @@
 * Improved stage diff output in `snow app` commands
 * Hid the diff from `snow app validate` output since it was redundant
 * Added log into the file with loaded external plugins
+* Improved output and format of Pydantic validation errors
 
 # v2.5.0
 ## Backward incompatibility

--- a/src/snowflake/cli/api/project/errors.py
+++ b/src/snowflake/cli/api/project/errors.py
@@ -14,15 +14,16 @@
 
 from textwrap import dedent
 
+from click import ClickException
 from pydantic import ValidationError
 
 
-class SchemaValidationError(Exception):
-    generic_message = "For field {loc} you provided '{loc}'. This caused: {msg}"
+class SchemaValidationError(ClickException):
+    generic_message = "For field {location} you provided '{input}'. This caused: {msg}"
     message_templates = {
-        "string_type": "{msg} for field '{loc}', you provided '{input}'.",
-        "extra_forbidden": "{msg}. You provided field '{loc}' with value '{input}' that is not supported in given version.",
-        "missing": "Your project definition is missing following fields: {loc}",
+        "string_type": "{msg} for field '{location}', you provided '{input}'.",
+        "extra_forbidden": "{msg}. You provided field '{location}' with value '{input}' that is not supported in given version.",
+        "missing": "Your project definition is missing the following field: '{location}'",
     }
 
     def __init__(self, error: ValidationError):
@@ -30,7 +31,9 @@ class SchemaValidationError(Exception):
         message = f"During evaluation of {error.title} in project definition following errors were encountered:\n"
         message += "\n".join(
             [
-                self.message_templates.get(e["type"], self.generic_message).format(**e)
+                self.message_templates.get(e["type"], self.generic_message).format(
+                    **e, location=".".join(e["loc"]) if e["loc"] is not None else None
+                )
                 for e in errors
             ]
         )

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -18,7 +18,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
 from packaging.version import Version
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
+from snowflake.cli.api.project.errors import SchemaValidationError
 from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.snowpark.snowpark import Snowpark
 from snowflake.cli.api.project.schemas.streamlit.streamlit import Streamlit
@@ -46,6 +47,12 @@ class ProjectProperties:
 
 
 class _BaseDefinition(UpdatableModel):
+    def __init__(self, *args, **kwargs):
+        try:
+            super().__init__(**kwargs)
+        except ValidationError as e:
+            raise SchemaValidationError(e) from e
+
     definition_version: Union[str, int] = Field(
         title="Version of the project definition schema, which is currently 1",
     )

--- a/src/snowflake/cli/api/project/schemas/updatable_model.py
+++ b/src/snowflake/cli/api/project/schemas/updatable_model.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
-from snowflake.cli.api.project.errors import SchemaValidationError
+from pydantic import BaseModel, ConfigDict, Field
 from snowflake.cli.api.project.util import IDENTIFIER_NO_LENGTH
 
 
@@ -25,10 +24,7 @@ class UpdatableModel(BaseModel):
     model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
     def __init__(self, *args, **kwargs):
-        try:
-            super().__init__(**kwargs)
-        except ValidationError as e:
-            raise SchemaValidationError(e)
+        super().__init__(**kwargs)
 
     def update_from_dict(self, update_values: Dict[str, Any]):
         """

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -21,8 +21,8 @@ from textwrap import dedent
 from typing import Any, Dict, List, Optional, Set
 
 from click import ClickException
+from pydantic import ValidationError
 from snowflake.cli.api.console import cli_console as cc
-from snowflake.cli.api.project.errors import SchemaValidationError
 from snowflake.cli.api.project.schemas.native_app.path_mapping import (
     PathMapping,
     ProcessorMapping,
@@ -353,7 +353,7 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
                         deploy_root=bundle_map.deploy_root(),
                     )
                     collected_extension_functions.append(extension_fn)
-                except SchemaValidationError:
+                except ValidationError:
                     cc.warning("Invalid extension function definition")
 
             if collected_extension_functions:

--- a/tests/nativeapp/test_post_deploy.py
+++ b/tests/nativeapp/test_post_deploy.py
@@ -16,6 +16,7 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli.api.project.errors import SchemaValidationError
 from snowflake.cli.api.project.schemas.native_app.application import (
@@ -168,13 +169,14 @@ def test_invalid_hook_type(
     "args,expected_error",
     [
         ({"sql_script": "/path"}, None),
-        ({}, "missing following fields: ('sql_script',)"),
+        ({}, "missing the following field: 'sql_script'"),
     ],
 )
 def test_post_deploy_hook_schema(args, expected_error):
     if expected_error:
-        with pytest.raises(SchemaValidationError) as err:
+        with pytest.raises(ValidationError) as err:
             ApplicationPostDeployHook(**args)
-        assert expected_error in str(err)
+
+        assert expected_error in str(SchemaValidationError(err.value))
     else:
         ApplicationPostDeployHook(**args)

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -80,9 +80,9 @@ def test_underspecified_project(project_definition_files):
     with pytest.raises(SchemaValidationError) as exc_info:
         load_project(project_definition_files).project_definition
 
-    assert "NativeApp" in str(exc_info)
-    assert "Your project definition is missing following fields: ('artifacts',)" in str(
-        exc_info.value
+    assert (
+        "Your project definition is missing the following field: 'native_app.artifacts'"
+        in str(exc_info.value)
     )
 
 
@@ -93,9 +93,8 @@ def test_fails_without_definition_version(project_definition_files):
     with pytest.raises(SchemaValidationError) as exc_info:
         load_project(project_definition_files).project_definition
 
-    assert "ProjectDefinition" in str(exc_info)
     assert (
-        "Your project definition is missing following fields: ('definition_version',)"
+        "Your project definition is missing the following field: 'definition_version'"
         in str(exc_info.value)
     )
 
@@ -105,9 +104,8 @@ def test_does_not_accept_unknown_fields(project_definition_files):
     with pytest.raises(SchemaValidationError) as exc_info:
         load_project(project_definition_files).project_definition
 
-    assert "NativeApp" in str(exc_info)
     assert (
-        "You provided field '('unknown_fields_accepted',)' with value 'true' that is not supported in given version."
+        "You provided field 'native_app.unknown_fields_accepted' with value 'true' that is not supported in given version."
         in str(exc_info)
     )
 


### PR DESCRIPTION
…er up to avoid Pydantic Union issue

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
1) Improved output of Pydantic validation:
BEFORE:
```
An unexpected exception occurred. Use --debug option to see the traceback. Exception message:

During evaluation of NativeApp in project definition following errors were encountered:
Your project definition is missing following fields: ('name',)
Your project definition is missing following fields: ('artifacts',)
Extra inputs are not permitted. You provided field '('extra',)' with value 'extrafieldvalue' that is not supported in given version.
```
AFTER:
```
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ During evaluation of ProjectDefinition in project definition following errors were encountered:                                       │
│ Your project definition is missing the following field: 'native_app.name'                                                             │
│ Your project definition is missing the following field: 'native_app.artifacts'                                                        │
│ Extra inputs are not permitted. You provided field 'native_app.extra' with value 'extrafieldvalue' that is not supported in given     │
│ version.                                                                                                                              │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

2) Moved SchemaValidationError exception Translation to outside UpdatableModal in order to not interfere with Pydantic validations, especially when using Union types.
