### PR TITLE
Add warning when templating is used in v1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,7 @@
 * Improved stage diff output in `snow app` commands
 * Hid the diff from `snow app validate` output since it was redundant
 * Added log into the file with loaded external plugins
+* Warn users if they attempt to use templating with project definition version 1
 * Improved output and format of Pydantic validation errors
 
 # v2.5.0

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -254,8 +254,8 @@ def _get_referenced_vars_in_definition(
 
 def _template_version_warning():
     cc.warning(
-        "Ignoring template pattern in 'snowflake.yml' project definition file. "
-        "Update definition_version to 1.1 or later to enable template expansion."
+        "Ignoring template pattern in project definition file. "
+        "Update 'definition_version' to 1.1 or later in snowflake.yml to enable template expansion."
     )
 
 

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -254,7 +254,7 @@ def _get_referenced_vars_in_definition(
 
 def _template_version_warning():
     cc.warning(
-        "Ignoring template pattern in project definition file.\n"
+        "Ignoring template pattern in project definition file. "
         "Update project definition version to 1.1 or later to enable template expansion."
     )
 

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -252,10 +252,10 @@ def _get_referenced_vars_in_definition(
     return referenced_vars
 
 
-def _template_version_warning(version):
+def _template_version_warning():
     cc.warning(
-        f"Possible use of templating in project definition file.\n"
-        f"Templating is not supported in current definition_version: {version}"
+        "Ignoring template pattern in project definition file.\n"
+        "Update project definition version to 1.1 or later to enable template expansion."
     )
 
 
@@ -296,10 +296,10 @@ def render_definition_template(
                 template_env, definition
             )
             if referenced_vars:
-                _template_version_warning(definition["definition_version"])
+                _template_version_warning()
         except Exception:
             # also warn on Exception, as it means the user is incorrectly attempting to use templating
-            _template_version_warning(definition["definition_version"])
+            _template_version_warning()
 
         project_definition = ProjectDefinition(**original_definition)
         project_context[CONTEXT_KEY]["env"] = environment_overrides

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 import copy
 from typing import Any, Optional
 
-from jinja2 import Environment, nodes
+from jinja2 import Environment, TemplateSyntaxError, nodes
 from packaging.version import Version
+from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.exceptions import CycleDetectedError, InvalidTemplate
 from snowflake.cli.api.project.schemas.project_definition import (
     ProjectDefinition,
@@ -49,7 +50,13 @@ class TemplatedEnvironment:
 
     def get_referenced_vars(self, template_value: Any) -> set[TemplateVar]:
         template_str = str(template_value)
-        ast = self._jinja_env.parse(template_str)
+        try:
+            ast = self._jinja_env.parse(template_str)
+        except TemplateSyntaxError as e:
+            raise InvalidTemplate(
+                f"Error parsing template from project definition file. Value: '{template_str}'. Error: {e}"
+            ) from e
+
         return self._get_referenced_vars(ast, template_str)
 
     def _get_referenced_vars(
@@ -232,6 +239,26 @@ def _validate_env_section(env_section: dict):
             )
 
 
+def _get_referenced_vars_in_definition(
+    template_env: TemplatedEnvironment, definition: Definition
+):
+    referenced_vars = set()
+
+    def find_any_template_vars(element):
+        referenced_vars.update(template_env.get_referenced_vars(element))
+
+    traverse(definition, visit_action=find_any_template_vars)
+
+    return referenced_vars
+
+
+def _template_version_warning(version):
+    cc.warning(
+        f"Possible use of templating in project definition file.\n"
+        f"Templating is not supported in current definition_version: {version}"
+    )
+
+
 def render_definition_template(
     original_definition: Optional[Definition], context_overrides: Context
 ) -> ProjectProperties:
@@ -259,10 +286,21 @@ def render_definition_template(
         return ProjectProperties(None, {CONTEXT_KEY: {"env": environment_overrides}})
 
     project_context = {CONTEXT_KEY: definition}
+    template_env = TemplatedEnvironment(get_snowflake_cli_jinja_env())
 
     if "definition_version" not in definition or Version(
         definition["definition_version"]
     ) < Version("1.1"):
+        try:
+            referenced_vars = _get_referenced_vars_in_definition(
+                template_env, definition
+            )
+            if referenced_vars:
+                _template_version_warning(definition["definition_version"])
+        except Exception:
+            # also warn on Exception, as it means the user is incorrectly attempting to use templating
+            _template_version_warning(definition["definition_version"])
+
         project_definition = ProjectDefinition(**original_definition)
         project_context[CONTEXT_KEY]["env"] = environment_overrides
         return ProjectProperties(project_definition, project_context)
@@ -270,14 +308,7 @@ def render_definition_template(
     default_env = definition.get("env", {})
     _validate_env_section(default_env)
 
-    template_env = TemplatedEnvironment(get_snowflake_cli_jinja_env())
-
-    referenced_vars = set()
-
-    def find_any_template_vars(element):
-        referenced_vars.update(template_env.get_referenced_vars(element))
-
-    traverse(definition, visit_action=find_any_template_vars)
+    referenced_vars = _get_referenced_vars_in_definition(template_env, definition)
 
     dependencies_graph = _build_dependency_graph(
         template_env, referenced_vars, project_context, environment_overrides

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -254,8 +254,8 @@ def _get_referenced_vars_in_definition(
 
 def _template_version_warning():
     cc.warning(
-        "Ignoring template pattern in project definition file. "
-        "Update project definition version to 1.1 or later to enable template expansion."
+        "Ignoring template pattern in 'snowflake.yml' project definition file. "
+        "Update definition_version to 1.1 or later to enable template expansion."
     )
 
 

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -102,8 +102,8 @@ def test_no_resolve_and_warning_in_version_1(warning_mock):
         }
     }
     warning_mock.assert_called_once_with(
-        "Possible use of templating in project definition file.\n"
-        "Templating is not supported in current definition_version: 1"
+        "Ignoring template pattern in project definition file.\n"
+        "Update project definition version to 1.1 or later to enable template expansion."
     )
 
 
@@ -125,8 +125,8 @@ def test_partial_invalid_template_in_version_1(warning_mock):
     }
     # we still want to warn if there was an incorrect attempt to use templating
     warning_mock.assert_called_once_with(
-        "Possible use of templating in project definition file.\n"
-        "Templating is not supported in current definition_version: 1"
+        "Ignoring template pattern in project definition file.\n"
+        "Update project definition version to 1.1 or later to enable template expansion."
     )
 
 

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -102,8 +102,8 @@ def test_no_resolve_and_warning_in_version_1(warning_mock):
         }
     }
     warning_mock.assert_called_once_with(
-        "Ignoring template pattern in 'snowflake.yml' project definition file. "
-        "Update definition_version to 1.1 or later to enable template expansion."
+        "Ignoring template pattern in project definition file. "
+        "Update 'definition_version' to 1.1 or later in snowflake.yml to enable template expansion."
     )
 
 
@@ -125,8 +125,8 @@ def test_partial_invalid_template_in_version_1(warning_mock):
     }
     # we still want to warn if there was an incorrect attempt to use templating
     warning_mock.assert_called_once_with(
-        "Ignoring template pattern in 'snowflake.yml' project definition file. "
-        "Update definition_version to 1.1 or later to enable template expansion."
+        "Ignoring template pattern in project definition file. "
+        "Update 'definition_version' to 1.1 or later in snowflake.yml to enable template expansion."
     )
 
 

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -102,7 +102,7 @@ def test_no_resolve_and_warning_in_version_1(warning_mock):
         }
     }
     warning_mock.assert_called_once_with(
-        "Ignoring template pattern in project definition file.\n"
+        "Ignoring template pattern in project definition file. "
         "Update project definition version to 1.1 or later to enable template expansion."
     )
 
@@ -125,7 +125,7 @@ def test_partial_invalid_template_in_version_1(warning_mock):
     }
     # we still want to warn if there was an incorrect attempt to use templating
     warning_mock.assert_called_once_with(
-        "Ignoring template pattern in project definition file.\n"
+        "Ignoring template pattern in project definition file. "
         "Update project definition version to 1.1 or later to enable template expansion."
     )
 

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -633,7 +633,3 @@ def test_os_env_and_override_envs_in_version_1():
 
     assert result["ctx"]["env"]["override_env"] == "override_env_value"
     assert result["ctx"]["env"]["os_env_var"] == "os_env_var_value"
-
-
-def test_use_of_rendering_in_v1_with_warning():
-    pass

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -25,6 +25,8 @@ from snowflake.cli.api.project.errors import SchemaValidationError
 from snowflake.cli.api.utils.definition_rendering import render_definition_template
 from snowflake.cli.api.utils.models import ProjectEnvironment
 
+from tests.nativeapp.utils import NATIVEAPP_MODULE
+
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_resolve_variables_in_project_no_cross_variable_dependencies():
@@ -70,7 +72,7 @@ def test_resolve_variables_in_project_cross_variable_dependencies():
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
-def test_no_resolve_in_version_1():
+def test_env_not_supported_in_version_1():
     definition = {
         "definition_version": "1",
         "env": {
@@ -81,6 +83,86 @@ def test_no_resolve_in_version_1():
     }
     with pytest.raises(SchemaValidationError):
         render_definition_template(definition, {})
+
+
+@mock.patch.dict(os.environ, {"A": "value"}, clear=True)
+@mock.patch(f"{NATIVEAPP_MODULE}.cc.warning")
+def test_no_resolve_and_warning_in_version_1(warning_mock):
+    definition = {
+        "definition_version": "1",
+        "native_app": {"name": "test_source_<% ctx.env.A %>", "artifacts": []},
+    }
+    result = render_definition_template(definition, {}).project_context
+
+    assert result == {
+        "ctx": {
+            "definition_version": "1",
+            "native_app": {"name": "test_source_<% ctx.env.A %>", "artifacts": []},
+            "env": ProjectEnvironment({}, {}),
+        }
+    }
+    warning_mock.assert_called_once_with(
+        "Possible use of templating in project definition file.\n"
+        "Templating is not supported in current definition_version: 1"
+    )
+
+
+@mock.patch.dict(os.environ, {"A": "value"}, clear=True)
+@mock.patch(f"{NATIVEAPP_MODULE}.cc.warning")
+def test_partial_invalid_template_in_version_1(warning_mock):
+    definition = {
+        "definition_version": "1",
+        "native_app": {"name": "test_source_<% ctx.env.A", "artifacts": []},
+    }
+    result = render_definition_template(definition, {}).project_context
+
+    assert result == {
+        "ctx": {
+            "definition_version": "1",
+            "native_app": {"name": "test_source_<% ctx.env.A", "artifacts": []},
+            "env": ProjectEnvironment({}, {}),
+        }
+    }
+    # we still want to warn if there was an incorrect attempt to use templating
+    warning_mock.assert_called_once_with(
+        "Possible use of templating in project definition file.\n"
+        "Templating is not supported in current definition_version: 1"
+    )
+
+
+@mock.patch.dict(os.environ, {"A": "value"}, clear=True)
+@mock.patch(f"{NATIVEAPP_MODULE}.cc.warning")
+def test_no_warning_in_version_1_1(warning_mock):
+    definition = {
+        "definition_version": "1.1",
+        "native_app": {"name": "test_source_<% ctx.env.A %>", "artifacts": []},
+    }
+    result = render_definition_template(definition, {}).project_context
+
+    assert result == {
+        "ctx": {
+            "definition_version": "1.1",
+            "native_app": {"name": "test_source_value", "artifacts": []},
+            "env": ProjectEnvironment({}, {}),
+        }
+    }
+    warning_mock.assert_not_called()
+
+
+@mock.patch.dict(os.environ, {"A": "value"}, clear=True)
+def test_invalid_template_in_version_1_1():
+    definition = {
+        "definition_version": "1.1",
+        "native_app": {"name": "test_source_<% ctx.env.A", "artifacts": []},
+    }
+    with pytest.raises(InvalidTemplate) as err:
+        render_definition_template(definition, {})
+
+    assert err.value.message.startswith(
+        "Error parsing template from project definition file. "
+        "Value: 'test_source_<% ctx.env.A'. "
+        "Error: unexpected end of template, expected 'end of print statement'."
+    )
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
@@ -551,3 +633,7 @@ def test_os_env_and_override_envs_in_version_1():
 
     assert result["ctx"]["env"]["override_env"] == "override_env_value"
     assert result["ctx"]["env"]["os_env_var"] == "os_env_var_value"
+
+
+def test_use_of_rendering_in_v1_with_warning():
+    pass

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -102,8 +102,8 @@ def test_no_resolve_and_warning_in_version_1(warning_mock):
         }
     }
     warning_mock.assert_called_once_with(
-        "Ignoring template pattern in project definition file. "
-        "Update project definition version to 1.1 or later to enable template expansion."
+        "Ignoring template pattern in 'snowflake.yml' project definition file. "
+        "Update definition_version to 1.1 or later to enable template expansion."
     )
 
 
@@ -125,8 +125,8 @@ def test_partial_invalid_template_in_version_1(warning_mock):
     }
     # we still want to warn if there was an incorrect attempt to use templating
     warning_mock.assert_called_once_with(
-        "Ignoring template pattern in project definition file. "
-        "Update project definition version to 1.1 or later to enable template expansion."
+        "Ignoring template pattern in 'snowflake.yml' project definition file. "
+        "Update definition_version to 1.1 or later to enable template expansion."
     )
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Add warning when templating is used in v1
- we try to parse the template variables, if we find any, we warn.
- if Jinja throws an error, it means templating Syntax was attempted, but was not fully correct. We will also warn in that case.