### PR TITLE
De-dupe app create / upgrade path in NativeAppRunProcessor

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -65,6 +65,13 @@ UPGRADE_RESTRICTION_CODES = {
 }
 
 
+def was_app_created_by_cli(show_app_row: dict):
+    return (
+        show_app_row[COMMENT_COL] in ALLOWED_SPECIAL_COMMENTS
+        and show_app_row[VERSION_COL] == LOOSE_FILES_MAGIC_VERSION
+    )
+
+
 class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
     def __init__(self, project_definition: NativeApp, project_root: Path):
         super().__init__(project_definition, project_root)
@@ -91,9 +98,7 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
             if show_app_row:
 
                 # Check if not created by Snowflake CLI or not created using "files on a named stage" / stage dev mode.
-                if show_app_row[COMMENT_COL] not in ALLOWED_SPECIAL_COMMENTS or (
-                    show_app_row[VERSION_COL] != LOOSE_FILES_MAGIC_VERSION
-                ):
+                if not was_app_created_by_cli(show_app_row):
                     raise ApplicationAlreadyExistsError(self.app_name)
 
                 # Check for the right owner

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -51,6 +51,9 @@ from snowflake.cli.plugins.nativeapp.manager import (
     generic_sql_error_handler,
 )
 from snowflake.cli.plugins.nativeapp.policy import PolicyBase
+from snowflake.cli.plugins.nativeapp.project_model import (
+    NativeAppProjectModel,
+)
 from snowflake.cli.plugins.stage.manager import StageManager
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor, SnowflakeCursor
@@ -65,107 +68,69 @@ UPGRADE_RESTRICTION_CODES = {
 }
 
 
-def was_app_created_by_cli(show_app_row: dict):
-    return (
-        show_app_row[COMMENT_COL] in ALLOWED_SPECIAL_COMMENTS
-        and show_app_row[VERSION_COL] == LOOSE_FILES_MAGIC_VERSION
-    )
+class SameAccountInstallMethod:
+    _requires_created_by_cli: bool
+    _from_release_directive: bool
+    version: Optional[str]
+    patch: Optional[int]
+
+    def __init__(
+        self,
+        requires_created_by_cli: bool,
+        version: Optional[str] = None,
+        patch: Optional[int] = None,
+        from_release_directive: bool = False,
+    ):
+        self._requires_created_by_cli = requires_created_by_cli
+        self.version = version
+        self.patch = patch
+        self._from_release_directive = from_release_directive
+
+    @classmethod
+    def unversioned_dev(cls):
+        """aka. stage dev aka loose files"""
+        return cls(True)
+
+    @classmethod
+    def versioned_dev(cls, version: str, patch: Optional[int] = None):
+        return cls(False, version, patch)
+
+    @classmethod
+    def release_directive(cls):
+        return cls(False, from_release_directive=True)
+
+    @property
+    def is_dev_mode(self) -> bool:
+        return not self._from_release_directive
+
+    def using_clause(self, app: NativeAppProjectModel) -> str:
+        if self._from_release_directive:
+            return ""
+
+        if self.version:
+            patch_clause = f"patch {self.patch}" if self.patch else ""
+            return f"using version {self.version} {patch_clause}"
+
+        stage_name = StageManager.quote_stage_name(app.stage_fqn)
+        return f"using {stage_name}"
+
+    def ensure_app_usable(self, app: NativeAppProjectModel, show_app_row: dict):
+        """Raise an exception if we cannot proceed with install given the pre-existing application object"""
+
+        if self._requires_created_by_cli:
+            if show_app_row[COMMENT_COL] not in ALLOWED_SPECIAL_COMMENTS or (
+                show_app_row[VERSION_COL] != LOOSE_FILES_MAGIC_VERSION
+            ):
+                # this application object was not created by this tooling
+                raise ApplicationAlreadyExistsError(app.app_name)
+
+        # expected owner
+        ensure_correct_owner(row=show_app_row, role=app.app_role, obj_name=app.app_name)
 
 
 class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
     def __init__(self, project_definition: NativeApp, project_root: Path):
         super().__init__(project_definition, project_root)
-
-    def _create_dev_app(self, policy: PolicyBase, is_interactive: bool = False) -> None:
-        """
-        (Re-)creates the application object with our up-to-date stage.
-        """
-        with self.use_role(self.app_role):
-
-            # 1. Need to use a warehouse to create an application object
-            try:
-                if self.application_warehouse:
-                    self._execute_query(f"use warehouse {self.application_warehouse}")
-            except ProgrammingError as err:
-                generic_sql_error_handler(
-                    err=err, role=self.app_role, warehouse=self.application_warehouse
-                )
-
-            # 2. Check for an existing application object by the same name
-            show_app_row = self.get_existing_app_info()
-
-            # 3. If existing application object is found, perform a few validations and upgrade the application object.
-            if show_app_row:
-
-                # Check if not created by Snowflake CLI or not created using "files on a named stage" / stage dev mode.
-                if not was_app_created_by_cli(show_app_row):
-                    raise ApplicationAlreadyExistsError(self.app_name)
-
-                # Check for the right owner
-                ensure_correct_owner(
-                    row=show_app_row, role=self.app_role, obj_name=self.app_name
-                )
-
-                # If all the above checks are in order, proceed to upgrade
-                try:
-                    cc.step(f"Upgrading existing application object {self.app_name}.")
-                    self._execute_query(
-                        f"alter application {self.app_name} upgrade using @{self.stage_fqn}"
-                    )
-
-                    # if debug_mode is present (controlled), ensure it is up-to-date
-                    if self.debug_mode is not None:
-                        self._execute_query(
-                            f"alter application {self.app_name} set debug_mode = {self.debug_mode}"
-                        )
-
-                    self._execute_post_deploy_hooks()
-                    return
-
-                except ProgrammingError as err:
-                    if err.errno not in UPGRADE_RESTRICTION_CODES:
-                        generic_sql_error_handler(err)
-                    else:
-                        cc.warning(err.msg)
-                        self.drop_application_before_upgrade(policy, is_interactive)
-
-            # 4. If no existing application object is found, create an application object using "files on a named stage" / stage dev mode.
-            cc.step(f"Creating new application {self.app_name} in account.")
-
-            if self.app_role != self.package_role:
-                with self.use_role(new_role=self.package_role):
-                    self._execute_queries(
-                        dedent(
-                            f"""\
-                        grant install, develop on application package {self.package_name} to role {self.app_role};
-                        grant usage on schema {self.package_name}.{self.stage_schema} to role {self.app_role};
-                        grant read on stage {self.stage_fqn} to role {self.app_role};
-                        """
-                        )
-                    )
-
-            stage_name = StageManager.quote_stage_name(self.stage_fqn)
-
-            try:
-                # by default, applications are created in debug mode; this can be overridden in the project definition
-                initial_debug_mode = (
-                    self.debug_mode if self.debug_mode is not None else True
-                )
-                self._execute_query(
-                    dedent(
-                        f"""\
-                    create application {self.app_name}
-                        from application package {self.package_name}
-                        using {stage_name}
-                        debug_mode = {initial_debug_mode}
-                        comment = {SPECIAL_COMMENT}
-                    """
-                    )
-                )
-            except ProgrammingError as err:
-                generic_sql_error_handler(err)
-
-            self._execute_post_deploy_hooks()
 
     def _execute_sql_script(self, sql_script_path):
         """
@@ -288,17 +253,12 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
             else:
                 generic_sql_error_handler(err)
 
-    def upgrade_app(
+    def create_or_upgrade_app(
         self,
         policy: PolicyBase,
-        is_interactive: bool,
-        version: Optional[str] = None,
-        patch: Optional[int] = None,
+        install_method: SameAccountInstallMethod,
+        is_interactive: bool = False,
     ):
-
-        patch_clause = f"patch {patch}" if patch else ""
-        using_clause = f"using version {version} {patch_clause}" if version else ""
-
         with self.use_role(self.app_role):
 
             # 1. Need to use a warehouse to create an application object
@@ -316,24 +276,25 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
             # 3. If existing application is found, perform a few validations and upgrade the application object.
             if show_app_row:
 
-                # We skip comment check here, because prod/pre-existing application objects may not be created by the Snowflake CLI.
-                # Check for the right owner
-                ensure_correct_owner(
-                    row=show_app_row, role=self.app_role, obj_name=self.app_name
-                )
+                install_method.ensure_app_usable(self._na_project, show_app_row)
 
                 # If all the above checks are in order, proceed to upgrade
                 try:
+                    cc.step(f"Upgrading existing application object {self.app_name}.")
+                    using_clause = install_method.using_clause(self._na_project)
                     self._execute_query(
                         f"alter application {self.app_name} upgrade {using_clause}"
                     )
 
-                    if using_clause:
+                    if install_method.is_dev_mode:
                         # if debug_mode is present (controlled), ensure it is up-to-date
                         if self.debug_mode is not None:
                             self._execute_query(
                                 f"alter application {self.app_name} set debug_mode = {self.debug_mode}"
                             )
+
+                    # hooks always executed after a create or upgrade
+                    self._execute_post_deploy_hooks()
                     return
 
                 except ProgrammingError as err:
@@ -347,27 +308,28 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
             cc.step(f"Creating new application object {self.app_name} in account.")
 
             if self.app_role != self.package_role:
-                with self.use_role(new_role=self.package_role):
+                with self.use_role(self.package_role):
                     self._execute_query(
-                        f"grant install on application package {self.package_name} to role {self.app_role}"
+                        f"grant install, develop on application package {self.package_name} to role {self.app_role}"
                     )
-                    if version:
-                        self._execute_query(
-                            f"grant develop on application package {self.package_name} to role {self.app_role}"
-                        )
+                    self._execute_query(
+                        f"grant usage on schema {self.package_name}.{self.stage_schema} to role {self.app_role}"
+                    )
+                    self._execute_query(
+                        f"grant read on stage {self.stage_fqn} to role {self.app_role}"
+                    )
 
             try:
                 # by default, applications are created in debug mode when possible;
                 # this can be overridden in the project definition
                 debug_mode_clause = ""
-                if (
-                    using_clause
-                ):  # release directive installations cannot use debug_mode
+                if install_method.is_dev_mode:
                     initial_debug_mode = (
                         self.debug_mode if self.debug_mode is not None else True
                     )
                     debug_mode_clause = f"debug_mode = {initial_debug_mode}"
 
+                using_clause = install_method.using_clause(self._na_project)
                 self._execute_query(
                     dedent(
                         f"""\
@@ -377,6 +339,9 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                     """
                     )
                 )
+
+                # hooks always executed after a create or upgrade
+                self._execute_post_deploy_hooks()
 
             except ProgrammingError as err:
                 generic_sql_error_handler(err)
@@ -393,12 +358,21 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
         *args,
         **kwargs,
     ):
-        """app run process"""
+        """
+        Create or upgrade the application object using the given strategy
+        (unversioned dev, versioned dev, or same-account release directive).
+        """
 
+        # same-account release directive
         if from_release_directive:
-            self.upgrade_app(policy=policy, is_interactive=is_interactive)
+            self.create_or_upgrade_app(
+                policy=policy,
+                is_interactive=is_interactive,
+                install_method=SameAccountInstallMethod.release_directive(),
+            )
             return
 
+        # versioned dev
         if version:
             try:
                 version_exists = self.get_existing_version_info(version)
@@ -411,15 +385,19 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                     f"Application package {self.package_name} does not exist. Use 'snow app version create' to first create an application package and then define a version in it."
                 )
 
-            self.upgrade_app(
+            self.create_or_upgrade_app(
                 policy=policy,
-                version=version,
-                patch=patch,
+                install_method=SameAccountInstallMethod.versioned_dev(version, patch),
                 is_interactive=is_interactive,
             )
             return
 
+        # unversioned dev
         self.deploy(
             bundle_map=bundle_map, prune=True, recursive=True, validate=validate
         )
-        self._create_dev_app(policy=policy, is_interactive=is_interactive)
+        self.create_or_upgrade_app(
+            policy=policy,
+            is_interactive=is_interactive,
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -37,7 +37,10 @@ from snowflake.cli.plugins.nativeapp.policy import (
     AskAlwaysPolicy,
     DenyAlwaysPolicy,
 )
-from snowflake.cli.plugins.nativeapp.run_processor import NativeAppRunProcessor
+from snowflake.cli.plugins.nativeapp.run_processor import (
+    NativeAppRunProcessor,
+    SameAccountInstallMethod,
+)
 from snowflake.cli.plugins.stage.diff import DiffResult
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
@@ -48,7 +51,6 @@ from tests.nativeapp.patch_utils import (
 )
 from tests.nativeapp.utils import (
     NATIVEAPP_MANAGER_EXECUTE,
-    NATIVEAPP_MANAGER_EXECUTE_QUERIES,
     RUN_PROCESSOR_GET_EXISTING_APP_INFO,
     TYPER_CONFIRM,
     mock_execute_helper,
@@ -122,7 +124,10 @@ def test_create_dev_app_w_warehouse_access_exception(
     assert not mock_diff_result.has_changes()
 
     with pytest.raises(ProgrammingError) as err:
-        run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+        run_processor.create_or_upgrade_app(
+            policy=MagicMock(),
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )
 
     assert mock_execute.mock_calls == expected
     assert "Please grant usage privilege on warehouse to this role." in err.value.msg
@@ -149,9 +154,7 @@ def test_create_dev_app_create_new_w_no_additional_privileges(
                     dedent(
                         f"""\
                     create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -173,18 +176,18 @@ def test_create_dev_app_create_new_w_no_additional_privileges(
 
     run_processor = _get_na_run_processor()
     assert not mock_diff_result.has_changes()
-    run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
 # Test create_dev_app with no existing application AND create succeeds AND app role != package role
 @mock.patch(RUN_PROCESSOR_GET_EXISTING_APP_INFO, return_value=None)
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
 @mock_connection()
 def test_create_dev_app_create_new_with_additional_privileges(
     mock_conn,
-    mock_execute_queries,
     mock_execute_query,
     mock_get_existing_app_info,
     temp_dir,
@@ -203,6 +206,20 @@ def test_create_dev_app_create_new_with_additional_privileges(
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
             (None, mock.call("use role package_role")),
+            (
+                None,
+                mock.call(
+                    "grant install, develop on application package app_pkg to role app_role"
+                ),
+            ),
+            (
+                None,
+                mock.call("grant usage on schema app_pkg.app_src to role app_role"),
+            ),
+            (
+                None,
+                mock.call("grant read on stage app_pkg.app_src.stage to role app_role"),
+            ),
             (None, mock.call("use role app_role")),
             (
                 None,
@@ -210,9 +227,7 @@ def test_create_dev_app_create_new_with_additional_privileges(
                     dedent(
                         f"""\
                     create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -224,19 +239,6 @@ def test_create_dev_app_create_new_with_additional_privileges(
     mock_conn.return_value = MockConnectionCtx()
     mock_execute_query.side_effect = side_effects
 
-    mock_execute_queries_expected = [
-        mock.call(
-            dedent(
-                f"""\
-            grant install, develop on application package app_pkg to role app_role;
-            grant usage on schema app_pkg.app_src to role app_role;
-            grant read on stage app_pkg.app_src.stage to role app_role;
-            """
-            )
-        )
-    ]
-    mock_execute_queries.side_effect = [None, None, None]
-
     mock_diff_result = DiffResult()
     current_working_directory = os.getcwd()
     create_named_file(
@@ -247,9 +249,10 @@ def test_create_dev_app_create_new_with_additional_privileges(
 
     run_processor = _get_na_run_processor()
     assert not mock_diff_result.has_changes()
-    run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute_query.mock_calls == mock_execute_query_expected
-    assert mock_execute_queries.mock_calls == mock_execute_queries_expected
 
 
 # Test create_dev_app with no existing application AND create throws an exception
@@ -275,9 +278,7 @@ def test_create_dev_app_create_new_w_missing_warehouse_exception(
                     dedent(
                         f"""\
                     create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -302,7 +303,10 @@ def test_create_dev_app_create_new_w_missing_warehouse_exception(
     assert not mock_diff_result.has_changes()
 
     with pytest.raises(ProgrammingError) as err:
-        run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+        run_processor.create_or_upgrade_app(
+            policy=MagicMock(),
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )
 
     assert "Please provide a warehouse for the active session role" in err.value.msg
     assert mock_execute.mock_calls == expected
@@ -363,7 +367,10 @@ def test_create_dev_app_incorrect_properties(
     with pytest.raises(ApplicationAlreadyExistsError):
         run_processor = _get_na_run_processor()
         assert not mock_diff_result.has_changes()
-        run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+        run_processor.create_or_upgrade_app(
+            policy=MagicMock(),
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )
 
     assert mock_execute.mock_calls == expected
 
@@ -406,7 +413,10 @@ def test_create_dev_app_incorrect_owner(
     with pytest.raises(UnexpectedOwnerError):
         run_processor = _get_na_run_processor()
         assert not mock_diff_result.has_changes()
-        run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+        run_processor.create_or_upgrade_app(
+            policy=MagicMock(),
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )
 
     assert mock_execute.mock_calls == expected
 
@@ -455,7 +465,9 @@ def test_create_dev_app_no_diff_changes(
 
     run_processor = _get_na_run_processor()
     assert not mock_diff_result.has_changes()
-    run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -503,7 +515,9 @@ def test_create_dev_app_w_diff_changes(
 
     run_processor = _get_na_run_processor()
     assert mock_diff_result.has_changes()
-    run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -554,7 +568,10 @@ def test_create_dev_app_recreate_w_missing_warehouse_exception(
     assert mock_diff_result.has_changes()
 
     with pytest.raises(ProgrammingError) as err:
-        run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+        run_processor.create_or_upgrade_app(
+            policy=MagicMock(),
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )
 
     assert mock_execute.mock_calls == expected
     assert "Please provide a warehouse for the active session role" in err.value.msg
@@ -581,9 +598,7 @@ def test_create_dev_app_create_new_quoted(
                     dedent(
                         f"""\
                     create application "My Application"
-                        from application package "My Package"
-                        using '@"My Package".app_src.stage'
-                        debug_mode = True
+                        from application package "My Package" using '@"My Package".app_src.stage' debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -637,7 +652,9 @@ def test_create_dev_app_create_new_quoted(
 
     run_processor = _get_na_run_processor()
     assert not mock_diff_result.has_changes()
-    run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -662,9 +679,7 @@ def test_create_dev_app_create_new_quoted_override(
                     dedent(
                         f"""\
                     create application "My Application"
-                        from application package "My Package"
-                        using '@"My Package".app_src.stage'
-                        debug_mode = True
+                        from application package "My Package" using '@"My Package".app_src.stage' debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -691,7 +706,9 @@ def test_create_dev_app_create_new_quoted_override(
 
     run_processor = _get_na_run_processor()
     assert not mock_diff_result.has_changes()
-    run_processor._create_dev_app(policy=MagicMock())  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -739,6 +756,20 @@ def test_create_dev_app_recreate_app_when_orphaned(
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
             (None, mock.call("use role package_role")),
+            (
+                None,
+                mock.call(
+                    "grant install, develop on application package app_pkg to role app_role"
+                ),
+            ),
+            (
+                None,
+                mock.call("grant usage on schema app_pkg.app_src to role app_role"),
+            ),
+            (
+                None,
+                mock.call("grant read on stage app_pkg.app_src.stage to role app_role"),
+            ),
             (None, mock.call("use role app_role")),
             (
                 None,
@@ -746,9 +777,7 @@ def test_create_dev_app_recreate_app_when_orphaned(
                     dedent(
                         f"""\
                     create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -768,7 +797,9 @@ def test_create_dev_app_recreate_app_when_orphaned(
     )
 
     run_processor = _get_na_run_processor()
-    run_processor._create_dev_app(allow_always_policy)  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -837,6 +868,20 @@ def test_create_dev_app_recreate_app_when_orphaned_requires_cascade(
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
             (None, mock.call("use role package_role")),
+            (
+                None,
+                mock.call(
+                    "grant install, develop on application package app_pkg to role app_role"
+                ),
+            ),
+            (
+                None,
+                mock.call("grant usage on schema app_pkg.app_src to role app_role"),
+            ),
+            (
+                None,
+                mock.call("grant read on stage app_pkg.app_src.stage to role app_role"),
+            ),
             (None, mock.call("use role app_role")),
             (
                 None,
@@ -844,9 +889,7 @@ def test_create_dev_app_recreate_app_when_orphaned_requires_cascade(
                     dedent(
                         f"""\
                     create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -866,7 +909,9 @@ def test_create_dev_app_recreate_app_when_orphaned_requires_cascade(
     )
 
     run_processor = _get_na_run_processor()
-    run_processor._create_dev_app(allow_always_policy)  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -934,6 +979,20 @@ def test_create_dev_app_recreate_app_when_orphaned_requires_cascade_unknown_obje
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
             (None, mock.call("use role package_role")),
+            (
+                None,
+                mock.call(
+                    "grant install, develop on application package app_pkg to role app_role"
+                ),
+            ),
+            (
+                None,
+                mock.call("grant usage on schema app_pkg.app_src to role app_role"),
+            ),
+            (
+                None,
+                mock.call("grant read on stage app_pkg.app_src.stage to role app_role"),
+            ),
             (None, mock.call("use role app_role")),
             (
                 None,
@@ -941,9 +1000,7 @@ def test_create_dev_app_recreate_app_when_orphaned_requires_cascade_unknown_obje
                     dedent(
                         f"""\
                     create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
                         comment = {SPECIAL_COMMENT}
                     """
                     )
@@ -963,7 +1020,9 @@ def test_create_dev_app_recreate_app_when_orphaned_requires_cascade_unknown_obje
     )
 
     run_processor = _get_na_run_processor()
-    run_processor._create_dev_app(allow_always_policy)  # noqa: SLF001
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -1005,7 +1064,11 @@ def test_upgrade_app_warehouse_error(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(ProgrammingError):
-        run_processor.upgrade_app(policy_param, is_interactive=True)
+        run_processor.create_or_upgrade_app(
+            policy_param,
+            is_interactive=True,
+            install_method=SameAccountInstallMethod.release_directive(),
+        )
     assert mock_execute.mock_calls == expected
 
 
@@ -1052,7 +1115,11 @@ def test_upgrade_app_incorrect_owner(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(UnexpectedOwnerError):
-        run_processor.upgrade_app(policy=policy_param, is_interactive=True)
+        run_processor.create_or_upgrade_app(
+            policy=policy_param,
+            is_interactive=True,
+            install_method=SameAccountInstallMethod.release_directive(),
+        )
     assert mock_execute.mock_calls == expected
 
 
@@ -1099,7 +1166,11 @@ def test_upgrade_app_succeeds(
     )
 
     run_processor = _get_na_run_processor()
-    run_processor.upgrade_app(policy=policy_param, is_interactive=True)
+    run_processor.create_or_upgrade_app(
+        policy=policy_param,
+        is_interactive=True,
+        install_method=SameAccountInstallMethod.release_directive(),
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -1153,7 +1224,11 @@ def test_upgrade_app_fails_generic_error(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(ProgrammingError):
-        run_processor.upgrade_app(policy=policy_param, is_interactive=True)
+        run_processor.create_or_upgrade_app(
+            policy=policy_param,
+            is_interactive=True,
+            install_method=SameAccountInstallMethod.release_directive(),
+        )
     assert mock_execute.mock_calls == expected
 
 
@@ -1216,8 +1291,10 @@ def test_upgrade_app_fails_upgrade_restriction_error(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(typer.Exit):
-        result = run_processor.upgrade_app(
-            policy_param, is_interactive=is_interactive_param
+        result = run_processor.create_or_upgrade_app(
+            policy_param,
+            is_interactive=is_interactive_param,
+            install_method=SameAccountInstallMethod.release_directive(),
         )
         assert result.exit_code == expected_code
     assert mock_execute.mock_calls == expected
@@ -1288,7 +1365,11 @@ def test_upgrade_app_fails_drop_fails(
 
     run_processor = _get_na_run_processor()
     with pytest.raises(ProgrammingError):
-        run_processor.upgrade_app(policy_param, is_interactive=is_interactive_param)
+        run_processor.create_or_upgrade_app(
+            policy_param,
+            is_interactive=is_interactive_param,
+            install_method=SameAccountInstallMethod.release_directive(),
+        )
     assert mock_execute.mock_calls == expected
 
 
@@ -1338,8 +1419,16 @@ def test_upgrade_app_recreate_app(
             (
                 None,
                 mock.call(
-                    "grant install on application package app_pkg to role app_role"
+                    "grant install, develop on application package app_pkg to role app_role"
                 ),
+            ),
+            (
+                None,
+                mock.call("grant usage on schema app_pkg.app_src to role app_role"),
+            ),
+            (
+                None,
+                mock.call("grant read on stage app_pkg.app_src.stage to role app_role"),
             ),
             (None, mock.call("use role app_role")),
             (
@@ -1368,7 +1457,11 @@ def test_upgrade_app_recreate_app(
     )
 
     run_processor = _get_na_run_processor()
-    run_processor.upgrade_app(policy_param, is_interactive=True)
+    run_processor.create_or_upgrade_app(
+        policy_param,
+        is_interactive=True,
+        install_method=SameAccountInstallMethod.release_directive(),
+    )
     assert mock_execute.mock_calls == expected
 
 
@@ -1482,14 +1575,16 @@ def test_upgrade_app_recreate_app_from_version(
             (
                 None,
                 mock.call(
-                    "grant install on application package app_pkg to role app_role"
+                    "grant install, develop on application package app_pkg to role app_role"
                 ),
             ),
             (
                 None,
-                mock.call(
-                    "grant develop on application package app_pkg to role app_role"
-                ),
+                mock.call("grant usage on schema app_pkg.app_src to role app_role"),
+            ),
+            (
+                None,
+                mock.call("grant read on stage app_pkg.app_src.stage to role app_role"),
             ),
             (None, mock.call("use role app_role")),
             (


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Previously, `_create_dev_app` and `upgrade_app` duplicated a lot of each others' code. This refactor merges the two codepaths and introduces the `SameAccountInstallMethod` class to encapsulate some of the per-installation-type logic.
