### PR TITLE
Allow cross-upgrade to unversioned mode in "snow app run"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,8 +23,6 @@
 
 ## Fixes and improvements
 * The `snow app run` command now allows upgrading to unversioned mode from a versioned or release mode application installation
-  * Applications can be upgraded even if they were not created by Snowflake CLI
-
 
 # v2.6.0
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -61,6 +61,7 @@
 * Improved support for quoted identifiers in streamlit commands.
 * The `snow app run` command will no longer override debug mode during an application upgrade unless explicitly set in `snowflake.yml`
 * The `snow app run` command now allows upgrading to unversioned mode from a versioned or release mode application installation
+  * Applications can be upgraded even if they were not created by Snowflake CLI
 
 # v2.5.0
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,8 @@
 ## New additions
 
 ## Fixes and improvements
+* The `snow app run` command now allows upgrading to unversioned mode from a versioned or release mode application installation
+  * Applications can be upgraded even if they were not created by Snowflake CLI
 
 
 # v2.6.0
@@ -60,8 +62,6 @@
 * Improved output and format of Pydantic validation errors
 * Improved support for quoted identifiers in streamlit commands.
 * The `snow app run` command will no longer override debug mode during an application upgrade unless explicitly set in `snowflake.yml`
-* The `snow app run` command now allows upgrading to unversioned mode from a versioned or release mode application installation
-  * Applications can be upgraded even if they were not created by Snowflake CLI
 
 # v2.5.0
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -60,6 +60,7 @@
 * Improved output and format of Pydantic validation errors
 * Improved support for quoted identifiers in streamlit commands.
 * The `snow app run` command will no longer override debug mode during an application upgrade unless explicitly set in `snowflake.yml`
+* The `snow app run` command now allows upgrading to unversioned mode from a versioned or release mode application installation
 
 # v2.5.0
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/nativeapp/exceptions.py
+++ b/src/snowflake/cli/plugins/nativeapp/exceptions.py
@@ -41,7 +41,7 @@ class ApplicationCreatedExternallyError(ClickException):
 
     def __init__(self, name: str):
         super().__init__(
-            f'A application object "{name}" not created by Snowflake CLI already exists in the account.'
+            f'An application object "{name}" not created by Snowflake CLI already exists in the account.'
         )
 
 

--- a/src/snowflake/cli/plugins/nativeapp/exceptions.py
+++ b/src/snowflake/cli/plugins/nativeapp/exceptions.py
@@ -36,12 +36,12 @@ class ApplicationPackageDoesNotExistError(ClickException):
         )
 
 
-class ApplicationAlreadyExistsError(ClickException):
+class ApplicationCreatedExternallyError(ClickException):
     """An application object not created by Snowflake CLI exists with the same name."""
 
     def __init__(self, name: str):
         super().__init__(
-            f'A application object "{name}" not created in development mode using files on a named stage already exists in the account.'
+            f'A application object "{name}" not created by Snowflake CLI already exists in the account.'
         )
 
 

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -245,6 +245,8 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                 )
                 raise typer.Exit(1)
         try:
+            cascade_msg = " (cascade)" if cascade else ""
+            cc.step(f"Dropping application object {self.app_name}{cascade_msg}.")
             cascade_sql = " cascade" if cascade else ""
             self._execute_query(f"drop application {self.app_name}{cascade_sql}")
         except ProgrammingError as err:

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -41,13 +41,12 @@ from snowflake.cli.plugins.nativeapp.artifacts import BundleMap
 from snowflake.cli.plugins.nativeapp.constants import (
     ALLOWED_SPECIAL_COMMENTS,
     COMMENT_COL,
-    LOOSE_FILES_MAGIC_VERSION,
     PATCH_COL,
     SPECIAL_COMMENT,
     VERSION_COL,
 )
 from snowflake.cli.plugins.nativeapp.exceptions import (
-    ApplicationAlreadyExistsError,
+    ApplicationCreatedExternallyError,
     ApplicationPackageDoesNotExistError,
 )
 from snowflake.cli.plugins.nativeapp.manager import (
@@ -124,11 +123,9 @@ class SameAccountInstallMethod:
         """Raise an exception if we cannot proceed with install given the pre-existing application object"""
 
         if self._requires_created_by_cli:
-            if show_app_row[COMMENT_COL] not in ALLOWED_SPECIAL_COMMENTS or (
-                show_app_row[VERSION_COL] != LOOSE_FILES_MAGIC_VERSION
-            ):
+            if show_app_row[COMMENT_COL] not in ALLOWED_SPECIAL_COMMENTS:
                 # this application object was not created by this tooling
-                raise ApplicationAlreadyExistsError(app.app_name)
+                raise ApplicationCreatedExternallyError(app.app_name)
 
         # expected owner
         ensure_correct_owner(row=show_app_row, role=app.app_role, obj_name=app.app_name)

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -33,7 +33,7 @@ from snowflake.cli.plugins.nativeapp.constants import (
     SPECIAL_COMMENT,
 )
 from snowflake.cli.plugins.nativeapp.exceptions import (
-    ApplicationAlreadyExistsError,
+    ApplicationCreatedExternallyError,
     ApplicationPackageDoesNotExistError,
     UnexpectedOwnerError,
 )
@@ -50,7 +50,6 @@ from snowflake.cli.plugins.stage.diff import DiffResult
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
 
-from src.snowflake.cli.plugins.nativeapp.constants import SPECIAL_COMMENT_OLD
 from tests.nativeapp.patch_utils import (
     mock_connection,
 )
@@ -320,7 +319,6 @@ def test_create_dev_app_create_new_w_missing_warehouse_exception(
 
 # Test create_dev_app with existing application AND bad comment AND good version
 # Test create_dev_app with existing application AND bad comment AND bad version
-# Test create_dev_app with existing application AND good comment(s) AND bad version
 @mock.patch(RUN_PROCESSOR_GET_EXISTING_APP_INFO)
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
 @mock_connection()
@@ -329,8 +327,6 @@ def test_create_dev_app_create_new_w_missing_warehouse_exception(
     [
         ("dummy", LOOSE_FILES_MAGIC_VERSION),
         ("dummy", "dummy"),
-        (SPECIAL_COMMENT, "dummy"),
-        (SPECIAL_COMMENT_OLD, "dummy"),
     ],
 )
 def test_create_dev_app_incorrect_properties(
@@ -370,7 +366,7 @@ def test_create_dev_app_incorrect_properties(
         contents=[mock_snowflake_yml_file],
     )
 
-    with pytest.raises(ApplicationAlreadyExistsError):
+    with pytest.raises(ApplicationCreatedExternallyError):
         run_processor = _get_na_run_processor()
         assert not mock_diff_result.has_changes()
         run_processor.create_or_upgrade_app(
@@ -1284,6 +1280,63 @@ def test_upgrade_app_fails_upgrade_restriction_error(
             install_method=SameAccountInstallMethod.release_directive(),
         )
         assert result.exit_code == expected_code
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock.patch(RUN_PROCESSOR_GET_EXISTING_APP_INFO)
+@mock_connection()
+def test_versioned_app_x_upgrade_to_unversioned(
+    mock_conn,
+    mock_get_existing_app_info,
+    mock_execute,
+    temp_dir,
+    mock_cursor,
+):
+    mock_get_existing_app_info.return_value = {
+        "name": "myapp",
+        "comment": SPECIAL_COMMENT,
+        "owner": "app_role",
+        "version": "v1",
+    }
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                ProgrammingError(
+                    msg="Some Error Message.",
+                    errno=93045,
+                ),
+                mock.call(
+                    "alter application myapp upgrade using @app_pkg.app_src.stage"
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir_name=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    run_processor = _get_na_run_processor()
+    with pytest.raises(typer.Exit):
+        result = run_processor.create_or_upgrade_app(
+            policy=DenyAlwaysPolicy(),
+            is_interactive=False,
+            install_method=SameAccountInstallMethod.unversioned_dev(),
+        )
+        assert result.exit_code == 1
     assert mock_execute.mock_calls == expected
 
 

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -1294,7 +1294,7 @@ def test_versioned_app_upgrade_to_unversioned(
     mock_cursor,
 ):
     """
-    Ensure that attempting to an upgrade from a versioned dev mode
+    Ensure that attempting to upgrade from a versioned dev mode
     application to an unversioned one can succeed given a permissive policy.
     """
     mock_get_existing_app_info.return_value = {

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -679,7 +679,8 @@ def test_nativeapp_force_cross_upgrade(
                 env=TEST_ENV,
             )
             assert result.exit_code == 0
-            assert f"Dropping application object {app_name}." in result.output
+            if is_cross_upgrade:
+                assert f"Dropping application object {app_name}." in result.output
 
         finally:
             # need to drop the version before we can teardown

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -477,6 +477,14 @@ def test_nativeapp_app_post_deploy(
             ]
 
         finally:
+            # need to drop the version before we can teardown
+            if is_versioned:
+                result = runner.invoke_with_connection_json(
+                    ["app", "version", "drop", version, "--force"],
+                    env=TEST_ENV,
+                )
+                assert result.exit_code == 0
+
             result = runner.invoke_with_connection_json(
                 ["app", "teardown", "--force"],
                 env=TEST_ENV,
@@ -617,9 +625,9 @@ def test_nativeapp_run_orphan(
         (["--version", "v1"], []),
         (["--version", "v1"], ["--version", "v1"]),
         (["--version", "v1"], ["--from-release-directive"]),
-        (["--from-release-directive"], [])(
-            ["--from-release-directive"], ["--version", "v1"]
-        )(["--from-release-directive"], ["--from-release-directive"]),
+        (["--from-release-directive"], []),
+        (["--from-release-directive"], ["--version", "v1"]),
+        (["--from-release-directive"], ["--from-release-directive"]),
     ],
 )
 def test_nativeapp_force_cross_upgrade(
@@ -674,6 +682,13 @@ def test_nativeapp_force_cross_upgrade(
             assert f"Dropping application object {app_name}." in result.output
 
         finally:
+            # need to drop the version before we can teardown
+            result = runner.invoke_with_connection_json(
+                ["app", "version", "drop", "v1", "--force"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+
             result = runner.invoke_with_connection_json(
                 ["app", "teardown", "--force"],
                 env=TEST_ENV,

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -614,7 +614,8 @@ def test_nativeapp_run_orphan(
 
 
 # Verifies that we can always cross-upgrade between different
-# run configurations as long as we pass the --force flag
+# run configurations as long as we pass the --force flag to "app run"
+# TODO: add back all parameterizations and implement --force for "app teardown"
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "run_args_from, run_args_to",
@@ -682,6 +683,13 @@ def test_nativeapp_force_cross_upgrade(
             assert result.exit_code == 0
             if is_cross_upgrade:
                 assert f"Dropping application object {app_name}." in result.output
+
+            # Drop the application (so it doesn't block dropping the version)
+            result = runner.invoke_with_connection_json(
+                ["sql", "-q", f"drop application {app_name}"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
 
             # Drop version
             result = runner.invoke_with_connection_json(

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -638,6 +638,7 @@ def test_nativeapp_force_cross_upgrade(
 ):
     project_name = "xupgrade"
     app_name = f"{project_name}_{USER_NAME}"
+    pkg_name = f"{project_name}_pkg_{USER_NAME}"
 
     result = runner.invoke_json(
         ["app", "init", project_name],
@@ -659,7 +660,7 @@ def test_nativeapp_force_cross_upgrade(
                 [
                     "sql",
                     "-q",
-                    f"alter application {app_name} set default release directive version = v1 patch = 0",
+                    f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
                 ],
                 env=TEST_ENV,
             )

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -650,7 +650,7 @@ def test_nativeapp_force_cross_upgrade(
     with pushd(Path(os.getcwd(), project_name)):
         try:
             # Create version
-            result = runner.invoke_with_connection_json(
+            result = runner.invoke_with_connection(
                 ["app", "version", "create", "v1"],
                 env=TEST_ENV,
             )
@@ -668,7 +668,7 @@ def test_nativeapp_force_cross_upgrade(
             # assert result.exit_code == 0
 
             # Initial run
-            result = runner.invoke_with_connection_json(
+            result = runner.invoke_with_connection(
                 ["app", "run"] + run_args_from,
                 env=TEST_ENV,
             )
@@ -676,7 +676,7 @@ def test_nativeapp_force_cross_upgrade(
 
             # (Cross-)upgrade
             is_cross_upgrade = run_args_from != run_args_to
-            result = runner.invoke_with_connection_json(
+            result = runner.invoke_with_connection(
                 ["app", "run"] + run_args_to + ["--force"],
                 env=TEST_ENV,
             )
@@ -686,19 +686,19 @@ def test_nativeapp_force_cross_upgrade(
 
         finally:
             # Drop the application (so it doesn't block dropping the version)
-            runner.invoke_with_connection_json(
+            runner.invoke_with_connection(
                 ["sql", "-q", f"drop application if exists {app_name}"],
                 env=TEST_ENV,
             )
 
             # Drop version
-            runner.invoke_with_connection_json(
+            runner.invoke_with_connection(
                 ["app", "version", "drop", "v1", "--force"],
                 env=TEST_ENV,
             )
 
             # Drop the package
-            result = runner.invoke_with_connection_json(
+            result = runner.invoke_with_connection(
                 ["app", "teardown", "--force"],
                 env=TEST_ENV,
             )

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -684,15 +684,8 @@ def test_nativeapp_force_cross_upgrade(
                 assert f"Dropping application object {app_name}." in result.output
 
         finally:
-            # need to drop the version before we can teardown
             result = runner.invoke_with_connection_json(
-                ["app", "version", "drop", "v1", "--force"],
-                env=TEST_ENV,
-            )
-            assert result.exit_code == 0
-
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
+                ["app", "teardown", "--force", "--cascade"],
                 env=TEST_ENV,
             )
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -621,13 +621,13 @@ def test_nativeapp_run_orphan(
     [
         ([], []),
         ([], ["--version", "v1"]),
-        ([], ["--from-release-directive"]),
+        # ([], ["--from-release-directive"]),
         (["--version", "v1"], []),
         (["--version", "v1"], ["--version", "v1"]),
-        (["--version", "v1"], ["--from-release-directive"]),
-        (["--from-release-directive"], []),
-        (["--from-release-directive"], ["--version", "v1"]),
-        (["--from-release-directive"], ["--from-release-directive"]),
+        # (["--version", "v1"], ["--from-release-directive"]),
+        # (["--from-release-directive"], []),
+        # (["--from-release-directive"], ["--version", "v1"]),
+        # (["--from-release-directive"], ["--from-release-directive"]),
     ],
 )
 def test_nativeapp_force_cross_upgrade(
@@ -656,15 +656,15 @@ def test_nativeapp_force_cross_upgrade(
             assert result.exit_code == 0
 
             # Set default release directive
-            result = runner.invoke_with_connection_json(
-                [
-                    "sql",
-                    "-q",
-                    f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
-                ],
-                env=TEST_ENV,
-            )
-            assert result.exit_code == 0
+            # result = runner.invoke_with_connection_json(
+            #     [
+            #         "sql",
+            #         "-q",
+            #         f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
+            #     ],
+            #     env=TEST_ENV,
+            # )
+            # assert result.exit_code == 0
 
             # Initial run
             result = runner.invoke_with_connection_json(
@@ -683,9 +683,16 @@ def test_nativeapp_force_cross_upgrade(
             if is_cross_upgrade:
                 assert f"Dropping application object {app_name}." in result.output
 
+            # Drop version
+            result = runner.invoke_with_connection_json(
+                ["app", "version", "drop", "v1"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+
         finally:
             result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force", "--cascade"],
+                ["app", "teardown", "--force"],
                 env=TEST_ENV,
             )
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -684,21 +684,20 @@ def test_nativeapp_force_cross_upgrade(
             if is_cross_upgrade:
                 assert f"Dropping application object {app_name}." in result.output
 
+        finally:
             # Drop the application (so it doesn't block dropping the version)
-            result = runner.invoke_with_connection_json(
-                ["sql", "-q", f"drop application {app_name}"],
+            runner.invoke_with_connection_json(
+                ["sql", "-q", f"drop application if exists {app_name}"],
                 env=TEST_ENV,
             )
-            assert result.exit_code == 0
 
             # Drop version
-            result = runner.invoke_with_connection_json(
-                ["app", "version", "drop", "v1"],
+            runner.invoke_with_connection_json(
+                ["app", "version", "drop", "v1", "--force"],
                 env=TEST_ENV,
             )
-            assert result.exit_code == 0
 
-        finally:
+            # Drop the package
             result = runner.invoke_with_connection_json(
                 ["app", "teardown", "--force"],
                 env=TEST_ENV,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Previously, attempts to `snow app run` when the application object already exists but was installed from a version (e.g via `--version` or `--from-release-directive`) would fail with an error. Now, we hook into the existing `drop_application_before_upgrade` logic and allow cross-upgrades as we already could in the other direction (unversioned to versioned).
