### PR TITLE
Allow adding a version to a package without CLI magic comment

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 ## Fixes and improvements
 * The `snow app run` command now allows upgrading to unversioned mode from a versioned or release mode application installation
 * The `snow app teardown` command now allows dropping a package with versions when the `--force` flag is provided
+* The `snow app version create` command now allows operating on application packages created outside the CLI
 * Added support for user stages in stage execute command
 * Added support for user stages in stage and git copy commands
 

--- a/tests_integration/nativeapp/__snapshots__/test_version.ambr
+++ b/tests_integration/nativeapp/__snapshots__/test_version.ambr
@@ -1,0 +1,29 @@
+# serializer version: 1
+# name: test_nativeapp_version_create_package_no_magic_comment[integration]
+  list([
+    dict({
+      'comment': 'Default version used for development. Override for actual deployment.',
+      'created_on': '2024-07-09T11:53:43.234000-07:00',
+      'dropped_on': None,
+      'label': 'Dev Version',
+      'log_level': 'INFO',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'ALWAYS',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': 'Default version used for development. Override for actual deployment.',
+      'created_on': '2024-07-09T11:54:02.487000-07:00',
+      'dropped_on': None,
+      'label': 'Dev Version',
+      'log_level': 'INFO',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'ALWAYS',
+      'version': 'V1',
+    }),
+  ])
+# ---

--- a/tests_integration/nativeapp/__snapshots__/test_version.ambr
+++ b/tests_integration/nativeapp/__snapshots__/test_version.ambr
@@ -3,7 +3,6 @@
   list([
     dict({
       'comment': 'Default version used for development. Override for actual deployment.',
-      'created_on': '2024-07-09T11:53:43.234000-07:00',
       'dropped_on': None,
       'label': 'Dev Version',
       'log_level': 'INFO',
@@ -15,7 +14,6 @@
     }),
     dict({
       'comment': 'Default version used for development. Override for actual deployment.',
-      'created_on': '2024-07-09T11:54:02.487000-07:00',
       'dropped_on': None,
       'label': 'Dev Version',
       'log_level': 'INFO',

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -406,6 +406,9 @@ def test_nativeapp_version_create_package_no_magic_comment(
             actual = runner.invoke_with_connection_json(
                 ["app", "version", "list"], env=TEST_ENV
             )
+            for row in actual.json:
+                # Remove date field
+                row.pop("created_on", None)
             assert actual.json == snapshot
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -363,10 +363,18 @@ def test_nativeapp_version_create_package_no_magic_comment(
             )
 
             result_create = runner.invoke_with_connection_json(
+                ["app", "version", "create", "v1", "--skip-git-check"],
+                env=TEST_ENV,
+                input="n\n",
+            )
+            assert result_create.exit_code == 1
+            assert result_create.output == "Aborted.\n"
+
+            result_create_force = runner.invoke_with_connection_json(
                 ["app", "version", "create", "v1", "--force", "--skip-git-check"],
                 env=TEST_ENV,
             )
-            assert result_create.exit_code == 0
+            assert result_create_force.exit_code == 0
 
             # app package contains version v1
             expect = snowflake_session.execute_string(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Prompts the user when running `snow app version create` against a package that was not created by the CLI. The standard `--interactive/--no-interactive` and `--force` flags apply as usual.
