### PR TITLE
Support project definition v2 in "snow app open"

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -257,7 +257,6 @@ def app_open(
 
 @app.command("teardown", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
 def app_teardown(
     force: Optional[bool] = ForceOption,
     cascade: Optional[bool] = typer.Option(

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -58,6 +58,9 @@ from snowflake.cli.plugins.nativeapp.utils import (
     get_first_paragraph_from_markdown_file,
     shallow_git_clone,
 )
+from snowflake.cli.plugins.nativeapp.v2_conversions.v2_to_v1_decorator import (
+    nativeapp_definition_v2_to_v1,
+)
 from snowflake.cli.plugins.nativeapp.version.commands import app as versions_app
 
 app = SnowTyperFactory(
@@ -228,6 +231,7 @@ def app_run(
 
 @app.command("open", requires_connection=True)
 @with_project_definition()
+@nativeapp_definition_v2_to_v1
 def app_open(
     **options,
 ) -> CommandResult:

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -257,6 +257,7 @@ def app_open(
 
 @app.command("teardown", requires_connection=True)
 @with_project_definition()
+@nativeapp_definition_v2_to_v1
 def app_teardown(
     force: Optional[bool] = ForceOption,
     cascade: Optional[bool] = typer.Option(

--- a/src/snowflake/cli/plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from click import ClickException
 from snowflake.cli.api.cli_global_context import cli_context, cli_context_manager
@@ -31,10 +31,55 @@ from snowflake.cli.api.project.schemas.project_definition import (
 )
 
 
+def _pdf_v2_to_v1(v2_definition: DefinitionV20) -> DefinitionV11:
+    pdfv1: Dict[str, Any] = {"definition_version": "1.1", "native_app": {}}
+
+    app_package_definition: ApplicationPackageEntity = None
+    app_definition: Optional[ApplicationEntity] = None
+
+    for key, entity in v2_definition.entities.items():
+        if entity.get_type() == ApplicationPackageEntity.get_type():
+            if app_package_definition:
+                raise ClickException(
+                    "More than one application package entity exists in the project definition file."
+                )
+            app_package_definition = entity
+        elif entity.get_type() == ApplicationEntity.get_type():
+            if app_definition:
+                raise ClickException(
+                    "More than one application entity exists in the project definition file."
+                )
+            app_definition = entity
+    if not app_package_definition:
+        raise ClickException(
+            "Could not find an application package entity in the project definition file."
+        )
+
+    # NativeApp
+    pdfv1["native_app"]["name"] = "Auto converted NativeApp project from V2"
+    pdfv1["native_app"]["artifacts"] = app_package_definition.artifacts
+    pdfv1["native_app"]["source_stage"] = app_package_definition.stage
+
+    # Package
+    pdfv1["native_app"]["package"] = {}
+    pdfv1["native_app"]["package"]["name"] = app_package_definition.name
+
+    # Application
+    if app_definition:
+        pdfv1["native_app"]["application"] = {}
+        pdfv1["native_app"]["application"]["name"] = app_definition.name
+        if app_definition.meta and app_definition.meta.role:
+            pdfv1["native_app"]["application"]["role"] = app_definition.meta.role
+
+    # Override the definition object in global context
+    return DefinitionV11(**pdfv1)
+
+
 def nativeapp_definition_v2_to_v1(func):
     """
     A command decorator that attempts to automatically convert a native app project from
     definition v2 to v1.1.
+    The definition object in CliGlobalContext will be replaced with the converted object.
     Exactly one application package entity type is expected, and up to one application
     entity type is expected.
     """
@@ -43,45 +88,8 @@ def nativeapp_definition_v2_to_v1(func):
     def wrapper(*args, **kwargs):
         original_pdf: DefinitionV20 = cli_context.project_definition
         if original_pdf.definition_version == "2":
-            pdfv1 = {"definition_version": "1.1", "native_app": {}}
-
-            app_package_definition: ApplicationPackageEntity = None
-            app_definition: Optional[ApplicationEntity] = None
-
-            for key, entity in original_pdf.entities.items():
-                if entity.get_type() == ApplicationPackageEntity.get_type():
-                    if app_package_definition:
-                        raise ClickException(
-                            "More than one application package entity exists in the project definition file."
-                        )
-                    app_package_definition = entity
-                elif entity.get_type() == ApplicationEntity.get_type():
-                    if app_definition:
-                        raise ClickException(
-                            "More than one application entity exists in the project definition file."
-                        )
-                    app_definition = entity
-            if not app_package_definition:
-                raise ClickException(
-                    "Could not find an application package entity in the project definition file."
-                )
-
-            # NativeApp
-            pdfv1["native_app"]["name"] = "Auto converted NativeApp project from V2"
-            pdfv1["native_app"]["artifacts"] = app_package_definition.artifacts
-            pdfv1["native_app"]["source_stage"] = app_package_definition.stage
-
-            # Package
-            pdfv1["native_app"]["package"] = {}
-            pdfv1["native_app"]["package"]["name"] = app_package_definition.name
-
-            # Application
-            if app_definition:
-                pdfv1["native_app"]["application"] = {}
-                pdfv1["native_app"]["application"]["name"] = app_definition.name
-
-            # Override the definition object in global context
-            cli_context_manager.set_project_definition(DefinitionV11(**pdfv1))
+            pdfv1 = _pdf_v2_to_v1(original_pdf)
+            cli_context_manager.set_project_definition(pdfv1)
         return func(*args, **kwargs)
 
     return wrapper

--- a/src/snowflake/cli/plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -78,7 +78,7 @@ def _pdf_v2_to_v1(v2_definition: DefinitionV20) -> DefinitionV11:
 def nativeapp_definition_v2_to_v1(func):
     """
     A command decorator that attempts to automatically convert a native app project from
-    definition v2 to v1.1.
+    definition v2 to v1.1. Assumes with_project_definition() has already been called.
     The definition object in CliGlobalContext will be replaced with the converted object.
     Exactly one application package entity type is expected, and up to one application
     entity type is expected.
@@ -87,6 +87,10 @@ def nativeapp_definition_v2_to_v1(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         original_pdf: DefinitionV20 = cli_context.project_definition
+        if not original_pdf:
+            raise ValueError(
+                "Project definition could not be found. The nativeapp_definition_v2_to_v1 command decorator assumes with_project_definition() was called before it."
+            )
         if original_pdf.definition_version == "2":
             pdfv1 = _pdf_v2_to_v1(original_pdf)
             cli_context_manager.set_project_definition(pdfv1)

--- a/src/snowflake/cli/plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Optional
+
+from click import ClickException
+from snowflake.cli.api.cli_global_context import cli_context, cli_context_manager
+from snowflake.cli.api.project.schemas.entities.application_entity import (
+    ApplicationEntity,
+)
+from snowflake.cli.api.project.schemas.entities.application_package_entity import (
+    ApplicationPackageEntity,
+)
+from snowflake.cli.api.project.schemas.project_definition import (
+    DefinitionV11,
+    DefinitionV20,
+)
+
+
+def nativeapp_definition_v2_to_v1(func):
+    """
+    A command decorator that attempts to automatically convert a native app project from
+    definition v2 to v1.1.
+    Exactly one application package entity type is expected, and up to one application
+    entity type is expected.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        original_pdf: DefinitionV20 = cli_context.project_definition
+        if original_pdf.definition_version == "2":
+            pdfv1 = {"definition_version": "1.1", "native_app": {}}
+
+            app_package_definition: ApplicationPackageEntity = None
+            app_definition: Optional[ApplicationEntity] = None
+
+            for key, entity in original_pdf.entities.items():
+                if entity.get_type() == ApplicationPackageEntity.get_type():
+                    if app_package_definition:
+                        raise ClickException(
+                            "More than one application package entity exists in the project definition file."
+                        )
+                    app_package_definition = entity
+                elif entity.get_type() == ApplicationEntity.get_type():
+                    if app_definition:
+                        raise ClickException(
+                            "More than one application entity exists in the project definition file."
+                        )
+                    app_definition = entity
+            if not app_package_definition:
+                raise ClickException(
+                    "Could not find an application package entity in the project definition file."
+                )
+
+            # NativeApp
+            pdfv1["native_app"]["name"] = "Auto converted NativeApp project from V2"
+            pdfv1["native_app"]["artifacts"] = app_package_definition.artifacts
+            pdfv1["native_app"]["source_stage"] = app_package_definition.stage
+
+            # Package
+            pdfv1["native_app"]["package"] = {}
+            pdfv1["native_app"]["package"]["name"] = app_package_definition.name
+
+            # Application
+            if app_definition:
+                pdfv1["native_app"]["application"] = {}
+                pdfv1["native_app"]["application"]["name"] = app_definition.name
+
+            # Override the definition object in global context
+            cli_context_manager.set_project_definition(DefinitionV11(**pdfv1))
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/nativeapp/test_v2_to_v1.py
+++ b/tests/nativeapp/test_v2_to_v1.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from click import ClickException
+from snowflake.cli.api.project.schemas.project_definition import (
+    DefinitionV11,
+    DefinitionV20,
+)
+
+# from snowflake.cli.api.project.errors import SchemaValidationError
+from snowflake.cli.plugins.nativeapp.v2_conversions.v2_to_v1_decorator import (
+    _pdf_v2_to_v1,
+)
+
+from tests.testing_utils.mock_config import mock_config_key
+
+
+@pytest.mark.parametrize(
+    "pdfv2_input, expected_pdfv1, expected_error",
+    [
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    "pkg1": {
+                        "type": "application package",
+                        "name": "pkg",
+                        "artifacts": [],
+                        "manifest": "",
+                    },
+                    "pkg2": {
+                        "type": "application package",
+                        "name": "pkg",
+                        "artifacts": [],
+                        "manifest": "",
+                    },
+                },
+            },
+            None,
+            "More than one application package entity exists",
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    "pkg": {
+                        "type": "application package",
+                        "name": "pkg",
+                        "artifacts": [],
+                        "manifest": "",
+                    },
+                    "app1": {
+                        "type": "application",
+                        "name": "pkg",
+                        "from": {"target": "pkg"},
+                    },
+                    "app2": {
+                        "type": "application",
+                        "name": "pkg",
+                        "from": {"target": "pkg"},
+                    },
+                },
+            },
+            None,
+            "More than one application entity exists",
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    "pkg": {
+                        "type": "application package",
+                        "name": "pkg_name",
+                        "artifacts": [{"src": "app/*", "dest": "./"}],
+                        "manifest": "",
+                        "stage": "app.stage",
+                    },
+                    "app": {
+                        "type": "application",
+                        "name": "app_name",
+                        "from": {"target": "pkg"},
+                        "meta": {"role": "app_role"},
+                    },
+                },
+            },
+            {
+                "definition_version": "1.1",
+                "native_app": {
+                    "name": "Auto converted NativeApp project from V2",
+                    "artifacts": [{"src": "app/*", "dest": "./"}],
+                    "source_stage": "app.stage",
+                    "package": {
+                        "name": "pkg_name",
+                    },
+                    "application": {
+                        "name": "app_name",
+                        "role": "app_role",
+                    },
+                },
+            },
+            None,
+        ],
+    ],
+)
+def test_v2_to_v1_conversions(pdfv2_input, expected_pdfv1, expected_error):
+    with mock_config_key("enable_project_definition_v2", True):
+        pdfv2 = DefinitionV20(**pdfv2_input)
+        if expected_error:
+            with pytest.raises(ClickException) as err:
+                _pdf_v2_to_v1(pdfv2)
+            assert expected_error in err.value.message
+        else:
+            pdfv1_actual = vars(_pdf_v2_to_v1(pdfv2))
+            pdfv1_expected = vars(DefinitionV11(**expected_pdfv1))
+
+            # Assert that the expected dict is a subset of the actual dict
+            assert {**pdfv1_actual, **pdfv1_expected} == pdfv1_actual

--- a/tests_integration/nativeapp/test_open.py
+++ b/tests_integration/nativeapp/test_open.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from unittest import mock
+import re
+import os
+
+from snowflake.cli.api.project.util import generate_user_env
+
+from tests.project.fixtures import *
+
+USER_NAME = f"user_{uuid.uuid4().hex}"
+TEST_ENV = generate_user_env(USER_NAME)
+
+
+@pytest.mark.integration
+@mock.patch("typer.launch")
+def test_nativeapp_open(
+    mock_typer_launch,
+    runner,
+    snowflake_session,
+    project_directory,
+):
+    project_name = "myapp"
+    app_name = f"{project_name}_{USER_NAME}"
+
+    with project_directory("napp_init_v1"):
+        try:
+            result = runner.invoke_with_connection_json(
+                ["app", "run"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+
+            result = runner.invoke_with_connection_json(
+                ["app", "open"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+            assert "Snowflake Native App opened in browser." in result.output
+
+            mock_call = mock_typer_launch.call_args_list[0].args[0]
+            assert re.match(
+                rf"https://app.snowflake.com/.*#/apps/application/{app_name}",
+                mock_call,
+                re.IGNORECASE,
+            )
+
+        finally:
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown", "--force", "--cascade"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+
+
+@pytest.mark.integration
+@mock.patch.dict(
+    os.environ,
+    {
+        "SNOWFLAKE_CLI_FEATURES_ENABLE_PROJECT_DEFINITION_V2": "true",
+    },
+)
+@mock.patch("typer.launch")
+def test_nativeapp_open_v2(
+    mock_typer_launch,
+    runner,
+    snowflake_session,
+    project_directory,
+):
+    project_name = "myapp"
+    app_name = f"{project_name}_{USER_NAME}"
+
+    # "snow app run" doesn't support definition v2 yet, so creating the app with v1 project first
+    with project_directory("napp_init_v1"):
+        result = runner.invoke_with_connection_json(
+            ["app", "run"],
+            env=TEST_ENV,
+        )
+        assert result.exit_code == 0
+
+    with project_directory("napp_init_v2"):
+        try:
+            result = runner.invoke_with_connection_json(
+                ["app", "open"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+            assert "Snowflake Native App opened in browser." in result.output
+
+            mock_call = mock_typer_launch.call_args_list[0].args[0]
+            assert re.match(
+                rf"https://app.snowflake.com/.*#/apps/application/{app_name}",
+                mock_call,
+                re.IGNORECASE,
+            )
+
+        finally:
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown", "--force", "--cascade"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_open.py
+++ b/tests_integration/nativeapp/test_open.py
@@ -83,7 +83,7 @@ def test_nativeapp_open_v2(
     project_name = "myapp"
     app_name = f"{project_name}_{USER_NAME}"
 
-    # "snow app run" doesn't support definition v2 yet, so creating the app with v1 project first
+    # "snow app run" doesn't support definition v2 yet, so creating the app with a v1 project first
     with project_directory("napp_init_v1"):
         result = runner.invoke_with_connection_json(
             ["app", "run"],
@@ -108,8 +108,10 @@ def test_nativeapp_open_v2(
             )
 
         finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force", "--cascade"],
-                env=TEST_ENV,
-            )
-            assert result.exit_code == 0
+            # "snow app teardown" doesn't support definition v2 yet
+            with project_directory("napp_init_v1"):
+                result = runner.invoke_with_connection_json(
+                    ["app", "teardown", "--force", "--cascade"],
+                    env=TEST_ENV,
+                )
+                assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_open.py
+++ b/tests_integration/nativeapp/test_open.py
@@ -83,7 +83,7 @@ def test_nativeapp_open_v2(
     project_name = "myapp"
     app_name = f"{project_name}_{USER_NAME}"
 
-    # "snow app run" doesn't support definition v2 yet, so creating the app with a v1 project first
+    # TODO Move to napp_init_v2 block once "snow app run" supports definition v2
     with project_directory("napp_init_v1"):
         result = runner.invoke_with_connection_json(
             ["app", "run"],
@@ -108,7 +108,7 @@ def test_nativeapp_open_v2(
             )
 
         finally:
-            # "snow app teardown" doesn't support definition v2 yet
+            # TODO Move to napp_init_v2 block once "snow app run" supports definition v2
             with project_directory("napp_init_v1"):
                 result = runner.invoke_with_connection_json(
                     ["app", "teardown", "--force", "--cascade"],

--- a/tests_integration/test_data/projects/napp_init_v1/app/README.md
+++ b/tests_integration/test_data/projects/napp_init_v1/app/README.md
@@ -1,0 +1,4 @@
+# README
+
+This directory contains an extremely simple application that is used for
+integration testing SnowCLI.

--- a/tests_integration/test_data/projects/napp_init_v1/app/manifest.yml
+++ b/tests_integration/test_data/projects/napp_init_v1/app/manifest.yml
@@ -1,0 +1,9 @@
+# This is a manifest.yml file, a required component of creating a Snowflake Native App. 
+# This file defines properties required by the application package, including the location of the setup script and version definitions.
+# Refer to https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest for a detailed understanding of this file. 
+
+manifest_version: 1
+
+artifacts:
+  setup_script: setup_script.sql
+  readme: README.md

--- a/tests_integration/test_data/projects/napp_init_v1/app/setup_script.sql
+++ b/tests_integration/test_data/projects/napp_init_v1/app/setup_script.sql
@@ -1,0 +1,11 @@
+-- This is the setup script that runs while installing a Snowflake Native App in a consumer account.
+-- To write this script, you can familiarize yourself with some of the following concepts:
+-- Application Roles
+-- Versioned Schemas
+-- UDFs/Procs
+-- Extension Code
+-- Refer to https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script for a detailed understanding of this file. 
+
+CREATE OR ALTER VERSIONED SCHEMA core;
+
+-- The rest of this script is left blank for purposes of your learning and exploration.

--- a/tests_integration/test_data/projects/napp_init_v1/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_init_v1/snowflake.yml
@@ -1,0 +1,7 @@
+definition_version: 1
+native_app:
+  name: myapp
+  source_stage: app_src.stage
+  artifacts:
+    - src: app/*
+      dest: ./

--- a/tests_integration/test_data/projects/napp_init_v2/app/README.md
+++ b/tests_integration/test_data/projects/napp_init_v2/app/README.md
@@ -1,0 +1,4 @@
+# README
+
+This directory contains an extremely simple application that is used for
+integration testing SnowCLI.

--- a/tests_integration/test_data/projects/napp_init_v2/app/manifest.yml
+++ b/tests_integration/test_data/projects/napp_init_v2/app/manifest.yml
@@ -1,0 +1,9 @@
+# This is a manifest.yml file, a required component of creating a Snowflake Native App. 
+# This file defines properties required by the application package, including the location of the setup script and version definitions.
+# Refer to https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest for a detailed understanding of this file. 
+
+manifest_version: 1
+
+artifacts:
+  setup_script: setup_script.sql
+  readme: README.md

--- a/tests_integration/test_data/projects/napp_init_v2/app/setup_script.sql
+++ b/tests_integration/test_data/projects/napp_init_v2/app/setup_script.sql
@@ -1,0 +1,11 @@
+-- This is the setup script that runs while installing a Snowflake Native App in a consumer account.
+-- To write this script, you can familiarize yourself with some of the following concepts:
+-- Application Roles
+-- Versioned Schemas
+-- UDFs/Procs
+-- Extension Code
+-- Refer to https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script for a detailed understanding of this file. 
+
+CREATE OR ALTER VERSIONED SCHEMA core;
+
+-- The rest of this script is left blank for purposes of your learning and exploration.

--- a/tests_integration/test_data/projects/napp_init_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_init_v2/snowflake.yml
@@ -1,3 +1,5 @@
+# This is the v2 version of the napp_init_v1 project definition
+
 definition_version: 2
 entities:
   pkg:

--- a/tests_integration/test_data/projects/napp_init_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_init_v2/snowflake.yml
@@ -1,0 +1,14 @@
+definition_version: 2
+entities:
+  pkg:
+    type: application package
+    name: myapp_pkg_<% ctx.env.USER %>
+    artifacts:
+      - src: app/*
+        dest: ./
+    manifest: app/manifest.yml
+  app:
+    type: application
+    name: myapp_<% ctx.env.USER %>
+    from:
+      target: pkg


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

1. Created the `@nativeapp_definition_v2_to_v1` command decorator that attempts to convert project definition v2 to v1.
2. Added this decorator to the `snow app open` command.

The conversion logic is minimalistic: only what's needed for the `open` command. The following PRs will add support for the remaining commands.

### Manual test

Cloned a new NA project, rewrote `snowflake.yml` with v2 syntax, and verified `snow app open` opens the same URL:

v1:
```
$ snow app init pdfv2-open && cd pdfv2-open
$ snow app run
$ cat snowflake.yml
$ snow app open
# https://<URL>/#/apps/application/PDFV2_OPEN_GBLOOM
```
```yml
definition_version: 1
native_app:
  name: pdfv2_open
  source_stage: app_src.stage
  artifacts:
    - src: app/*
      dest: ./
```

v2:
```yml
definition_version: 2
entities:
  pkg:
    type: application package
    name: pdfv2_open_pkg_gbloom
    artifacts:
      - src: app/*
        dest: ./
    manifest: app/manifest.yml
  app:
    type: application
    name: pdfv2_open_gbloom
    from:
      target: pkg
```
```
$ snow app open
# https://<URL>/#/apps/application/PDFV2_OPEN_GBLOOM
```
