### PR TITLE
Added connectors log_configuration module to reload

### DIFF
--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -22,6 +23,7 @@ from snowflake.cli.api.exceptions import InvalidSchemaError
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.project.schemas.project_definition import ProjectDefinition
 from snowflake.connector import SnowflakeConnection
+from snowflake.connector.compat import IS_WINDOWS
 
 schema_pattern = re.compile(r".+\..+")
 
@@ -214,6 +216,15 @@ class _ConnectionContext:
 
     def _build_connection(self):
         from snowflake.cli.app.snow_connector import connect_to_snowflake
+
+        # Ignore warnings about bad owner or permissions on Windows
+        # Telemetry omit our warning filter from config.py
+        if IS_WINDOWS:
+            warnings.filterwarnings(
+                action="ignore",
+                message="Bad owner or permissions.*",
+                module="snowflake.connector.config_manager",
+            )
 
         return connect_to_snowflake(
             temporary_connection=self.temporary_connection,

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -333,6 +333,7 @@ def snowflake_home(monkeypatch):
         for module in [
             sys.modules["snowflake.connector.constants"],
             sys.modules["snowflake.connector.config_manager"],
+            sys.modules["snowflake.connector.log_configuration"],
             sys.modules["snowflake.cli.api.config"],
         ]:
             importlib.reload(module)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Before each test we reload few modules but we missed one module. We had 2 different CONFIG_MANAGER objects, when we were sending the telemetry, we were using "old" CONFIG_MANAGER with default config.toml.
