### PR TITLE
Allow commands to return multiple results as a stream

### DIFF
--- a/src/snowflake/cli/api/output/types.py
+++ b/src/snowflake/cli/api/output/types.py
@@ -57,6 +57,15 @@ class MultipleResults(CommandResult):
         return (element for element in self._elements)
 
 
+class StreamResult(CommandResult):
+    def __init__(self, generator: t.Generator[CommandResult, None, None]):
+        self._generator = generator
+
+    @property
+    def result(self):
+        return self._generator
+
+
 class QueryResult(CollectionResult):
     def __init__(self, cursor: SnowflakeCursor | DictCursor):
         self.column_names = [col.name for col in cursor.description]

--- a/src/snowflake/cli/app/printing.py
+++ b/src/snowflake/cli/app/printing.py
@@ -90,7 +90,7 @@ def _print_multiple_table_results(obj: CollectionResult):
         for item in items:
             table.add_row(*[str(i) for i in item.values()])
     # Add separator between tables
-    rich_print()
+    rich_print(flush=True)
 
 
 def is_structured_format(output_format):
@@ -99,6 +99,7 @@ def is_structured_format(output_format):
 
 def print_structured(result: CommandResult):
     """Handles outputs like json, yml and other structured and parsable formats."""
+    printed_end_line = False
     if isinstance(result, MultipleResults):
         _stream_json(result)
     elif isinstance(result, StreamResult):
@@ -106,11 +107,13 @@ def print_structured(result: CommandResult):
         # instead of joining all the values into a JSON array
         for r in result.result:
             json.dump(r, sys.stdout, cls=CustomJSONEncoder)
-            print()
+            print(flush=True)
+            printed_end_line = True
     else:
         json.dump(result, sys.stdout, cls=CustomJSONEncoder, indent=4)
     # Adds empty line at the end
-    print()
+    if not printed_end_line:
+        print(flush=True)
 
 
 def _stream_json(result):
@@ -137,11 +140,11 @@ def _stream_json(result):
 def print_unstructured(obj: CommandResult | None):
     """Handles outputs like table, plain text and other unstructured types."""
     if not obj:
-        rich_print("Done")
+        rich_print("Done", flush=True)
     elif not obj.result:
-        rich_print("No data")
+        rich_print("No data", flush=True)
     elif isinstance(obj, MessageResult):
-        rich_print(sanitize_for_terminal(obj.message))
+        rich_print(sanitize_for_terminal(obj.message), flush=True)
     else:
         if isinstance(obj, ObjectResult):
             _print_single_table(obj)
@@ -159,7 +162,7 @@ def _print_single_table(obj):
         table.add_row(
             sanitize_for_terminal(str(key)), sanitize_for_terminal(str(value))
         )
-    rich_print(table)
+    rich_print(table, flush=True)
 
 
 def print_result(cmd_result: CommandResult, output_format: OutputFormat | None = None):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
As part of implementing `snow app events -f`, we want to be able to stream messages indefinitely. This PR allows commands return a `StreamResult`, which wraps a generator of `CommandResult` objects. When we print a `StreamResult`, we iterate over all of its values and pass them individually through the same printing process.

An example use-case (some code omitted):
```python
@app.command("events", requires_connection=True)
def app_events(**options):
    """Fetches events for this app from the event table configured in Snowflake."""
    manager = NativeAppManager(...)

    def g():
        for event in manager.get_events():
            yield ObjectResult(event)

    return StreamResult(g())
```
This generator-based implementation will allow us to make this command poll for events periodically, yielding new result objects for new events to print.