### PR TITLE
SNOW-1544013 Fetch events for app

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -315,10 +315,10 @@ class NativeAppManager(SqlExecutionMixin):
         )
 
     @cached_property
-    def account_event_table(self) -> str | None:
+    def account_event_table(self) -> str:
         query = "show parameters like 'event_table' in account"
         results = self._execute_query(query, cursor_class=DictCursor)
-        return next((r["value"] for r in results if r["key"] == "EVENT_TABLE"), None)
+        return next((r["value"] for r in results if r["key"] == "EVENT_TABLE"), "")
 
     def verify_project_distribution(
         self, expected_distribution: Optional[str] = None
@@ -715,7 +715,7 @@ class NativeAppManager(SqlExecutionMixin):
                     )
 
     def get_events(self) -> list[dict]:
-        if self.account_event_table is None:
+        if not self.account_event_table:
             raise NoEventTableForAccount()
 
         # resource_attributes:"snow.database.name" uses the unquoted/uppercase app name

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -718,11 +718,13 @@ class NativeAppManager(SqlExecutionMixin):
         if self.account_event_table is None:
             raise NoEventTableForAccount()
 
+        # resource_attributes:"snow.database.name" uses the unquoted/uppercase app name
+        app_name = unquote_identifier(self.app_name)
         query = dedent(
             f"""\
             select timestamp, value::varchar value
             from {self.account_event_table}
-            where resource_attributes:"snow.database.name" ilike '{self.app_name}'
+            where resource_attributes:"snow.database.name" = '{app_name}'
             order by timestamp asc;"""
         )
         try:

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1350,7 +1350,7 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     mock_execute.side_effect = side_effects
 
     native_app_manager = _get_na_manager()
-    assert native_app_manager.account_event_table is None
+    assert native_app_manager.account_event_table == ""
 
 
 @mock.patch(

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -66,6 +66,7 @@ from tests.nativeapp.utils import (
     NATIVEAPP_MODULE,
     mock_execute_helper,
     mock_snowflake_yml_file,
+    quoted_override_yml_file,
     touch,
 )
 from tests.testing_utils.files_and_dirs import create_named_file
@@ -1374,7 +1375,53 @@ def test_get_events(mock_execute, mock_account_event_table, temp_dir, mock_curso
                         f"""\
                         select timestamp, value::varchar value
                         from db.schema.event_table
-                        where resource_attributes:"snow.database.name" ilike 'myapp'
+                        where resource_attributes:"snow.database.name" = 'MYAPP'
+                        order by timestamp asc;"""
+                    ),
+                    cursor_class=DictCursor,
+                ),
+            ),
+        ]
+    )
+    mock_execute.side_effect = side_effects
+
+    native_app_manager = _get_na_manager()
+    assert native_app_manager.get_events() == [
+        dict(TIMESTAMP="2020-01-01T00:00:00Z", VALUE="test")
+    ]
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(
+    NATIVEAPP_MANAGER_ACCOUNT_EVENT_TABLE,
+    return_value="db.schema.event_table",
+    new_callable=mock.PropertyMock,
+)
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+def test_get_events_quoted_app_name(
+    mock_execute, mock_account_event_table, temp_dir, mock_cursor
+):
+    create_named_file(
+        file_name="snowflake.yml",
+        dir_name=temp_dir,
+        contents=[mock_snowflake_yml_file],
+    )
+    create_named_file(
+        file_name="snowflake.local.yml",
+        dir_name=temp_dir,
+        contents=[quoted_override_yml_file],
+    )
+
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([dict(TIMESTAMP="2020-01-01T00:00:00Z", VALUE="test")], []),
+                mock.call(
+                    dedent(
+                        f"""\
+                        select timestamp, value::varchar value
+                        from db.schema.event_table
+                        where resource_attributes:"snow.database.name" = 'My Application'
                         order by timestamp asc;"""
                     ),
                     cursor_class=DictCursor,

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -27,7 +27,7 @@ TEST_ENV = generate_user_env(USER_NAME)
 
 
 @pytest.mark.integration
-def test_app_events(runner, temporary_working_directory):
+def test_app_events_no_event_table(runner, temporary_working_directory):
     project_name = "myapp"
     result = runner.invoke_json(
         ["app", "init", project_name],
@@ -36,10 +36,11 @@ def test_app_events(runner, temporary_working_directory):
     assert result.exit_code == 0, result.output
 
     with pushd(Path(os.getcwd(), project_name)):
-        # validate the account's event table
+        # The integration test account doesn't have an event table set up
+        # but this test is still useful to validate the negative case
         result = runner.invoke_with_connection(
             ["app", "events"],
             env=TEST_ENV,
         )
-        assert result.exit_code == 0, result.output
-        assert "No events found." in result.output
+        assert result.exit_code == 1, result.output
+        assert "No event table was found for this Snowflake account." in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fetches events from the account event table (See #1337). This does not implement filtering, timeboxing, or limiting output (these will come in a followup).

Regular output prints the messages as a log stream, including any ASCII control codes:
![image](https://github.com/user-attachments/assets/a0edc893-f627-40f2-acd3-c2752c059dde)

JSON output prints each message as individual JSON values:
![image](https://github.com/user-attachments/assets/b6bdfa34-2cf4-4318-aee3-56d3ba4380b4)

This can then be piped to `jq` or equivalent:
![image](https://github.com/user-attachments/assets/92527e6c-80fa-4a58-9f45-565dd6c023c9)


