### PR TITLE
SNOW-1544013 Add interval filtering to `snow app events`

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -383,8 +383,14 @@ def app_validate(**options):
 @with_project_definition()
 @nativeapp_definition_v2_to_v1
 def app_events(
-    since: str = typer.Option(default=""),
-    until: str = typer.Option(default=""),
+    since: str = typer.Option(
+        default="",
+        help="Fetch events that are newer than this time ago, in Snowflake interval syntax.",
+    ),
+    until: str = typer.Option(
+        default="",
+        help="Fetch events that are older than this time ago, in Snowflake interval syntax.",
+    ),
     **options,
 ):
     """Fetches events for this app from the event table configured in Snowflake."""

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -382,7 +382,11 @@ def app_validate(**options):
 @app.command("events", hidden=True, requires_connection=True)
 @with_project_definition()
 @nativeapp_definition_v2_to_v1
-def app_events(**options):
+def app_events(
+    since: str = typer.Option(default=""),
+    until: str = typer.Option(default=""),
+    **options,
+):
     """Fetches events for this app from the event table configured in Snowflake."""
     assert_project_type("native_app")
 
@@ -390,7 +394,7 @@ def app_events(**options):
         project_definition=get_cli_context().project_definition.native_app,
         project_root=get_cli_context().project_root,
     )
-    events = manager.get_events()
+    events = manager.get_events(since, until)
     if not events:
         return MessageResult("No events found.")
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -181,6 +181,10 @@
    Fetches events for this app from the event table configured in Snowflake.      
                                                                                   
   +- Options --------------------------------------------------------------------+
+  | --since            TEXT  Fetch events that are newer than this time ago, in  |
+  |                          Snowflake interval syntax.                          |
+  | --until            TEXT  Fetch events that are older than this time ago, in  |
+  |                          Snowflake interval syntax.                          |
   | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
   |                          current working directory.                          |
   | --env              TEXT  String in format of key=value. Overrides variables  |


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds `--since` and `--until` flags to restrict the time range for events. The query is updated to compare the `timestamp` column against the current time minus an `interval` specified by the user: https://docs.snowflake.com/en/sql-reference/data-types-datetime#interval-constants
