### PR TITLE
Support regionless host URLs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@
 * Added support for user stages in stage and git copy commands
 * Improved support for quoted identifiers in snowpark commands.
 * Updated post_deploy SQL script default database to be the application database
+* Regionless host URLs are now supported when generating Snowsight URLs
 
 # v2.6.1
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/connection/util.py
+++ b/src/snowflake/cli/plugins/connection/util.py
@@ -72,14 +72,12 @@ def is_regionless_redirect(conn: SnowflakeConnection) -> bool:
 def get_host_region(host: str) -> str | None:
     """
     Looks for hosts of form
-    <account>.[(<x>.)<y>.<z>].snowlakecomputing.com
-    Returns the two- or three-part [region identifier].
+    <account>.[x.y.z].snowflakecomputing.com
+    Returns the three-part [region identifier] or None.
     """
     host_parts = host.split(".")
     if host_parts[-1] == "local":
         return LOCAL_DEPLOYMENT_REGION
-    elif len(host_parts) == 5:
-        return ".".join(host_parts[1:3])
     elif len(host_parts) == 6:
         return ".".join(host_parts[1:4])
     return None

--- a/src/snowflake/cli/plugins/connection/util.py
+++ b/src/snowflake/cli/plugins/connection/util.py
@@ -82,6 +82,8 @@ def get_region(conn: SnowflakeConnection) -> str:
     """
     if conn.host:
         host_parts = conn.host.split(".")
+        if host_parts[-1] == "local":
+            return LOCAL_DEPLOYMENT
         if len(host_parts) == 6:
             return ".".join(host_parts[1:4])
 

--- a/src/snowflake/cli/plugins/connection/util.py
+++ b/src/snowflake/cli/plugins/connection/util.py
@@ -71,8 +71,9 @@ def is_regionless_redirect(conn: SnowflakeConnection) -> bool:
 
 def get_host_region(host: str) -> str | None:
     """
-    Looks for hosts of the form
-    <account>[.<x>].<y>.<z>.snowlakecomputing.com
+    Looks for hosts of form
+    <account>.[(<x>.)<y>.<z>].snowlakecomputing.com
+    Returns the two- or three-part [region identifier].
     """
     host_parts = host.split(".")
     if host_parts[-1] == "local":

--- a/src/snowflake/cli/plugins/connection/util.py
+++ b/src/snowflake/cli/plugins/connection/util.py
@@ -21,8 +21,6 @@ from click.exceptions import ClickException
 from snowflake.connector import SnowflakeConnection
 from snowflake.connector.cursor import DictCursor
 
-LOCAL_DEPLOYMENT: str = "us-west-2"
-
 log = logging.getLogger(__name__)
 
 REGIONLESS_QUERY = """
@@ -34,6 +32,7 @@ REGIONLESS_QUERY = """
 
 ALLOWLIST_QUERY = "SELECT SYSTEM$ALLOWLIST()"
 SNOWFLAKE_DEPLOYMENT = "SNOWFLAKE_DEPLOYMENT"
+LOCAL_DEPLOYMENT_REGION: str = "us-west-2"
 
 
 class MissingConnectionHostError(ClickException):
@@ -65,7 +64,7 @@ def is_regionless_redirect(conn: SnowflakeConnection) -> bool:
 def host_to_region(host: str) -> str | None:
     host_parts = host.split(".")
     if host_parts[-1] == "local":
-        return LOCAL_DEPLOYMENT
+        return LOCAL_DEPLOYMENT_REGION
     if len(host_parts) == 6:
         return ".".join(host_parts[1:4])
     return None
@@ -103,7 +102,7 @@ def get_region(conn: SnowflakeConnection) -> str:
         if region := host_to_region(host):
             return region
 
-    raise MissingConnectionHostError(host)
+    raise MissingConnectionHostError(host or conn.host)
 
 
 def get_context(conn: SnowflakeConnection) -> str:

--- a/src/snowflake/cli/plugins/connection/util.py
+++ b/src/snowflake/cli/plugins/connection/util.py
@@ -61,7 +61,7 @@ def is_regionless_redirect(conn: SnowflakeConnection) -> bool:
         return True
 
 
-def host_to_region(host: str) -> str | None:
+def get_host_region(host: str) -> str | None:
     host_parts = host.split(".")
     if host_parts[-1] == "local":
         return LOCAL_DEPLOYMENT_REGION
@@ -80,7 +80,7 @@ def guess_regioned_host_from_allowlist(conn: SnowflakeConnection) -> str | None:
         allowlist_tuples = json.loads(cursor.fetchone()["SYSTEM$ALLOWLIST()"])
         for t in allowlist_tuples:
             if t["type"] == SNOWFLAKE_DEPLOYMENT:
-                if host_to_region(t["host"]) is not None:
+                if get_host_region(t["host"]) is not None:
                     return t["host"]
     except:
         log.warning(
@@ -95,11 +95,11 @@ def get_region(conn: SnowflakeConnection) -> str:
     form "x.y.z", or raise an error if we could not find an appropriate host.
     """
     if conn.host:
-        if region := host_to_region(conn.host):
+        if region := get_host_region(conn.host):
             return region
 
     if host := guess_regioned_host_from_allowlist(conn):
-        if region := host_to_region(host):
+        if region := get_host_region(host):
             return region
 
     raise MissingConnectionHostError(host or conn.host)

--- a/src/snowflake/cli/plugins/streamlit/manager.py
+++ b/src/snowflake/cli/plugins/streamlit/manager.py
@@ -26,7 +26,8 @@ from snowflake.cli.api.feature_flags import FeatureFlag
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.connection.util import (
-    MissingConnectionHostError,
+    MissingConnectionAccountError,
+    MissingConnectionRegionError,
     make_snowsight_url,
 )
 from snowflake.cli.plugins.stage.manager import StageManager
@@ -205,5 +206,5 @@ class StreamlitManager(SqlExecutionMixin):
                 self._conn,
                 f"/#/streamlit-apps/{fqn.url_identifier}",
             )
-        except MissingConnectionHostError as e:
+        except (MissingConnectionRegionError, MissingConnectionAccountError) as e:
             return "https://app.snowflake.com"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,8 +26,9 @@ from snowflake.cli.api.project.util import identifier_for_url
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.utils import path_utils
 from snowflake.cli.plugins.connection.util import (
-    LOCAL_DEPLOYMENT,
+    LOCAL_DEPLOYMENT_REGION,
     get_context,
+    get_host_region,
     guess_regioned_host_from_allowlist,
     make_snowsight_url,
 )
@@ -286,5 +287,6 @@ def test_get_context_local_non_regionless_gets_local_region(
     mock_conn = mock.MagicMock(spec=SnowflakeConnection)
     mock_conn.host = "some.dns.local"
     is_regionless_redirect.return_value = False
-    assert get_context(mock_conn) == LOCAL_DEPLOYMENT
+    assert get_host_region(mock_conn.host) == LOCAL_DEPLOYMENT_REGION
+    assert get_context(mock_conn) == LOCAL_DEPLOYMENT_REGION
     guess_regioned_host_from_allowlist.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ from snowflake.cli.api.project.util import identifier_for_url
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.utils import path_utils
 from snowflake.cli.plugins.connection.util import (
+    LOCAL_DEPLOYMENT,
     get_context,
     guess_regioned_host_from_allowlist,
     make_snowsight_url,
@@ -275,3 +276,15 @@ def test_get_context_non_regionless_uses_region(
     )
     is_regionless_redirect.return_value = False
     assert get_context(mock_conn) == "x.y.z"
+
+
+@patch("snowflake.cli.plugins.connection.util.is_regionless_redirect")
+@patch("snowflake.cli.plugins.connection.util.guess_regioned_host_from_allowlist")
+def test_get_context_local_non_regionless_gets_local_region(
+    guess_regioned_host_from_allowlist, is_regionless_redirect
+):
+    mock_conn = mock.MagicMock(spec=SnowflakeConnection)
+    mock_conn.host = "some.dns.local"
+    is_regionless_redirect.return_value = False
+    assert get_context(mock_conn) == LOCAL_DEPLOYMENT
+    guess_regioned_host_from_allowlist.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -290,3 +290,17 @@ def test_get_context_local_non_regionless_gets_local_region(
     assert get_host_region(mock_conn.host) == LOCAL_DEPLOYMENT_REGION
     assert get_context(mock_conn) == LOCAL_DEPLOYMENT_REGION
     guess_regioned_host_from_allowlist.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "host, expected",
+    [
+        ("some.dns.local", LOCAL_DEPLOYMENT_REGION),
+        ("org-acct.mydns.snowflakecomputing.com", None),
+        ("account.x.us-west-2.aws.snowflakecomputing.com", "x.us-west-2.aws"),
+        ("naf_test_pc.us-west-2.snowflakecomputing.com", None),
+        ("test_account.az.int.snowflakecomputing.com", None),
+    ],
+)
+def test_get_host_region(host, expected):
+    assert get_host_region(host) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -300,6 +300,7 @@ def test_get_context_local_non_regionless_gets_local_region(
         ("account.x.us-west-2.aws.snowflakecomputing.com", "x.us-west-2.aws"),
         ("naf_test_pc.us-west-2.snowflakecomputing.com", None),
         ("test_account.az.int.snowflakecomputing.com", None),
+        ("frozenweb.prod3.external-zone.snowflakecomputing.com", None),
     ],
 )
 def test_get_host_region(host, expected):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Use `SYSTEM$ALLOWLIST()` to determine the regioned host if the user's connection parameters have given us a regionless one. This allows us to return the correct context path part for the Snowsight URLs we generate.