### PR TITLE
Handle null md5s when given by storage backend

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@
 * Added support for user stages in stage and git copy commands
 * Improved support for quoted identifiers in snowpark commands.
 * Updated post_deploy SQL script default database to be the application database
+* Handle `NULL` md5 values correctly when returned by stage storage backends
 
 # v2.6.1
 ## Backward incompatibility

--- a/src/snowflake/cli/plugins/stage/diff.py
+++ b/src/snowflake/cli/plugins/stage/diff.py
@@ -133,7 +133,7 @@ def strip_stage_name(path: str) -> StagePath:
     return StagePath(*path.split("/")[1:])
 
 
-def build_md5_map(list_stage_cursor: DictCursor) -> Dict[StagePath, str]:
+def build_md5_map(list_stage_cursor: DictCursor) -> Dict[StagePath, Optional[str]]:
     """
     Returns a mapping of relative stage paths to their md5sums.
     """

--- a/src/snowflake/cli/plugins/stage/diff.py
+++ b/src/snowflake/cli/plugins/stage/diff.py
@@ -72,10 +72,12 @@ class DiffResult:
         }
 
 
-def is_valid_md5sum(checksum: str) -> bool:
+def is_valid_md5sum(checksum: Optional[str]) -> bool:
     """
     Could the provided hexadecimal checksum represent a valid md5sum?
     """
+    if checksum is None:
+        return False
     return re.match(MD5SUM_REGEX, checksum) is not None
 
 

--- a/tests/stage/test_diff.py
+++ b/tests/stage/test_diff.py
@@ -187,6 +187,8 @@ def test_unmodified_file_no_remote_md5sum(mock_list, mock_cursor):
         if row["name"] == "stage/README.md":
             row["md5"] = None
 
+    assert any([row["md5"] is None for row in rows])
+
     mock_list.return_value = mock_cursor(
         rows=rows,
         columns=STAGE_LS_COLUMNS,

--- a/tests/stage/test_diff.py
+++ b/tests/stage/test_diff.py
@@ -178,6 +178,30 @@ def test_modified_file(mock_list, mock_cursor):
         assert len(diff_result.only_local) == 0
 
 
+@mock.patch(f"{STAGE_MANAGER}.list_files")
+def test_unmodified_file_no_remote_md5sum(mock_list, mock_cursor):
+
+    # the stage is identical to the local, except we don't have an md5 for README.md
+    rows = stage_contents(FILE_CONTENTS)
+    for row in rows:
+        if row["name"] == "stage/README.md":
+            row["md5"] = None
+
+    mock_list.return_value = mock_cursor(
+        rows=rows,
+        columns=STAGE_LS_COLUMNS,
+    )
+
+    with temp_local_dir(FILE_CONTENTS) as local_path:
+        diff_result = compute_stage_diff(local_path, "a.b.c")
+        assert len(diff_result.only_on_stage) == 0
+        assert sorted(diff_result.different) == as_stage_paths(["README.md"])
+        assert sorted(diff_result.identical) == as_stage_paths(
+            ["my.jar", "ui/streamlit.py"]
+        )
+        assert len(diff_result.only_local) == 0
+
+
 def test_get_stage_path_from_file():
     expected = [
         "",


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Some stage storage backends (e.g. Azure) do not calculate md5sums automatically for multi-part file uploads. As such, these storage backends will return `NULL` for the md5 column. This PR ensures we do not error out and instead treat these files as modified.