### PR TITLE
SNOW-1544013 Add `--first` and `--last` to `snow app events`

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -391,19 +391,30 @@ def app_events(
         default="",
         help="Fetch events that are older than this time ago, in Snowflake interval syntax.",
     ),
-    limit: int = typer.Option(
-        default=0, help="Maximum number of latest events to fetch."
+    first: int = typer.Option(
+        default=0, help="Fetch only the first N events. Cannot be used with --last."
+    ),
+    last: int = typer.Option(
+        default=0, help="Fetch only the last N events. Cannot be used with --first."
     ),
     **options,
 ):
     """Fetches events for this app from the event table configured in Snowflake."""
+    if first and last:
+        raise ClickException("--first and --last cannot be used together.")
+
     assert_project_type("native_app")
 
     manager = NativeAppManager(
         project_definition=get_cli_context().project_definition.native_app,
         project_root=get_cli_context().project_root,
     )
-    events = manager.get_events(since, until, limit)
+    events = manager.get_events(
+        since_interval=since,
+        until_interval=until,
+        first=first,
+        last=last,
+    )
     if not events:
         return MessageResult("No events found.")
 

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -391,6 +391,9 @@ def app_events(
         default="",
         help="Fetch events that are older than this time ago, in Snowflake interval syntax.",
     ),
+    limit: int = typer.Option(
+        default=0, help="Maximum number of latest events to fetch."
+    ),
     **options,
 ):
     """Fetches events for this app from the event table configured in Snowflake."""
@@ -400,7 +403,7 @@ def app_events(
         project_definition=get_cli_context().project_definition.native_app,
         project_root=get_cli_context().project_root,
     )
-    events = manager.get_events(since, until)
+    events = manager.get_events(since, until, limit)
     if not events:
         return MessageResult("No events found.")
 

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -718,8 +718,12 @@ class NativeAppManager(SqlExecutionMixin):
         self,
         since_interval: str = "",
         until_interval: str = "",
-        limit: int = 0,
+        first: int = 0,
+        last: int = 0,
     ) -> list[dict]:
+        if first and last:
+            raise ValueError("first and last cannot be used together")
+
         if not self.account_event_table:
             raise NoEventTableForAccount()
 
@@ -735,7 +739,8 @@ class NativeAppManager(SqlExecutionMixin):
             if until_interval
             else ""
         )
-        limit_clause = f"limit {limit}" if limit else ""
+        first_clause = f"limit {first}" if first else ""
+        last_clause = f"limit {last}" if last else ""
         query = dedent(
             f"""\
             select * from (
@@ -745,8 +750,9 @@ class NativeAppManager(SqlExecutionMixin):
                 {since_clause}
                 {until_clause}
                 order by timestamp desc
-                {limit_clause}
+                {last_clause}
             ) order by timestamp asc
+            {first_clause}
             """
         )
         try:

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -185,7 +185,11 @@
   |                             in Snowflake interval syntax.                    |
   | --until            TEXT     Fetch events that are older than this time ago,  |
   |                             in Snowflake interval syntax.                    |
-  | --limit            INTEGER  Maximum number of latest events to fetch.        |
+  | --first            INTEGER  Fetch only the first N events. Cannot be used    |
+  |                             with --last.                                     |
+  |                             [default: 0]                                     |
+  | --last             INTEGER  Fetch only the last N events. Cannot be used     |
+  |                             with --first.                                    |
   |                             [default: 0]                                     |
   | --project  -p      TEXT     Path where Snowflake project resides. Defaults   |
   |                             to current working directory.                    |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -181,15 +181,17 @@
    Fetches events for this app from the event table configured in Snowflake.      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --since            TEXT  Fetch events that are newer than this time ago, in  |
-  |                          Snowflake interval syntax.                          |
-  | --until            TEXT  Fetch events that are older than this time ago, in  |
-  |                          Snowflake interval syntax.                          |
-  | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
-  |                          current working directory.                          |
-  | --env              TEXT  String in format of key=value. Overrides variables  |
-  |                          from env section used for templating.               |
-  | --help     -h            Show this message and exit.                         |
+  | --since            TEXT     Fetch events that are newer than this time ago,  |
+  |                             in Snowflake interval syntax.                    |
+  | --until            TEXT     Fetch events that are older than this time ago,  |
+  |                             in Snowflake interval syntax.                    |
+  | --limit            INTEGER  Maximum number of latest events to fetch.        |
+  |                             [default: 0]                                     |
+  | --project  -p      TEXT     Path where Snowflake project resides. Defaults   |
+  |                             to current working directory.                    |
+  | --env              TEXT     String in format of key=value. Overrides         |
+  |                             variables from env section used for templating.  |
+  | --help     -h               Show this message and exit.                      |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment  -c      TEXT  Name of the connection, as defined |

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1354,40 +1354,24 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
 
 
 @pytest.mark.parametrize(
+    ["since", "expected_since_clause"],
     [
-        "since",
-        "expected_since_clause",
-        "until",
-        "expected_until_clause",
-        "limit",
-        "expected_limit_clause",
+        ("", ""),
+        ("1 hour", "and timestamp >= sysdate() - interval '1 hour'"),
     ],
+)
+@pytest.mark.parametrize(
+    ["until", "expected_until_clause"],
     [
-        (
-            "",
-            "",
-            "",
-            "",
-            0,
-            "",
-        ),
-        (
-            "1 hour",
-            "and timestamp >= sysdate() - interval '1 hour'",
-            "20 minutes",
-            "and timestamp <= sysdate() - interval '20 minutes'",
-            0,
-            "",
-        ),
-        ("", "", "", "", 10, "limit 10"),
-        (
-            "1 hour",
-            "and timestamp >= sysdate() - interval '1 hour'",
-            "20 minutes",
-            "and timestamp <= sysdate() - interval '20 minutes'",
-            10,
-            "limit 10",
-        ),
+        ("", ""),
+        ("20 minutes", "and timestamp <= sysdate() - interval '20 minutes'"),
+    ],
+)
+@pytest.mark.parametrize(
+    ["limit", "expected_limit_clause"],
+    [
+        (0, ""),
+        (10, "limit 10"),
     ],
 )
 @mock.patch(

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+import uuid
+
+from snowflake.cli.api.project.util import generate_user_env
+from tests.project.fixtures import *
+from tests_integration.test_utils import pushd
+
+USER_NAME = f"user_{uuid.uuid4().hex}"
+TEST_ENV = generate_user_env(USER_NAME)
+
+
+# Tests that snow app events --first N --last M exits with an error
+@pytest.mark.integration
+def test_app_events_cant_specify_first_and_last(runner, temporary_working_directory):
+    project_name = "myapp"
+    result = runner.invoke_json(
+        ["app", "init", project_name],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+
+    with pushd(Path(os.getcwd(), project_name)):
+        # The integration test account doesn't have an event table set up
+        # but this test is still useful to validate the negative case
+        result = runner.invoke_with_connection(
+            ["app", "events", "--first", "10", "--last", "20"],
+            env=TEST_ENV,
+        )
+        assert result.exit_code == 1, result.output
+        assert "--first and --last cannot be used together." in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds `--first` and `--last` parameters to `snow app events`. The two parameters are mutually exclusive to avoid generating a query that would return discontinuous results.

This required updating the query to sort in descending order to limit to the last N events, then re-sort in ascending order for printing and to limit to the first M events.
