### PR TITLE
Add default values to generated docs

### DIFF
--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -372,6 +372,7 @@ def _diag_log_path_callback(path: str):
 
 
 DiagLogPathOption: Path = typer.Option(
+    # set default via callback to avoid including tempdir path in generated docs (snow --docs)
     None,
     "--diag-log-path",
     help="Diagnostic report path",

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -350,8 +350,15 @@ EnableDiagOption = typer.Option(
     rich_help_panel=_CONNECTION_SECTION,
 )
 
+
+def _diag_log_path_callback(path: str):
+    if path is not None:
+        return path
+    return tempfile.gettempdir()
+
+
 DiagLogPathOption: Path = typer.Option(
-    tempfile.gettempdir(),
+    None,
     "--diag-log-path",
     help="Diagnostic report path",
     callback=_callback(

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -364,16 +364,19 @@ EnableDiagOption = typer.Option(
     rich_help_panel=_CONNECTION_SECTION,
 )
 
+# Set default via callback to avoid including tempdir path in generated docs (snow --docs).
+# Use constant instead of None, as None is removed from telemetry data.
+_DIAG_LOG_DEFAULT_VALUE = "<temporary_directory>"
+
 
 def _diag_log_path_callback(path: str):
-    if path is not None:
+    if path != _DIAG_LOG_DEFAULT_VALUE:
         return path
     return tempfile.gettempdir()
 
 
 DiagLogPathOption: Path = typer.Option(
-    # set default via callback to avoid including tempdir path in generated docs (snow --docs)
-    None,
+    _DIAG_LOG_DEFAULT_VALUE,
     "--diag-log-path",
     help="Diagnostic report path",
     callback=_callback(

--- a/src/snowflake/cli/app/dev/docs/templates/usage.rst.jinja2
+++ b/src/snowflake/cli/app/dev/docs/templates/usage.rst.jinja2
@@ -26,7 +26,7 @@ Arguments
         {{ param.make_metavar().replace("[", "").replace("]", "").lower() }}
     {%- endif -%}
     {{ '}' }}`
-{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default %} Default: {{ param.default }}{% endif %}{% else %}  TBD{% endif %}
+{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default %} Default: {{ param.default }}.{% endif %}{% else %}  TBD{% endif %}
 {% endfor %}
 {% else %}
 
@@ -48,7 +48,7 @@ Options
         {%- if param.type.name != "choice" %}{{ ' {' }}{% else %} {% endif %}{{ param.make_metavar() }}{% if param.type.name != "choice" %}{{ '}' }}
         {%- endif %}
     {%- endif %}`
-{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default is not none %} Default: {{ param.default }}{% endif %}{% else %}  TBD{% endif %}
+{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default is not none %} Default: {{ param.default }}.{% endif %}{% else %}  TBD{% endif %}
 {% endfor %}
 {% else %}
 

--- a/src/snowflake/cli/app/dev/docs/templates/usage.rst.jinja2
+++ b/src/snowflake/cli/app/dev/docs/templates/usage.rst.jinja2
@@ -26,7 +26,7 @@ Arguments
         {{ param.make_metavar().replace("[", "").replace("]", "").lower() }}
     {%- endif -%}
     {{ '}' }}`
-{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% else %}  TBD{% endif %}
+{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default %} Default: {{ param.default }}{% endif %}{% else %}  TBD{% endif %}
 {% endfor %}
 {% else %}
 
@@ -48,7 +48,7 @@ Options
         {%- if param.type.name != "choice" %}{{ ' {' }}{% else %} {% endif %}{{ param.make_metavar() }}{% if param.type.name != "choice" %}{{ '}' }}
         {%- endif %}
     {%- endif %}`
-{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% else %}  TBD{% endif %}
+{% if param.help %}{{ "  " + param.help | replace("`", "``") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default is not none %} Default: {{ param.default }}{% endif %}{% else %}  TBD{% endif %}
 {% endfor %}
 {% else %}
 

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -1,0 +1,115 @@
+# serializer version: 1
+# name: test_flags_have_default_values
+  '''
+  Given a prompt, the command generates a response using your choice of language model.
+  In the simplest use case, the prompt is a single string.
+  You may also provide a JSON file with conversation history including multiple prompts and responses for interactive chat-style usage.
+  
+  Syntax
+  ===============================================================================
+  
+  .. code-block:: console
+  
+    snow cortex complete
+      <text>
+      --model <model>
+      --file <file>
+      --connection <connection>
+      --account <account>
+      --user <user>
+      --password <password>
+      --authenticator <authenticator>
+      --private-key-path <private_key_path>
+      --token-file-path <token_file_path>
+      --database <database>
+      --schema <schema>
+      --role <role>
+      --warehouse <warehouse>
+      --temporary-connection
+      --mfa-passcode <mfa_passcode>
+      --enable-diag
+      --diag-log-path <diag_log_path>
+      --diag-allowlist-path <diag_allowlist_path>
+      --format <format>
+      --verbose
+      --debug
+      --silent
+  
+  Arguments
+  ===============================================================================
+  
+  :samp:`{text}`
+    Prompt to be used to generate a completion. Cannot be combined with --file option.
+  
+  Options
+  ===============================================================================
+  
+  :samp:`--model {TEXT}`
+    String specifying the model to be used. Default: snowflake-arctic
+  
+  :samp:`--file {FILE}`
+    JSON file containing conversation history to be used to generate a completion. Cannot be combined with TEXT argument.
+  
+  :samp:`--connection, -c, --environment {TEXT}`
+    Name of the connection, as defined in your ``config.toml``. Default: ``default``.
+  
+  :samp:`--account, --accountname {TEXT}`
+    Name assigned to your Snowflake account. Overrides the value specified for the connection.
+  
+  :samp:`--user, --username {TEXT}`
+    Username to connect to Snowflake. Overrides the value specified for the connection.
+  
+  :samp:`--password {TEXT}`
+    Snowflake password. Overrides the value specified for the connection.
+  
+  :samp:`--authenticator {TEXT}`
+    Snowflake authenticator. Overrides the value specified for the connection.
+  
+  :samp:`--private-key-path {TEXT}`
+    Snowflake private key path. Overrides the value specified for the connection.
+  
+  :samp:`--token-file-path {TEXT}`
+    Path to file with an OAuth token that should be used when connecting to Snowflake.
+  
+  :samp:`--database, --dbname {TEXT}`
+    Database to use. Overrides the value specified for the connection.
+  
+  :samp:`--schema, --schemaname {TEXT}`
+    Database schema to use. Overrides the value specified for the connection.
+  
+  :samp:`--role, --rolename {TEXT}`
+    Role to use. Overrides the value specified for the connection.
+  
+  :samp:`--warehouse {TEXT}`
+    Warehouse to use. Overrides the value specified for the connection.
+  
+  :samp:`--temporary-connection, -x`
+    Uses connection defined with command line parameters, instead of one defined in config. Default: False
+  
+  :samp:`--mfa-passcode {TEXT}`
+    Token to use for multi-factor authentication (MFA).
+  
+  :samp:`--enable-diag`
+    Run python connector diagnostic test. Default: False
+  
+  :samp:`--diag-log-path {TEXT}`
+    Diagnostic report path.
+  
+  :samp:`--diag-allowlist-path {TEXT}`
+    Diagnostic report path to optional allowlist.
+  
+  :samp:`--format [TABLE|JSON]`
+    Specifies the output format. Default: TABLE
+  
+  :samp:`--verbose, -v`
+    Displays log entries for log levels ``info`` and higher. Default: False
+  
+  :samp:`--debug`
+    Displays log entries for log levels ``debug`` and higher; debug logs contains additional information. Default: False
+  
+  :samp:`--silent`
+    Turns off intermediate output to console. Default: False
+  
+  
+  '''
+# ---

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -93,7 +93,7 @@
     Run python connector diagnostic test. Default: False.
   
   :samp:`--diag-log-path {TEXT}`
-    Diagnostic report path.
+    Diagnostic report path. Default: <temporary_directory>.
   
   :samp:`--diag-allowlist-path {TEXT}`
     Diagnostic report path to optional allowlist.

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -45,7 +45,7 @@
   ===============================================================================
   
   :samp:`--model {TEXT}`
-    String specifying the model to be used. Default: snowflake-arctic
+    String specifying the model to be used. Default: snowflake-arctic.
   
   :samp:`--file {FILE}`
     JSON file containing conversation history to be used to generate a completion. Cannot be combined with TEXT argument.
@@ -84,13 +84,13 @@
     Warehouse to use. Overrides the value specified for the connection.
   
   :samp:`--temporary-connection, -x`
-    Uses connection defined with command line parameters, instead of one defined in config. Default: False
+    Uses connection defined with command line parameters, instead of one defined in config. Default: False.
   
   :samp:`--mfa-passcode {TEXT}`
     Token to use for multi-factor authentication (MFA).
   
   :samp:`--enable-diag`
-    Run python connector diagnostic test. Default: False
+    Run python connector diagnostic test. Default: False.
   
   :samp:`--diag-log-path {TEXT}`
     Diagnostic report path.
@@ -99,16 +99,16 @@
     Diagnostic report path to optional allowlist.
   
   :samp:`--format [TABLE|JSON]`
-    Specifies the output format. Default: TABLE
+    Specifies the output format. Default: TABLE.
   
   :samp:`--verbose, -v`
-    Displays log entries for log levels ``info`` and higher. Default: False
+    Displays log entries for log levels ``info`` and higher. Default: False.
   
   :samp:`--debug`
-    Displays log entries for log levels ``debug`` and higher; debug logs contains additional information. Default: False
+    Displays log entries for log levels ``debug`` and higher; debug logs contains additional information. Default: False.
   
   :samp:`--silent`
-    Turns off intermediate output to console. Default: False
+    Turns off intermediate output to console. Default: False.
   
   
   '''

--- a/tests/test_docs_generation_output.py
+++ b/tests/test_docs_generation_output.py
@@ -162,3 +162,16 @@ def test_all_commands_have_generated_files(runner, temp_dir):
     _check(ctx.command, commands_path)
 
     assert len(errors) == 0, "\n".join(errors)
+
+
+def test_flags_have_default_values(runner, temp_dir, snapshot):
+    runner.invoke(["--docs"])
+
+    # cortex complete checks:
+    # "Default: False" case
+    # "--diag-log-path" flag, with tempdir path as default value
+    example_generated_file = (
+        Path(temp_dir) / "gen_docs" / "commands" / "cortex" / "usage-complete.txt"
+    )
+    assert example_generated_file.exists()
+    assert example_generated_file.read_text() == snapshot


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* modify template to add default values to generated flags and arguments
* change `--diag-log-path` implementation, so it's default value (tempdir path) is not visible on the output
* add unit test
