### PR TITLE
Decouple project definition object from artifact processors

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -19,13 +19,27 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from click.exceptions import ClickException
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.secure_path import SecurePath
 from yaml import safe_load
+
+if TYPE_CHECKING:
+    from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
 
 
 class DeployRootError(ClickException):
@@ -107,6 +121,17 @@ class BundleContext:
     bundle_root: Path
     deploy_root: Path
     generated_root: Path
+
+    @staticmethod
+    def from_na_project(na: NativeAppProjectModel) -> BundleContext:
+        return BundleContext(
+            na.package_name,
+            na.artifacts,
+            na.project_root,
+            na.bundle_root,
+            na.deploy_root,
+            na.generated_root,
+        )
 
 
 ArtifactPredicate = Callable[[Path, Path], bool]

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -16,30 +16,15 @@ from __future__ import annotations
 
 import itertools
 import os
-from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 from click.exceptions import ClickException
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.secure_path import SecurePath
 from yaml import safe_load
-
-if TYPE_CHECKING:
-    from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
 
 
 class DeployRootError(ClickException):
@@ -111,27 +96,6 @@ class NotInDeployRootError(ClickException):
         self.dest_path = dest_path
         self.deploy_root = deploy_root
         self.src_path = src_path
-
-
-@dataclass
-class BundleContext:
-    package_name: str
-    artifacts: List[PathMapping]
-    project_root: Path
-    bundle_root: Path
-    deploy_root: Path
-    generated_root: Path
-
-    @staticmethod
-    def from_na_project(na: NativeAppProjectModel) -> BundleContext:
-        return BundleContext(
-            na.package_name,
-            na.artifacts,
-            na.project_root,
-            na.bundle_root,
-            na.deploy_root,
-            na.generated_root,
-        )
 
 
 ArtifactPredicate = Callable[[Path, Path], bool]

--- a/src/snowflake/cli/plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/plugins/nativeapp/artifacts.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import itertools
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
@@ -96,6 +97,16 @@ class NotInDeployRootError(ClickException):
         self.dest_path = dest_path
         self.deploy_root = deploy_root
         self.src_path = src_path
+
+
+@dataclass
+class BundleContext:
+    package_name: str
+    artifacts: List[PathMapping]
+    project_root: Path
+    bundle_root: Path
+    deploy_root: Path
+    generated_root: Path
 
 
 ArtifactPredicate = Callable[[Path, Path], bool]

--- a/src/snowflake/cli/plugins/nativeapp/bundle_context.py
+++ b/src/snowflake/cli/plugins/nativeapp/bundle_context.py
@@ -19,7 +19,6 @@ from typing import (
 )
 
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
-from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
 
 
 @dataclass
@@ -30,14 +29,3 @@ class BundleContext:
     bundle_root: Path
     deploy_root: Path
     generated_root: Path
-
-    @staticmethod
-    def from_na_project(na: NativeAppProjectModel):
-        return BundleContext(
-            na.package_name,
-            na.artifacts,
-            na.project_root,
-            na.bundle_root,
-            na.deploy_root,
-            na.generated_root,
-        )

--- a/src/snowflake/cli/plugins/nativeapp/bundle_context.py
+++ b/src/snowflake/cli/plugins/nativeapp/bundle_context.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    List,
+)
+
+from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
+from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
+
+
+@dataclass
+class BundleContext:
+    package_name: str
+    artifacts: List[PathMapping]
+    project_root: Path
+    bundle_root: Path
+    deploy_root: Path
+    generated_root: Path
+
+    @staticmethod
+    def from_na_project(na: NativeAppProjectModel):
+        return BundleContext(
+            na.package_name,
+            na.artifacts,
+            na.project_root,
+            na.bundle_root,
+            na.deploy_root,
+            na.generated_root,
+        )

--- a/src/snowflake/cli/plugins/nativeapp/codegen/artifact_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/artifact_processor.py
@@ -23,7 +23,6 @@ from snowflake.cli.api.project.schemas.native_app.path_mapping import (
     PathMapping,
     ProcessorMapping,
 )
-from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
 
 
 class UnsupportedArtifactProcessorError(ClickException):
@@ -74,9 +73,17 @@ class ProjectFileContextManager:
 class ArtifactProcessor(ABC):
     def __init__(
         self,
-        na_project: NativeAppProjectModel,
+        package_name: str,
+        project_root: Path,
+        deploy_root: Path,
+        bundle_root: Path,
+        generated_root: Path,
     ) -> None:
-        self._na_project = na_project
+        self._package_name = package_name
+        self._project_root = project_root
+        self._deploy_root = deploy_root
+        self._bundle_root = bundle_root
+        self._generated_root = generated_root
 
     @abstractmethod
     def process(

--- a/src/snowflake/cli/plugins/nativeapp/codegen/artifact_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/artifact_processor.py
@@ -23,6 +23,7 @@ from snowflake.cli.api.project.schemas.native_app.path_mapping import (
     PathMapping,
     ProcessorMapping,
 )
+from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
 
 
 class UnsupportedArtifactProcessorError(ClickException):
@@ -73,17 +74,9 @@ class ProjectFileContextManager:
 class ArtifactProcessor(ABC):
     def __init__(
         self,
-        package_name: str,
-        project_root: Path,
-        deploy_root: Path,
-        bundle_root: Path,
-        generated_root: Path,
+        bundle_ctx: BundleContext,
     ) -> None:
-        self._package_name = package_name
-        self._project_root = project_root
-        self._deploy_root = deploy_root
-        self._bundle_root = bundle_root
-        self._generated_root = generated_root
+        self._bundle_ctx = bundle_ctx
 
     @abstractmethod
     def process(

--- a/src/snowflake/cli/plugins/nativeapp/codegen/artifact_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/artifact_processor.py
@@ -23,7 +23,7 @@ from snowflake.cli.api.project.schemas.native_app.path_mapping import (
     PathMapping,
     ProcessorMapping,
 )
-from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 
 
 class UnsupportedArtifactProcessorError(ClickException):

--- a/src/snowflake/cli/plugins/nativeapp/codegen/compiler.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/compiler.py
@@ -20,7 +20,7 @@ from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.project.schemas.native_app.path_mapping import (
     ProcessorMapping,
 )
-from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.artifact_processor import (
     ArtifactProcessor,
     UnsupportedArtifactProcessorError,

--- a/src/snowflake/cli/plugins/nativeapp/codegen/compiler.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/compiler.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, List, Optional
 
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.project.schemas.native_app.path_mapping import (
+    PathMapping,
     ProcessorMapping,
 )
 from snowflake.cli.plugins.nativeapp.codegen.artifact_processor import (
@@ -31,7 +33,6 @@ from snowflake.cli.plugins.nativeapp.codegen.snowpark.python_processor import (
     SnowparkAnnotationProcessor,
 )
 from snowflake.cli.plugins.nativeapp.feature_flags import FeatureFlag
-from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
 
 SNOWPARK_PROCESSOR = "snowpark"
 NA_SETUP_PROCESSOR = "native-app-setup"
@@ -53,9 +54,19 @@ class NativeAppCompiler:
 
     def __init__(
         self,
-        na_project: NativeAppProjectModel,
+        package_name: str,
+        artifacts: List[PathMapping],
+        project_root: Path,
+        bundle_root: Path,
+        deploy_root: Path,
+        generated_root: Path,
     ):
-        self._na_project = na_project
+        self._package_name = package_name
+        self._artifacts = artifacts
+        self._project_root = project_root
+        self._bundle_root = bundle_root
+        self._deploy_root = deploy_root
+        self._generated_root = generated_root
         # dictionary of all processors created and shared between different artifact objects.
         self.cached_processors: Dict[str, ArtifactProcessor] = {}
 
@@ -69,12 +80,12 @@ class NativeAppCompiler:
             return
 
         with cc.phase("Invoking artifact processors"):
-            if self._na_project.generated_root.exists():
+            if self._generated_root.exists():
                 raise ClickException(
-                    f"Path {self._na_project.generated_root} already exists. Please choose a different name for your generated directory in the project definition file."
+                    f"Path {self._generated_root} already exists. Please choose a different name for your generated directory in the project definition file."
                 )
 
-            for artifact in self._na_project.artifacts:
+            for artifact in self._artifacts:
                 for processor in artifact.processors:
                     if self._is_enabled(processor):
                         artifact_processor = self._try_create_processor(
@@ -111,14 +122,18 @@ class NativeAppCompiler:
             return None
 
         current_processor = processor_factory(
-            na_project=self._na_project,
+            package_name=self._package_name,
+            project_root=self._project_root,
+            deploy_root=self._deploy_root,
+            bundle_root=self._bundle_root,
+            generated_root=self._generated_root,
         )
         self.cached_processors[processor_name] = current_processor
 
         return current_processor
 
     def _should_invoke_processors(self):
-        for artifact in self._na_project.artifacts:
+        for artifact in self._artifacts:
             for processor in artifact.processors:
                 if self._is_enabled(processor):
                     return True

--- a/src/snowflake/cli/plugins/nativeapp/codegen/setup/native_app_setup_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/setup/native_app_setup_processor.py
@@ -55,8 +55,8 @@ class NativeAppSetupProcessor(ArtifactProcessor):
         Processes a Python setup script and generates the corresponding SQL commands.
         """
         bundle_map = BundleMap(
-            project_root=self._project_root,
-            deploy_root=self._deploy_root,
+            project_root=self._bundle_ctx.project_root,
+            deploy_root=self._bundle_ctx.deploy_root,
         )
         bundle_map.add(artifact_to_process)
 
@@ -69,7 +69,7 @@ class NativeAppSetupProcessor(ArtifactProcessor):
             absolute=True, expand_directories=True, predicate=is_python_file_artifact
         ):
             cc.message(
-                f"Found Python setup file: {src_file.relative_to(self._project_root)}"
+                f"Found Python setup file: {src_file.relative_to(self._bundle_ctx.project_root)}"
             )
             files_to_process.append(src_file)
 
@@ -81,9 +81,9 @@ class NativeAppSetupProcessor(ArtifactProcessor):
         cc.step(f"Processing {file_count} setup file{'s' if file_count > 1 else ''}")
 
         env_vars = {
-            "_SNOWFLAKE_CLI_PROJECT_PATH": str(self._project_root),
+            "_SNOWFLAKE_CLI_PROJECT_PATH": str(self._bundle_ctx.project_root),
             "_SNOWFLAKE_CLI_SETUP_FILES": os.pathsep.join(map(str, py_files)),
-            "_SNOWFLAKE_CLI_APP_NAME": str(self._package_name),
+            "_SNOWFLAKE_CLI_APP_NAME": str(self._bundle_ctx.package_name),
             "_SNOWFLAKE_CLI_SQL_DEST_DIR": str(self.generated_root),
         }
 
@@ -91,7 +91,7 @@ class NativeAppSetupProcessor(ArtifactProcessor):
             result = execute_script_in_sandbox(
                 script_source=DRIVER_PATH.read_text(),
                 env_type=ExecutionEnvironmentType.VENV,
-                cwd=self._bundle_root,
+                cwd=self._bundle_ctx.bundle_root,
                 timeout=DEFAULT_TIMEOUT,
                 path=self.sandbox_root,
                 env_vars=env_vars,
@@ -118,7 +118,9 @@ class NativeAppSetupProcessor(ArtifactProcessor):
         generated_root.mkdir(exist_ok=True, parents=True)
 
         cc.step("Patching setup script")
-        setup_file_path = find_setup_script_file(deploy_root=self._deploy_root)
+        setup_file_path = find_setup_script_file(
+            deploy_root=self._bundle_ctx.deploy_root
+        )
         with self.edit_file(setup_file_path) as f:
             new_contents = [f.contents]
 
@@ -126,30 +128,30 @@ class NativeAppSetupProcessor(ArtifactProcessor):
                 schemas_file = generated_root / sql_file_mappings["schemas"]
                 new_contents.insert(
                     0,
-                    f"EXECUTE IMMEDIATE FROM '/{to_stage_path(schemas_file.relative_to(self._deploy_root))}';",
+                    f"EXECUTE IMMEDIATE FROM '/{to_stage_path(schemas_file.relative_to(self._bundle_ctx.deploy_root))}';",
                 )
 
             if sql_file_mappings["compute_pools"]:
                 compute_pools_file = generated_root / sql_file_mappings["compute_pools"]
                 new_contents.append(
-                    f"EXECUTE IMMEDIATE FROM '/{to_stage_path(compute_pools_file.relative_to(self._deploy_root))}';"
+                    f"EXECUTE IMMEDIATE FROM '/{to_stage_path(compute_pools_file.relative_to(self._bundle_ctx.deploy_root))}';"
                 )
 
             if sql_file_mappings["services"]:
                 services_file = generated_root / sql_file_mappings["services"]
                 new_contents.append(
-                    f"EXECUTE IMMEDIATE FROM '/{to_stage_path(services_file.relative_to(self._deploy_root))}';"
+                    f"EXECUTE IMMEDIATE FROM '/{to_stage_path(services_file.relative_to(self._bundle_ctx.deploy_root))}';"
                 )
 
             f.edited_contents = "\n".join(new_contents)
 
     @property
     def sandbox_root(self):
-        return self._bundle_root / "setup_py_venv"
+        return self._bundle_ctx.bundle_root / "setup_py_venv"
 
     @property
     def generated_root(self):
-        return self._generated_root / "setup_py"
+        return self._bundle_ctx.generated_root / "setup_py"
 
     def _create_or_update_sandbox(self):
         sandbox_root = self.sandbox_root
@@ -158,7 +160,7 @@ class NativeAppSetupProcessor(ArtifactProcessor):
             cc.step("Virtual environment found")
         else:
             cc.step(
-                f"Creating virtual environment in {sandbox_root.relative_to(self._project_root)}"
+                f"Creating virtual environment in {sandbox_root.relative_to(self._bundle_ctx.project_root)}"
             )
         env_builder.ensure_created()
 

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -53,7 +53,6 @@ from snowflake.cli.plugins.nativeapp.codegen.snowpark.models import (
     ExtensionFunctionTypeEnum,
     NativeAppExtensionFunction,
 )
-from snowflake.cli.plugins.nativeapp.project_model import NativeAppProjectModel
 from snowflake.cli.plugins.stage.diff import to_stage_path
 
 DEFAULT_TIMEOUT = 30
@@ -163,11 +162,8 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
     and generate SQL code for creation of extension functions based on those discovered objects.
     """
 
-    def __init__(
-        self,
-        na_project: NativeAppProjectModel,
-    ):
-        super().__init__(na_project=na_project)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def process(
         self,
@@ -181,8 +177,8 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         """
 
         bundle_map = BundleMap(
-            project_root=self._na_project.project_root,
-            deploy_root=self._na_project.deploy_root,
+            project_root=self._project_root,
+            deploy_root=self._deploy_root,
         )
         bundle_map.add(artifact_to_process)
 
@@ -230,12 +226,12 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
             edit_setup_script_with_exec_imm_sql(
                 collected_sql_files=collected_sql_files,
                 deploy_root=bundle_map.deploy_root(),
-                generated_root=self._generated_root,
+                generated_root=self._generated_snowpark_root,
             )
 
     @property
-    def _generated_root(self):
-        return self._na_project.generated_root / "snowpark"
+    def _generated_snowpark_root(self):
+        return self._generated_root / "snowpark"
 
     def _normalize_imports(
         self,
@@ -315,7 +311,7 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         self, bundle_map: BundleMap, processor_mapping: Optional[ProcessorMapping]
     ) -> Dict[Path, List[NativeAppExtensionFunction]]:
         kwargs = (
-            _determine_virtual_env(self._na_project.project_root, processor_mapping)
+            _determine_virtual_env(self._project_root, processor_mapping)
             if processor_mapping is not None
             else {}
         )
@@ -338,7 +334,7 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
             )
             collected_extension_function_json = _execute_in_sandbox(
                 py_file=str(dest_file.resolve()),
-                deploy_root=self._na_project.deploy_root,
+                deploy_root=self._deploy_root,
                 kwargs=kwargs,
             )
 
@@ -369,8 +365,10 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
         """
         Generates a SQL filename for the generated root from the python file, and creates its parent directories.
         """
-        relative_py_file = py_file.relative_to(self._na_project.deploy_root)
-        sql_file = Path(self._generated_root, relative_py_file.with_suffix(".sql"))
+        relative_py_file = py_file.relative_to(self._deploy_root)
+        sql_file = Path(
+            self._generated_snowpark_root, relative_py_file.with_suffix(".sql")
+        )
         if sql_file.exists():
             cc.warning(
                 f"""\

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -351,7 +351,12 @@ class NativeAppManager(SqlExecutionMixin):
         """
         bundle_map = build_bundle(self.project_root, self.deploy_root, self.artifacts)
         compiler = NativeAppCompiler(
-            na_project=self.na_project,
+            package_name=self.package_name,
+            artifacts=self.artifacts,
+            project_root=self.project_root,
+            bundle_root=self.bundle_root,
+            deploy_root=self.deploy_root,
+            generated_root=self.generated_root,
         )
         compiler.compile_artifacts()
         return bundle_map

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -351,16 +351,7 @@ class NativeAppManager(SqlExecutionMixin):
         Populates the local deploy root from artifact sources.
         """
         bundle_map = build_bundle(self.project_root, self.deploy_root, self.artifacts)
-        compiler = NativeAppCompiler(
-            BundleContext(
-                self.package_name,
-                self.artifacts,
-                self.project_root,
-                self.bundle_root,
-                self.deploy_root,
-                self.generated_root,
-            )
-        )
+        compiler = NativeAppCompiler(BundleContext.from_na_project(self.na_project))
         compiler.compile_artifacts()
         return bundle_map
 

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -48,8 +48,8 @@ from snowflake.cli.plugins.nativeapp.artifacts import (
     build_bundle,
     resolve_without_follow,
 )
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.compiler import (
-    BundleContext,
     NativeAppCompiler,
 )
 from snowflake.cli.plugins.nativeapp.constants import (

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -49,6 +49,7 @@ from snowflake.cli.plugins.nativeapp.artifacts import (
     resolve_without_follow,
 )
 from snowflake.cli.plugins.nativeapp.codegen.compiler import (
+    BundleContext,
     NativeAppCompiler,
 )
 from snowflake.cli.plugins.nativeapp.constants import (
@@ -351,12 +352,14 @@ class NativeAppManager(SqlExecutionMixin):
         """
         bundle_map = build_bundle(self.project_root, self.deploy_root, self.artifacts)
         compiler = NativeAppCompiler(
-            package_name=self.package_name,
-            artifacts=self.artifacts,
-            project_root=self.project_root,
-            bundle_root=self.bundle_root,
-            deploy_root=self.deploy_root,
-            generated_root=self.generated_root,
+            BundleContext(
+                self.package_name,
+                self.artifacts,
+                self.project_root,
+                self.bundle_root,
+                self.deploy_root,
+                self.generated_root,
+            )
         )
         compiler.compile_artifacts()
         return bundle_map

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -48,7 +48,6 @@ from snowflake.cli.plugins.nativeapp.artifacts import (
     build_bundle,
     resolve_without_follow,
 )
-from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.compiler import (
     NativeAppCompiler,
 )
@@ -351,7 +350,7 @@ class NativeAppManager(SqlExecutionMixin):
         Populates the local deploy root from artifact sources.
         """
         bundle_map = build_bundle(self.project_root, self.deploy_root, self.artifacts)
-        compiler = NativeAppCompiler(BundleContext.from_na_project(self.na_project))
+        compiler = NativeAppCompiler(self.na_project.get_bundle_context())
         compiler.compile_artifacts()
         return bundle_map
 

--- a/src/snowflake/cli/plugins/nativeapp/project_model.py
+++ b/src/snowflake/cli/plugins/nativeapp/project_model.py
@@ -189,10 +189,10 @@ class NativeAppProjectModel:
 
     def get_bundle_context(self) -> BundleContext:
         return BundleContext(
-            self.package_name,
-            self.artifacts,
-            self.project_root,
-            self.bundle_root,
-            self.deploy_root,
-            self.generated_root,
+            package_name=self.package_name,
+            artifacts=self.artifacts,
+            project_root=self.project_root,
+            bundle_root=self.bundle_root,
+            deploy_root=self.deploy_root,
+            generated_root=self.generated_root,
         )

--- a/src/snowflake/cli/plugins/nativeapp/project_model.py
+++ b/src/snowflake/cli/plugins/nativeapp/project_model.py
@@ -31,6 +31,7 @@ from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.util import extract_schema, to_identifier
 from snowflake.cli.plugins.nativeapp.artifacts import resolve_without_follow
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.connector import DictCursor
 
 
@@ -185,3 +186,13 @@ class NativeAppProjectModel:
         if self.definition.application:
             return self.definition.application.debug
         return None
+
+    def get_bundle_context(self) -> BundleContext:
+        return BundleContext(
+            self.package_name,
+            self.artifacts,
+            self.project_root,
+            self.bundle_root,
+            self.deploy_root,
+            self.generated_root,
+        )

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -355,14 +355,7 @@ def test_process_no_collected_functions(
                 project_root=local_path,
             )
             processor = SnowparkAnnotationProcessor(
-                BundleContext(
-                    package_name=project.package_name,
-                    artifacts=project.artifacts,
-                    project_root=project.project_root,
-                    deploy_root=project.deploy_root,
-                    bundle_root=project.bundle_root,
-                    generated_root=project.generated_root,
-                )
+                BundleContext.from_na_project(project)
             )
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
@@ -416,14 +409,7 @@ def test_process_with_collected_functions(
                 project_root=local_path,
             )
             processor = SnowparkAnnotationProcessor(
-                BundleContext(
-                    package_name=project.package_name,
-                    artifacts=project.artifacts,
-                    project_root=project.project_root,
-                    deploy_root=project.deploy_root,
-                    bundle_root=project.bundle_root,
-                    generated_root=project.generated_root,
-                )
+                BundleContext.from_na_project(project)
             )
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
@@ -485,14 +471,7 @@ def test_package_normalization(
                 project_root=local_path,
             )
             processor = SnowparkAnnotationProcessor(
-                BundleContext(
-                    package_name=project.package_name,
-                    artifacts=project.artifacts,
-                    project_root=project.project_root,
-                    deploy_root=project.deploy_root,
-                    bundle_root=project.bundle_root,
-                    generated_root=project.generated_root,
-                )
+                BundleContext.from_na_project(project)
             )
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -22,7 +22,6 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.project.schemas.native_app.path_mapping import ProcessorMapping
-from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.sandbox import (
     ExecutionEnvironmentType,
     SandboxExecutionError,
@@ -354,9 +353,7 @@ def test_process_no_collected_functions(
                 project_definition=native_app_project_instance.native_app,
                 project_root=local_path,
             )
-            processor = SnowparkAnnotationProcessor(
-                BundleContext.from_na_project(project)
-            )
+            processor = SnowparkAnnotationProcessor(project.get_bundle_context())
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
                 processor_mapping=ProcessorMapping(name="SNOWPARK"),
@@ -408,9 +405,7 @@ def test_process_with_collected_functions(
                 project_definition=native_app_project_instance.native_app,
                 project_root=local_path,
             )
-            processor = SnowparkAnnotationProcessor(
-                BundleContext.from_na_project(project)
-            )
+            processor = SnowparkAnnotationProcessor(project.get_bundle_context())
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
                 processor_mapping=processor_mapping,
@@ -470,9 +465,7 @@ def test_package_normalization(
                 project_definition=native_app_project_instance.native_app,
                 project_root=local_path,
             )
-            processor = SnowparkAnnotationProcessor(
-                BundleContext.from_na_project(project)
-            )
+            processor = SnowparkAnnotationProcessor(project.get_bundle_context())
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
                 processor_mapping=processor_mapping,

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.project.schemas.native_app.path_mapping import ProcessorMapping
-from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.sandbox import (
     ExecutionEnvironmentType,
     SandboxExecutionError,

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -353,7 +353,14 @@ def test_process_no_collected_functions(
                 project_definition=native_app_project_instance.native_app,
                 project_root=local_path,
             )
-            SnowparkAnnotationProcessor(na_project=project).process(
+            processor = SnowparkAnnotationProcessor(
+                project.package_name,
+                project.project_root,
+                project.deploy_root,
+                project.bundle_root,
+                project.generated_root,
+            )
+            processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
                 processor_mapping=ProcessorMapping(name="SNOWPARK"),
                 write_to_sql=False,  # For testing
@@ -404,7 +411,14 @@ def test_process_with_collected_functions(
                 project_definition=native_app_project_instance.native_app,
                 project_root=local_path,
             )
-            SnowparkAnnotationProcessor(na_project=project).process(
+            processor = SnowparkAnnotationProcessor(
+                project.package_name,
+                project.project_root,
+                project.deploy_root,
+                project.bundle_root,
+                project.generated_root,
+            )
+            processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
                 processor_mapping=processor_mapping,
             )
@@ -463,7 +477,14 @@ def test_package_normalization(
                 project_definition=native_app_project_instance.native_app,
                 project_root=local_path,
             )
-            SnowparkAnnotationProcessor(na_project=project).process(
+            processor = SnowparkAnnotationProcessor(
+                project.package_name,
+                project.project_root,
+                project.deploy_root,
+                project.bundle_root,
+                project.generated_root,
+            )
+            processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
                 processor_mapping=processor_mapping,
             )

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.project.schemas.native_app.path_mapping import ProcessorMapping
+from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.sandbox import (
     ExecutionEnvironmentType,
     SandboxExecutionError,
@@ -354,11 +355,14 @@ def test_process_no_collected_functions(
                 project_root=local_path,
             )
             processor = SnowparkAnnotationProcessor(
-                project.package_name,
-                project.project_root,
-                project.deploy_root,
-                project.bundle_root,
-                project.generated_root,
+                BundleContext(
+                    package_name=project.package_name,
+                    artifacts=project.artifacts,
+                    project_root=project.project_root,
+                    deploy_root=project.deploy_root,
+                    bundle_root=project.bundle_root,
+                    generated_root=project.generated_root,
+                )
             )
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
@@ -412,11 +416,14 @@ def test_process_with_collected_functions(
                 project_root=local_path,
             )
             processor = SnowparkAnnotationProcessor(
-                project.package_name,
-                project.project_root,
-                project.deploy_root,
-                project.bundle_root,
-                project.generated_root,
+                BundleContext(
+                    package_name=project.package_name,
+                    artifacts=project.artifacts,
+                    project_root=project.project_root,
+                    deploy_root=project.deploy_root,
+                    bundle_root=project.bundle_root,
+                    generated_root=project.generated_root,
+                )
             )
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],
@@ -478,11 +485,14 @@ def test_package_normalization(
                 project_root=local_path,
             )
             processor = SnowparkAnnotationProcessor(
-                project.package_name,
-                project.project_root,
-                project.deploy_root,
-                project.bundle_root,
-                project.generated_root,
+                BundleContext(
+                    package_name=project.package_name,
+                    artifacts=project.artifacts,
+                    project_root=project.project_root,
+                    deploy_root=project.deploy_root,
+                    bundle_root=project.bundle_root,
+                    generated_root=project.generated_root,
+                )
             )
             processor.process(
                 artifact_to_process=native_app_project_instance.native_app.artifacts[0],

--- a/tests/nativeapp/codegen/test_compiler.py
+++ b/tests/nativeapp/codegen/test_compiler.py
@@ -58,8 +58,14 @@ def test_proj_def():
 
 @pytest.fixture()
 def test_compiler(test_proj_def):
+    na_project = create_native_app_project_model(test_proj_def.native_app)
     return NativeAppCompiler(
-        na_project=create_native_app_project_model(test_proj_def.native_app)
+        na_project.package_name,
+        na_project.artifacts,
+        na_project.project_root,
+        na_project.bundle_root,
+        na_project.deploy_root,
+        na_project.generated_root,
     )
 
 
@@ -92,7 +98,14 @@ def test_find_and_execute_processors_exception(test_proj_def, test_compiler):
     app_pkg = create_native_app_project_model(
         project_definition=test_proj_def.native_app
     )
-    test_compiler = NativeAppCompiler(na_project=app_pkg)
+    test_compiler = NativeAppCompiler(
+        app_pkg.package_name,
+        app_pkg.artifacts,
+        app_pkg.project_root,
+        app_pkg.bundle_root,
+        app_pkg.deploy_root,
+        app_pkg.generated_root,
+    )
 
     with pytest.raises(UnsupportedArtifactProcessorError):
         test_compiler.compile_artifacts()

--- a/tests/nativeapp/codegen/test_compiler.py
+++ b/tests/nativeapp/codegen/test_compiler.py
@@ -17,7 +17,6 @@ import pytest
 from snowflake.cli.api.project.schemas.project_definition import (
     build_project_definition,
 )
-from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.artifact_processor import (
     UnsupportedArtifactProcessorError,
 )
@@ -60,7 +59,7 @@ def test_proj_def():
 @pytest.fixture()
 def test_compiler(test_proj_def):
     na_project = create_native_app_project_model(test_proj_def.native_app)
-    return NativeAppCompiler(BundleContext.from_na_project(na_project))
+    return NativeAppCompiler(na_project.get_bundle_context())
 
 
 def test_try_create_processor_returns_none(test_proj_def, test_compiler):
@@ -92,7 +91,7 @@ def test_find_and_execute_processors_exception(test_proj_def, test_compiler):
     app_pkg = create_native_app_project_model(
         project_definition=test_proj_def.native_app
     )
-    test_compiler = NativeAppCompiler(BundleContext.from_na_project(app_pkg))
+    test_compiler = NativeAppCompiler(app_pkg.get_bundle_context())
 
     with pytest.raises(UnsupportedArtifactProcessorError):
         test_compiler.compile_artifacts()

--- a/tests/nativeapp/codegen/test_compiler.py
+++ b/tests/nativeapp/codegen/test_compiler.py
@@ -60,16 +60,7 @@ def test_proj_def():
 @pytest.fixture()
 def test_compiler(test_proj_def):
     na_project = create_native_app_project_model(test_proj_def.native_app)
-    return NativeAppCompiler(
-        BundleContext(
-            package_name=na_project.package_name,
-            artifacts=na_project.artifacts,
-            project_root=na_project.project_root,
-            bundle_root=na_project.bundle_root,
-            deploy_root=na_project.deploy_root,
-            generated_root=na_project.generated_root,
-        )
-    )
+    return NativeAppCompiler(BundleContext.from_na_project(na_project))
 
 
 def test_try_create_processor_returns_none(test_proj_def, test_compiler):
@@ -101,16 +92,7 @@ def test_find_and_execute_processors_exception(test_proj_def, test_compiler):
     app_pkg = create_native_app_project_model(
         project_definition=test_proj_def.native_app
     )
-    test_compiler = NativeAppCompiler(
-        BundleContext(
-            package_name=app_pkg.package_name,
-            artifacts=app_pkg.artifacts,
-            project_root=app_pkg.project_root,
-            bundle_root=app_pkg.bundle_root,
-            deploy_root=app_pkg.deploy_root,
-            generated_root=app_pkg.generated_root,
-        )
-    )
+    test_compiler = NativeAppCompiler(BundleContext.from_na_project(app_pkg))
 
     with pytest.raises(UnsupportedArtifactProcessorError):
         test_compiler.compile_artifacts()

--- a/tests/nativeapp/codegen/test_compiler.py
+++ b/tests/nativeapp/codegen/test_compiler.py
@@ -17,7 +17,7 @@ import pytest
 from snowflake.cli.api.project.schemas.project_definition import (
     build_project_definition,
 )
-from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.artifact_processor import (
     UnsupportedArtifactProcessorError,
 )

--- a/tests/nativeapp/codegen/test_compiler.py
+++ b/tests/nativeapp/codegen/test_compiler.py
@@ -17,6 +17,7 @@ import pytest
 from snowflake.cli.api.project.schemas.project_definition import (
     build_project_definition,
 )
+from snowflake.cli.plugins.nativeapp.artifacts import BundleContext
 from snowflake.cli.plugins.nativeapp.codegen.artifact_processor import (
     UnsupportedArtifactProcessorError,
 )
@@ -60,12 +61,14 @@ def test_proj_def():
 def test_compiler(test_proj_def):
     na_project = create_native_app_project_model(test_proj_def.native_app)
     return NativeAppCompiler(
-        na_project.package_name,
-        na_project.artifacts,
-        na_project.project_root,
-        na_project.bundle_root,
-        na_project.deploy_root,
-        na_project.generated_root,
+        BundleContext(
+            package_name=na_project.package_name,
+            artifacts=na_project.artifacts,
+            project_root=na_project.project_root,
+            bundle_root=na_project.bundle_root,
+            deploy_root=na_project.deploy_root,
+            generated_root=na_project.generated_root,
+        )
     )
 
 
@@ -99,12 +102,14 @@ def test_find_and_execute_processors_exception(test_proj_def, test_compiler):
         project_definition=test_proj_def.native_app
     )
     test_compiler = NativeAppCompiler(
-        app_pkg.package_name,
-        app_pkg.artifacts,
-        app_pkg.project_root,
-        app_pkg.bundle_root,
-        app_pkg.deploy_root,
-        app_pkg.generated_root,
+        BundleContext(
+            package_name=app_pkg.package_name,
+            artifacts=app_pkg.artifacts,
+            project_root=app_pkg.project_root,
+            bundle_root=app_pkg.bundle_root,
+            deploy_root=app_pkg.deploy_root,
+            generated_root=app_pkg.generated_root,
+        )
     )
 
     with pytest.raises(UnsupportedArtifactProcessorError):

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -1362,7 +1362,7 @@ def test_bundle_context_from_na_project():
         deploy_root="deploy_root",
         generated_root="generated_root",
     )
-    project_root = Path("/project/root")
+    project_root = resolve_without_follow(Path("/project/root"))
     na_project = create_native_app_project_model(na, project_root)
 
     actual_bundle_ctx = BundleContext.from_na_project(na_project)

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -19,8 +19,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Union
 
 import pytest
-from snowflake.cli.api.project.definition import default_app_package, load_project
-from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
+from snowflake.cli.api.project.definition import load_project
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.plugins.nativeapp.artifacts import (
     ArtifactError,
@@ -34,11 +33,9 @@ from snowflake.cli.plugins.nativeapp.artifacts import (
     resolve_without_follow,
     symlink_or_copy,
 )
-from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 
 from tests.nativeapp.utils import (
     assert_dir_snapshot,
-    create_native_app_project_model,
     touch,
 )
 from tests.testing_utils.files_and_dirs import pushd, temp_local_dir
@@ -1352,31 +1349,3 @@ def test_symlink_or_copy_with_symlinks_in_project_root(os_agnostic_snapshot):
             )
 
             assert_dir_snapshot(Path("./output/deploy"), os_agnostic_snapshot)
-
-
-def test_bundle_context_from_na_project():
-    na = NativeApp(
-        name="test_project",
-        artifacts=["a/b", {"src": "c", "dest": "d"}],
-        bundle_root="bundle_root",
-        deploy_root="deploy_root",
-        generated_root="generated_root",
-    )
-    project_root = resolve_without_follow(Path("/project/root"))
-    na_project = create_native_app_project_model(na, project_root)
-
-    actual_bundle_ctx = BundleContext.from_na_project(na_project)
-
-    expected_bundle_ctx = BundleContext(
-        default_app_package("test_project"),
-        [
-            PathMapping(src="a/b", dest=None),
-            PathMapping(src="c", dest="d"),
-        ],
-        project_root,
-        Path(project_root, "bundle_root"),
-        Path(project_root, "deploy_root"),
-        Path(project_root, "deploy_root", "generated_root"),
-    )
-
-    assert actual_bundle_ctx == expected_bundle_ctx

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -25,7 +25,6 @@ from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMappin
 from snowflake.cli.plugins.nativeapp.artifacts import (
     ArtifactError,
     ArtifactPredicate,
-    BundleContext,
     BundleMap,
     DeployRootError,
     NotInDeployRootError,
@@ -35,6 +34,7 @@ from snowflake.cli.plugins.nativeapp.artifacts import (
     resolve_without_follow,
     symlink_or_copy,
 )
+from snowflake.cli.plugins.nativeapp.bundle_context import BundleContext
 
 from tests.nativeapp.utils import (
     assert_dir_snapshot,

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -19,11 +19,13 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Union
 
 import pytest
-from snowflake.cli.api.project.definition import load_project
+from snowflake.cli.api.project.definition import default_app_package, load_project
+from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.plugins.nativeapp.artifacts import (
     ArtifactError,
     ArtifactPredicate,
+    BundleContext,
     BundleMap,
     DeployRootError,
     NotInDeployRootError,
@@ -34,7 +36,11 @@ from snowflake.cli.plugins.nativeapp.artifacts import (
     symlink_or_copy,
 )
 
-from tests.nativeapp.utils import assert_dir_snapshot, touch
+from tests.nativeapp.utils import (
+    assert_dir_snapshot,
+    create_native_app_project_model,
+    touch,
+)
 from tests.testing_utils.files_and_dirs import pushd, temp_local_dir
 from tests_common import IS_WINDOWS
 
@@ -1346,3 +1352,31 @@ def test_symlink_or_copy_with_symlinks_in_project_root(os_agnostic_snapshot):
             )
 
             assert_dir_snapshot(Path("./output/deploy"), os_agnostic_snapshot)
+
+
+def test_bundle_context_from_na_project():
+    na = NativeApp(
+        name="test_project",
+        artifacts=["a/b", {"src": "c", "dest": "d"}],
+        bundle_root="bundle_root",
+        deploy_root="deploy_root",
+        generated_root="generated_root",
+    )
+    project_root = Path("/project/root")
+    na_project = create_native_app_project_model(na, project_root)
+
+    actual_bundle_ctx = BundleContext.from_na_project(na_project)
+
+    expected_bundle_ctx = BundleContext(
+        default_app_package("test_project"),
+        [
+            PathMapping(src="a/b", dest=None),
+            PathMapping(src="c", dest="d"),
+        ],
+        project_root,
+        Path(project_root, "bundle_root"),
+        Path(project_root, "deploy_root"),
+        Path(project_root, "deploy_root", "generated_root"),
+    )
+
+    assert actual_bundle_ctx == expected_bundle_ctx

--- a/tests/nativeapp/test_project_model.py
+++ b/tests/nativeapp/test_project_model.py
@@ -188,15 +188,15 @@ def test_bundle_context_from_project_model(project_definition_files: List[Path])
     actual_bundle_ctx = project.get_bundle_context()
 
     expected_bundle_ctx = BundleContext(
-        default_app_package("minimal"),
-        [
+        package_name=default_app_package("minimal"),
+        artifacts=[
             PathMapping(src="setup.sql", dest=None),
             PathMapping(src="README.md", dest=None),
         ],
-        project_dir,
-        Path(project_dir / "output" / "bundle"),
-        Path(project_dir / "output" / "deploy"),
-        Path(project_dir / "output" / "deploy" / "__generated"),
+        project_root=project_dir,
+        bundle_root=Path(project_dir / "output" / "bundle"),
+        deploy_root=Path(project_dir / "output" / "deploy"),
+        generated_root=Path(project_dir / "output" / "deploy" / "__generated"),
     )
 
     assert actual_bundle_ctx == expected_bundle_ctx


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

Instead of passing `NativeAppCompiler` the entire project definition object (via `NativeAppProjectModel`), we're passing it now the specific parameters it needs, grouped together as `BundleContext`.

The main reason for this is the upcoming support for project definition v2, which has significantly different structure (it's not enough to pass the entire definition object, we also need to know which entity is being bundled, its dependencies, etc.).
