### PR TITLE
Add `--type` and `--scope` filters

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -409,7 +409,7 @@ def app_events(
     scopes: Annotated[list[str], typer.Option()] = typer.Option(
         [],
         "--scope",
-        help="Restrict results to specific scope. Can be specified multiple times.",
+        help="Restrict results to a specific scope name. Can be specified multiple times.",
     ),
     first: int = typer.Option(
         default=0, help="Fetch only the first N events. Cannot be used with --last."

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -749,7 +749,9 @@ class NativeAppManager(SqlExecutionMixin):
             f"and record_type in ({type_in_values})" if type_in_values else ""
         )
         scope_in_values = ",".join(f"'{v}'" for v in scopes)
-        scopes_clause = f"and scope in ({scope_in_values})" if scope_in_values else ""
+        scopes_clause = (
+            f"and scope:name in ({scope_in_values})" if scope_in_values else ""
+        )
         first_clause = f"limit {first}" if first else ""
         last_clause = f"limit {last}" if last else ""
         query = dedent(

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -190,9 +190,9 @@
   | --type             [log|span|span_event]  Restrict results to specific       |
   |                                           record type. Can be specified      |
   |                                           multiple times.                    |
-  | --scope            TEXT                   Restrict results to specific       |
-  |                                           scope. Can be specified multiple   |
-  |                                           times.                             |
+  | --scope            TEXT                   Restrict results to a specific     |
+  |                                           scope name. Can be specified       |
+  |                                           multiple times.                    |
   | --first            INTEGER                Fetch only the first N events.     |
   |                                           Cannot be used with --last.        |
   |                                           [default: 0]                       |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -181,21 +181,31 @@
    Fetches events for this app from the event table configured in Snowflake.      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --since            TEXT     Fetch events that are newer than this time ago,  |
-  |                             in Snowflake interval syntax.                    |
-  | --until            TEXT     Fetch events that are older than this time ago,  |
-  |                             in Snowflake interval syntax.                    |
-  | --first            INTEGER  Fetch only the first N events. Cannot be used    |
-  |                             with --last.                                     |
-  |                             [default: 0]                                     |
-  | --last             INTEGER  Fetch only the last N events. Cannot be used     |
-  |                             with --first.                                    |
-  |                             [default: 0]                                     |
-  | --project  -p      TEXT     Path where Snowflake project resides. Defaults   |
-  |                             to current working directory.                    |
-  | --env              TEXT     String in format of key=value. Overrides         |
-  |                             variables from env section used for templating.  |
-  | --help     -h               Show this message and exit.                      |
+  | --since            TEXT                   Fetch events that are newer than   |
+  |                                           this time ago, in Snowflake        |
+  |                                           interval syntax.                   |
+  | --until            TEXT                   Fetch events that are older than   |
+  |                                           this time ago, in Snowflake        |
+  |                                           interval syntax.                   |
+  | --type             [log|span|span_event]  Restrict results to specific       |
+  |                                           record type. Can be specified      |
+  |                                           multiple times.                    |
+  | --scope            TEXT                   Restrict results to specific       |
+  |                                           scope. Can be specified multiple   |
+  |                                           times.                             |
+  | --first            INTEGER                Fetch only the first N events.     |
+  |                                           Cannot be used with --last.        |
+  |                                           [default: 0]                       |
+  | --last             INTEGER                Fetch only the last N events.      |
+  |                                           Cannot be used with --first.       |
+  |                                           [default: 0]                       |
+  | --project  -p      TEXT                   Path where Snowflake project       |
+  |                                           resides. Defaults to current       |
+  |                                           working directory.                 |
+  | --env              TEXT                   String in format of key=value.     |
+  |                                           Overrides variables from env       |
+  |                                           section used for templating.       |
+  | --help     -h                             Show this message and exit.        |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment  -c      TEXT  Name of the connection, as defined |

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1368,6 +1368,22 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     ],
 )
 @pytest.mark.parametrize(
+    ["scopes", "expected_scopes_clause"],
+    [
+        ([], ""),
+        (["scope_1"], "and scope in ('scope_1')"),
+        (["scope_1", "scope_2"], "and scope in ('scope_1','scope_2')"),
+    ],
+)
+@pytest.mark.parametrize(
+    ["types", "expected_types_clause"],
+    [
+        ([], ""),
+        (["log"], "and record_type in ('log')"),
+        (["log", "span"], "and record_type in ('log','span')"),
+    ],
+)
+@pytest.mark.parametrize(
     ["first", "expected_first_clause"],
     [
         (0, ""),
@@ -1396,6 +1412,10 @@ def test_get_events(
     expected_since_clause,
     until,
     expected_until_clause,
+    types,
+    expected_types_clause,
+    scopes,
+    expected_scopes_clause,
     first,
     expected_first_clause,
     last,
@@ -1421,6 +1441,8 @@ def test_get_events(
                             where resource_attributes:"snow.database.name" = 'MYAPP'
                             {expected_since_clause}
                             {expected_until_clause}
+                            {expected_types_clause}
+                            {expected_scopes_clause}
                             order by timestamp desc
                             {expected_last_clause}
                         ) order by timestamp asc
@@ -1439,6 +1461,8 @@ def test_get_events(
         return native_app_manager.get_events(
             since_interval=since,
             until_interval=until,
+            record_types=types,
+            scopes=scopes,
             first=first,
             last=last,
         )

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1371,8 +1371,8 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     ["scopes", "expected_scopes_clause"],
     [
         ([], ""),
-        (["scope_1"], "and scope in ('scope_1')"),
-        (["scope_1", "scope_2"], "and scope in ('scope_1','scope_2')"),
+        (["scope_1"], "and scope:name in ('scope_1')"),
+        (["scope_1", "scope_2"], "and scope:name in ('scope_1','scope_2')"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1508,6 +1508,8 @@ def test_get_events_quoted_app_name(
                             select timestamp, value::varchar value
                             from db.schema.event_table
                             where resource_attributes:"snow.database.name" = 'My Application'
+                        
+                        
                         
                         
                             order by timestamp desc

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import os.path
 import uuid
 
 from snowflake.cli.api.project.util import generate_user_env
 from tests.project.fixtures import *
-from tests_integration.test_utils import pushd
+from tests_integration.test_utils import enable_definition_v2_feature_flag
 
 USER_NAME = f"user_{uuid.uuid4().hex}"
 TEST_ENV = generate_user_env(USER_NAME)
@@ -26,15 +24,12 @@ TEST_ENV = generate_user_env(USER_NAME)
 
 # Tests that snow app events --first N --last M exits with an error
 @pytest.mark.integration
-def test_app_events_cant_specify_first_and_last(runner, temporary_working_directory):
-    project_name = "myapp"
-    result = runner.invoke_json(
-        ["app", "init", project_name],
-        env=TEST_ENV,
-    )
-    assert result.exit_code == 0, result.output
-
-    with pushd(Path(os.getcwd(), project_name)):
+@enable_definition_v2_feature_flag
+@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
+def test_app_events_cant_specify_first_and_last(
+    test_project, runner, project_directory
+):
+    with project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
         result = runner.invoke_with_connection(
@@ -46,15 +41,10 @@ def test_app_events_cant_specify_first_and_last(runner, temporary_working_direct
 
 
 @pytest.mark.integration
-def test_app_events_reject_invalid_type(runner, temporary_working_directory):
-    project_name = "myapp"
-    result = runner.invoke_json(
-        ["app", "init", project_name],
-        env=TEST_ENV,
-    )
-    assert result.exit_code == 0, result.output
-
-    with pushd(Path(os.getcwd(), project_name)):
+@enable_definition_v2_feature_flag
+@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
+def test_app_events_reject_invalid_type(test_project, runner, project_directory):
+    with project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
         result = runner.invoke_with_connection(

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -43,3 +43,23 @@ def test_app_events_cant_specify_first_and_last(runner, temporary_working_direct
         )
         assert result.exit_code == 1, result.output
         assert "--first and --last cannot be used together." in result.output
+
+
+@pytest.mark.integration
+def test_app_events_reject_invalid_type(runner, temporary_working_directory):
+    project_name = "myapp"
+    result = runner.invoke_json(
+        ["app", "init", project_name],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+
+    with pushd(Path(os.getcwd(), project_name)):
+        # The integration test account doesn't have an event table set up
+        # but this test is still useful to validate the negative case
+        result = runner.invoke_with_connection(
+            ["app", "events", "--type", "foo"],
+            env=TEST_ENV,
+        )
+        assert result.exit_code == 2, result.output
+        assert "Invalid value for '--type'" in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds additional filters to allow devs to choose the type and source of the events they want to see. `--type` is used to choose between logs, spans, and span events, and `--scope` is used to filter on the event scope (e.g. the logger class/name in the case of logs).
