### PR TITLE
Add `--follow` to `snow app events`

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -476,13 +476,13 @@ def app_events(
     **options,
 ):
     """Fetches events for this app from the event table configured in Snowflake."""
-    if first != -1 and last != -1:
+    if first >= 0 and last >= 0:
         raise ClickException("--first and --last cannot be used together.")
 
     if follow:
         if until:
             raise ClickException("--follow and --until cannot be used together.")
-        if first != -1:
+        if first >= 0:
             raise ClickException("--follow and --first cannot be used together.")
 
     assert_project_type("native_app")

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -451,16 +451,23 @@ def app_events(
         help="Restrict results to a specific scope name. Can be specified multiple times.",
     ),
     first: int = typer.Option(
-        default=-1, help="Fetch only the first N events. Cannot be used with --last."
+        default=-1,
+        show_default=False,
+        help="Fetch only the first N events. Cannot be used with --last.",
     ),
     last: int = typer.Option(
-        default=-1, help="Fetch only the last N events. Cannot be used with --first."
+        default=-1,
+        show_default=False,
+        help="Fetch only the last N events. Cannot be used with --first.",
     ),
     follow: bool = typer.Option(
         False,
         "--follow",
         "-f",
-        help=f"Continue polling for events. Implies --last {DEFAULT_EVENT_FOLLOW_LAST} unless overridden.",
+        help=(
+            f"Continue polling for events. Implies --last {DEFAULT_EVENT_FOLLOW_LAST} "
+            f"unless overridden or the --since flag is used."
+        ),
     ),
     follow_interval: int = typer.Option(
         10,

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -463,6 +463,12 @@ def app_events(
     if first and last:
         raise ClickException("--first and --last cannot be used together.")
 
+    if follow:
+        if until:
+            raise ClickException("--follow and --until cannot be used together.")
+        if first:
+            raise ClickException("--follow and --first cannot be used together.")
+
     assert_project_type("native_app")
 
     record_type_names = [r.name for r in record_types]

--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -496,8 +496,8 @@ def app_events(
         stream = (
             EventResult(event)
             for event in manager.get_events(
-                since_interval=since,
-                until_interval=until,
+                since=since,
+                until=until,
                 record_types=record_type_names,
                 scopes=scopes,
                 first=first,

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -816,6 +816,9 @@ def _new_events_only(previous_events: list[dict], new_events: list[dict]) -> lis
     last_overlap_found_at = 0
     while overlap_amount <= min(len(new_events), len(previous_events)):
         # Check if end of previous_events overlaps with start of new_events
+        # This is O(n) but from the SQL filters and ordering used to generate
+        # both lists of events, we know that the only overlap would be for events
+        # that happened in the exact same microsecond (usually only 1 or 2, rarely more)
         if previous_events[-overlap_amount:] == new_events[:overlap_amount]:
             last_overlap_found_at = overlap_amount
         elif last_overlap_found_at:

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -726,7 +726,7 @@ class NativeAppManager(SqlExecutionMixin):
         record_types = record_types or []
         scopes = scopes or []
 
-        if first != -1 and last != -1:
+        if first >= 0 and last >= 0:
             raise ValueError("first and last cannot be used together")
 
         if not self.account_event_table:
@@ -754,8 +754,8 @@ class NativeAppManager(SqlExecutionMixin):
         scopes_clause = (
             f"and scope:name in ({scope_in_values})" if scope_in_values else ""
         )
-        first_clause = f"limit {first}" if first != -1 else ""
-        last_clause = f"limit {last}" if last != -1 else ""
+        first_clause = f"limit {first}" if first >= 0 else ""
+        last_clause = f"limit {last}" if last >= 0 else ""
         query = dedent(
             f"""\
             select * from (

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -780,7 +780,7 @@ class NativeAppManager(SqlExecutionMixin):
     def stream_events(
         self,
         last: int,
-        delay_seconds: int,
+        interval_seconds: int,
         record_types: list[str] | None = None,
         scopes: list[str] | None = None,
     ) -> Generator[dict, None, None]:
@@ -792,7 +792,7 @@ class NativeAppManager(SqlExecutionMixin):
             last_event_time = events[-1]["TIMESTAMP"]
 
             while True:  # Then infinite poll for new events
-                time.sleep(delay_seconds)
+                time.sleep(interval_seconds)
                 previous_events = events
                 events = self.get_events(
                     since=last_event_time, record_types=record_types, scopes=scopes

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -818,12 +818,13 @@ def _new_events_only(previous_events: list[dict], new_events: list[dict]) -> lis
     # but only once in previous_events, it should still
     # appear twice in new_events at the end
     new_events = new_events.copy()
-    for event in previous_events:
-        if event["TIMESTAMP"] == overlap_time:
-            # No need to handle ValueError here since we know
-            # that events that pass the above if check will
-            # either be in both lists or in new_events only
-            new_events.remove(event)
+    for event in reversed(previous_events):
+        if event["TIMESTAMP"] < overlap_time:
+            break
+        # No need to handle ValueError here since we know
+        # that events that pass the above if check will
+        # either be in both lists or in new_events only
+        new_events.remove(event)
     return new_events
 
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -271,6 +271,9 @@
   | --last             INTEGER                Fetch only the last N events.      |
   |                                           Cannot be used with --first.       |
   |                                           [default: 0]                       |
+  | --follow   -f                             Continue polling for events.       |
+  |                                           Implies --last 20 unless           |
+  |                                           overridden.                        |
   | --project  -p      TEXT                   Path where Snowflake project       |
   |                                           resides. Defaults to current       |
   |                                           working directory.                 |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -272,14 +272,13 @@
   | --first                    INTEGER                Fetch only the first N     |
   |                                                   events. Cannot be used     |
   |                                                   with --last.               |
-  |                                                   [default: 0]               |
   | --last                     INTEGER                Fetch only the last N      |
   |                                                   events. Cannot be used     |
   |                                                   with --first.              |
-  |                                                   [default: 0]               |
   | --follow           -f                             Continue polling for       |
   |                                                   events. Implies --last 20  |
-  |                                                   unless overridden.         |
+  |                                                   unless overridden or the   |
+  |                                                   --since flag is used.      |
   | --follow-interval          INTEGER                Polling interval in        |
   |                                                   seconds when using the     |
   |                                                   --follow flag.             |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -253,34 +253,47 @@
    Fetches events for this app from the event table configured in Snowflake.      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --since            TEXT                   Fetch events that are newer than   |
-  |                                           this time ago, in Snowflake        |
-  |                                           interval syntax.                   |
-  | --until            TEXT                   Fetch events that are older than   |
-  |                                           this time ago, in Snowflake        |
-  |                                           interval syntax.                   |
-  | --type             [log|span|span_event]  Restrict results to specific       |
-  |                                           record type. Can be specified      |
-  |                                           multiple times.                    |
-  | --scope            TEXT                   Restrict results to a specific     |
-  |                                           scope name. Can be specified       |
-  |                                           multiple times.                    |
-  | --first            INTEGER                Fetch only the first N events.     |
-  |                                           Cannot be used with --last.        |
-  |                                           [default: 0]                       |
-  | --last             INTEGER                Fetch only the last N events.      |
-  |                                           Cannot be used with --first.       |
-  |                                           [default: 0]                       |
-  | --follow   -f                             Continue polling for events.       |
-  |                                           Implies --last 20 unless           |
-  |                                           overridden.                        |
-  | --project  -p      TEXT                   Path where Snowflake project       |
-  |                                           resides. Defaults to current       |
-  |                                           working directory.                 |
-  | --env              TEXT                   String in format of key=value.     |
-  |                                           Overrides variables from env       |
-  |                                           section used for templating.       |
-  | --help     -h                             Show this message and exit.        |
+  | --since                    TEXT                   Fetch events that are      |
+  |                                                   newer than this time ago,  |
+  |                                                   in Snowflake interval      |
+  |                                                   syntax.                    |
+  | --until                    TEXT                   Fetch events that are      |
+  |                                                   older than this time ago,  |
+  |                                                   in Snowflake interval      |
+  |                                                   syntax.                    |
+  | --type                     [log|span|span_event]  Restrict results to        |
+  |                                                   specific record type. Can  |
+  |                                                   be specified multiple      |
+  |                                                   times.                     |
+  | --scope                    TEXT                   Restrict results to a      |
+  |                                                   specific scope name. Can   |
+  |                                                   be specified multiple      |
+  |                                                   times.                     |
+  | --first                    INTEGER                Fetch only the first N     |
+  |                                                   events. Cannot be used     |
+  |                                                   with --last.               |
+  |                                                   [default: 0]               |
+  | --last                     INTEGER                Fetch only the last N      |
+  |                                                   events. Cannot be used     |
+  |                                                   with --first.              |
+  |                                                   [default: 0]               |
+  | --follow           -f                             Continue polling for       |
+  |                                                   events. Implies --last 20  |
+  |                                                   unless overridden.         |
+  | --follow-interval          INTEGER                Polling interval in        |
+  |                                                   seconds when using the     |
+  |                                                   --follow flag.             |
+  |                                                   [default: 10]              |
+  | --project          -p      TEXT                   Path where Snowflake       |
+  |                                                   project resides. Defaults  |
+  |                                                   to current working         |
+  |                                                   directory.                 |
+  | --env                      TEXT                   String in format of        |
+  |                                                   key=value. Overrides       |
+  |                                                   variables from env section |
+  |                                                   used for templating.       |
+  | --help             -h                             Show this message and      |
+  |                                                   exit.                      |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment  -c      TEXT  Name of the connection, as defined |

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional
@@ -1358,6 +1359,7 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     [
         ("", ""),
         ("1 hour", "and timestamp >= sysdate() - interval '1 hour'"),
+        (datetime(2024, 1, 1), "and timestamp >= '2024-01-01 00:00:00'"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1365,6 +1367,7 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     [
         ("", ""),
         ("20 minutes", "and timestamp <= sysdate() - interval '20 minutes'"),
+        (datetime(2024, 1, 1), "and timestamp <= '2024-01-01 00:00:00'"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1459,8 +1462,8 @@ def test_get_events(
     def get_events():
         native_app_manager = _get_na_manager()
         return native_app_manager.get_events(
-            since_interval=since,
-            until_interval=until,
+            since=since,
+            until=until,
             record_types=types,
             scopes=scopes,
             first=first,

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1472,7 +1472,7 @@ def test_get_events(
             last=last,
         )
 
-    if first != -1 and last != -1:
+    if first >= 0 and last >= 0:
         # Filtering on first and last events at the same time doesn't make sense
         with pytest.raises(ValueError):
             get_events()

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1618,7 +1618,7 @@ def test_stream_events(mock_execute, mock_account_event_table, temp_dir, mock_cu
     mock_execute.side_effect = side_effects
 
     native_app_manager = _get_na_manager()
-    stream = native_app_manager.stream_events(last=len(events[0]), delay_seconds=0)
+    stream = native_app_manager.stream_events(last=len(events[0]), interval_seconds=0)
     for i in range(len(events[0])):
         # Exhaust the initial set of events
         assert next(stream) == events[0][i]

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1389,14 +1389,16 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
 @pytest.mark.parametrize(
     ["first", "expected_first_clause"],
     [
-        (0, ""),
+        (-1, ""),
+        (0, "limit 0"),
         (10, "limit 10"),
     ],
 )
 @pytest.mark.parametrize(
     ["last", "expected_last_clause"],
     [
-        (0, ""),
+        (-1, ""),
+        (0, "limit 0"),
         (20, "limit 20"),
     ],
 )
@@ -1470,7 +1472,7 @@ def test_get_events(
             last=last,
         )
 
-    if first and last:
+    if first != -1 and last != -1:
         # Filtering on first and last events at the same time doesn't make sense
         with pytest.raises(ValueError):
             get_events()
@@ -1618,7 +1620,7 @@ def test_stream_events(mock_execute, mock_account_event_table, temp_dir, mock_cu
     mock_execute.side_effect = side_effects
 
     native_app_manager = _get_na_manager()
-    stream = native_app_manager.stream_events(last=len(events[0]), interval_seconds=0)
+    stream = native_app_manager.stream_events(interval_seconds=0, last=len(events[0]))
     for i in range(len(events[0])):
         # Exhaust the initial set of events
         assert next(stream) == events[0][i]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds `--follow` flag to `snow app events` to enable live-tail of events. The command will poll the `get_events` function every 10 seconds (by default, can be changed with `--follow-interval`), printing new rows on each iteration.

The way we detect new events is to make a second query filtering on rows where the `timestamp >=` the timestamp of the last row from the old results. The bound needs to be inclusive since there could be new events with the same timestamp in the new results (i.e. the `timestamp` column isn't necessarily monotonic). Since the bound is inclusive, the first few events from the new results would be the same events as the last few events of the old results, which means we need to only print the net-new rows from the new results. We do this by finding the point of largest overlap between the end of the old results and the start of the new results, returning the rows that come after.