### PR TITLE
Fix some unit test warnings

### DIFF
--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -163,7 +163,7 @@ ConnectionOption = typer.Option(
     ),
     show_default=False,
     rich_help_panel=_CONNECTION_SECTION,
-    autocompletion=lambda: list(get_all_connections()),
+    shell_complete=lambda: list(get_all_connections()),
 )
 
 TemporaryConnectionOption = typer.Option(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ from syrupy.extensions import AmberSnapshotExtension
 from tests_common import IS_WINDOWS
 
 pytest_plugins = [
-    "tests_common",
     "tests.testing_utils.fixtures",
     "tests.project.fixtures",
     "tests.nativeapp.fixtures",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ from syrupy.extensions import AmberSnapshotExtension
 from tests_common import IS_WINDOWS
 
 pytest_plugins = [
+    "tests_common",
     "tests.testing_utils.fixtures",
     "tests.project.fixtures",
     "tests.nativeapp.fixtures",

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -274,7 +274,7 @@ def test_snowcli_config():
     test_config = TEST_DIR / "test.toml"
     with _named_temporary_file(suffix=".toml") as p:
         p.write_text(test_config.read_text())
-        p.chmod(0o777)
+        p.chmod(0o600)
         yield p
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
Fix following warnings in unit tests:
```

UserWarning: Bad owner or permissions on /var/folders/mb/8tf9vvd15zs46qvstkb3vmd80000gn/T/tmp44bgsv_h/.snowflake/connections.toml.
   * To change owner, run `chown $USER "/var/folders/mb/8tf9vvd15zs46qvstkb3vmd80000gn/T/tmp44bgsv_h/.snowflake/connections.toml"`.
   * To restrict permissions, run `chmod 0600 "/var/folders/mb/8tf9vvd15zs46qvstkb3vmd80000gn/T/tmp44bgsv_h/.snowflake/connections.toml"`.

        warnings.warn(
            "'autocompletion' is renamed to 'shell_complete'. The old name is"
            " deprecated and will be removed in Click 8.1. See the docs about"
            " 'Parameter' for information about new behavior.",
            DeprecationWarning,
            stacklevel=2,
        )
```
