### PR TITLE
Retry integration test failures automatically

### DIFF
--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -67,6 +67,4 @@ jobs:
           SNOWFLAKE_CONNECTIONS_INTEGRATION_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_CONNECTIONS_INTEGRATION_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_CONNECTIONS_INTEGRATION_PRIVATE_KEY_PATH: ${{ env.PRIVATE_KEY_PATH }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE: ${{ github.event.issue.html_url }}
         run: python -m hatch run ${{ inputs.hatch-run }}

--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -67,4 +67,6 @@ jobs:
           SNOWFLAKE_CONNECTIONS_INTEGRATION_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_CONNECTIONS_INTEGRATION_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_CONNECTIONS_INTEGRATION_PRIVATE_KEY_PATH: ${{ env.PRIVATE_KEY_PATH }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.html_url }}
         run: python -m hatch run ${{ inputs.hatch-run }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ pre-install-commands = [
 features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
-test = ["pytest -m integration -n6 --dist=worksteal"]
+test = ["python scripts/run_tests_with_retry.py Integration -m integration -n6 --dist=worksteal"]
 
 [[tool.hatch.envs.local.matrix]]
 python = ["3.10", "3.11", "3.12"]

--- a/scripts/run_tests_with_retry.py
+++ b/scripts/run_tests_with_retry.py
@@ -5,19 +5,24 @@ from subprocess import run
 test_type = sys.argv[1].title()
 pytest = ["pytest"] + sys.argv[2:]
 
+
+def p(*s):
+    print(*s, file=sys.stderr, flush=True)
+
+
 # Run tests once
 if run(pytest, check=False).returncode == 0:
     sys.exit(0)
 
 # Then run the failed tests once more,
 # if they fail, the failure was most likely legitimate
-print(f"{test_type} tests failed, re-running to detect flakes")
+p(f"{test_type} tests failed, re-running to detect flakes")
 if (ret := run(pytest + ["--last-failed"]).returncode) != 0:
-    print(f"{test_type} tests re-run failed")
+    p(f"{test_type} tests re-run failed")
     sys.exit(ret)
 
 # If they succeed, they are flaky, we should tell the user
-print(f"{test_type} tests passed during retry, these are most likely flaky")
+p(f"{test_type} tests passed during retry, these are most likely flaky")
 if issue := os.environ.get("ISSUE"):
     run(
         [

--- a/scripts/run_tests_with_retry.py
+++ b/scripts/run_tests_with_retry.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from subprocess import run
+
+test_type = sys.argv[1].title()
+pytest = ["pytest"] + sys.argv[2:]
+
+# Run tests once
+if run(pytest, check=False).returncode == 0:
+    sys.exit(0)
+
+# Then run the failed tests once more,
+# if they fail, the failure was most likely legitimate
+print(f"{test_type} tests failed, re-running to detect flakes")
+if (ret := run(pytest + ["--last-failed"]).returncode) != 0:
+    print(f"{test_type} tests re-run failed")
+    sys.exit(ret)
+
+# If they succeed, they are flaky, we should tell the user
+print(f"{test_type} tests passed during retry, these are most likely flaky")
+if issue := os.environ.get("ISSUE"):
+    run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            issue,
+            "--body",
+            f"{test_type} test failure detected",
+        ]
+    )

--- a/scripts/run_tests_with_retry.py
+++ b/scripts/run_tests_with_retry.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from subprocess import run
 
@@ -23,14 +22,3 @@ if (ret := run(pytest + ["--last-failed"]).returncode) != 0:
 
 # If they succeed, they are flaky, we should tell the user
 p(f"{test_type} tests passed during retry, these are most likely flaky")
-if issue := os.environ.get("ISSUE"):
-    run(
-        [
-            "gh",
-            "issue",
-            "comment",
-            issue,
-            "--body",
-            f"{test_type} test failure detected",
-        ]
-    )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Integration tests have gotten flaky recently, mostly due to 504 timeouts from Snowflake. Since this isn't limited to a specific test, we can't flag it as `@flaky`, `@retry`, etc. This PR introduces a cross-platform script that will automatically re-run pytest with `--last-failed` so that any tests that fail get one more try. If they pass on the retry, they were most likely flaky; if they fail again, they were most likely not.

In a future PR, I'd like to start tracking the flakiness of individual tests (and its root cause), so we can come up with specific mitigation measures.
