### PR TITLE
Set test config file mode to 600 to prevent warnings

### DIFF
--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -274,7 +274,7 @@ def test_snowcli_config():
     test_config = TEST_DIR / "test.toml"
     with _named_temporary_file(suffix=".toml") as p:
         p.write_text(test_config.read_text())
-        p.chmod(0o777)
+        p.chmod(0o600)  # Make config file private
         yield p
 
 

--- a/tests_integration/config/world_readable.toml
+++ b/tests_integration/config/world_readable.toml
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Same as connection_configs.toml but its mode bits
+# don't get set to 644 during tests (to test the warning mechanism)
+
+[connections.default]
+[connections.integration]
+schema = "public"
+role = "INTEGRATION_TESTS"

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -70,6 +70,8 @@ def test_snowcli_config_provider():
     with tempfile.TemporaryDirectory() as td:
         temp_dst = Path(td) / "config"
         shutil.copytree(TEST_DIR / "config", temp_dst)
+        for config_file in temp_dst.glob("**/*.toml"):
+            config_file.chmod(0o600)  # Make config file private
         yield TestConfigProvider(temp_dst)
 
 

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -47,6 +47,7 @@ pytest_plugins = [
 
 TEST_DIR = Path(__file__).parent
 DEFAULT_TEST_CONFIG = "connection_configs.toml"
+WORLD_READABLE_CONFIG = "world_readable.toml"
 
 
 @dataclass
@@ -71,7 +72,8 @@ def test_snowcli_config_provider():
         temp_dst = Path(td) / "config"
         shutil.copytree(TEST_DIR / "config", temp_dst)
         for config_file in temp_dst.glob("**/*.toml"):
-            config_file.chmod(0o600)  # Make config file private
+            if config_file.name != WORLD_READABLE_CONFIG:
+                config_file.chmod(0o600)  # Make config file private
         yield TestConfigProvider(temp_dst)
 
 

--- a/tests_integration/test_config.py
+++ b/tests_integration/test_config.py
@@ -15,9 +15,13 @@
 import pytest
 from snowflake.connector.compat import IS_WINDOWS
 
+from tests_integration.conftest import WORLD_READABLE_CONFIG
+
 
 @pytest.mark.integration
 def test_config_file_permissions_warning(runner, recwarn):
+    runner.use_config(WORLD_READABLE_CONFIG)
+
     result = runner.invoke_with_config(["connection", "list"])
     assert result.exit_code == 0, result.output
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Prevents the warnings about file permissions in tests:
```
  /home/runner/.local/share/hatch/env/virtual/snowflake-cli-labs/M-xJJ0Mq/integration/lib/python3.10/site-packages/snowflake/connector/config_manager.py:351: UserWarning: Bad owner or permissions on /home/runner/work/snowflake-cli/snowflake-cli/tests_integration/config/plugin_tests/override_plugin_config.toml.
   * To change owner, run `chown $USER "/home/runner/work/snowflake-cli/snowflake-cli/tests_integration/config/plugin_tests/override_plugin_config.toml"`.
   * To restrict permissions, run `chmod 0600 "/home/runner/work/snowflake-cli/snowflake-cli/tests_integration/config/plugin_tests/override_plugin_config.toml"`.
  
    warn(f"Bad owner or permissions on {str(filep)}{chmod_message}")
```

Since Git doesn't store file permissions (only the executable bit), the files get checked out as `644` so we need to remove group and public read access.