### PR TITLE
SNOW-1571918 Update deprecated usages to recommended ones

### DIFF
--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -163,7 +163,7 @@ ConnectionOption = typer.Option(
     ),
     show_default=False,
     rich_help_panel=_CONNECTION_SECTION,
-    autocompletion=lambda: list(get_all_connections()),
+    shell_complete=lambda _, __, ___: list(get_all_connections()),
 )
 
 TemporaryConnectionOption = typer.Option(

--- a/src/snowflake/cli/api/project/schemas/updatable_model.py
+++ b/src/snowflake/cli/api/project/schemas/updatable_model.py
@@ -187,7 +187,8 @@ def DiscriminatorField(*args, **kwargs):  # noqa N802
     When this `DiscriminatorField` is used on a pydantic attribute,
     we will not allow templating on it.
     """
-    return Field(is_discriminator_field=True, *args, **kwargs)
+    extra = dict(is_discriminator_field=True)
+    return Field(json_schema_extra=extra, *args, **kwargs)
 
 
 def IdentifierField(*args, **kwargs):  # noqa N802


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes warnings by updating uses of deprecated code:
- Fixes a warning from `click` that `autocompletion` is deprecated:
> DeprecationWarning: 'autocompletion' is renamed to 'shell_complete'. The old name is deprecated and will be removed in Click 8.1. See the docs about 'Parameter' for information about new behavior.
    _typer_param_setup_autocompletion_compat(self, autocompletion=autocompletion)

The type signature of `shell_complete` is a little different but we're not using any of it anyways:
![image](https://github.com/user-attachments/assets/eeb6decf-dd76-4c62-b871-8e5aa9f1f6a2)

- Fixes a warning from `pydantic` about a deprecated pattern:
> PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'is_discriminator_field'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.8/migration/

