### PR TITLE
Use IDENTIFIER for string literals

### DIFF
--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -28,6 +28,7 @@ from snowflake.cli.api.cli_global_context import get_cli_context_manager
 from snowflake.cli.api.commands.typer_pre_execute import register_pre_execute_command
 from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.exceptions import MissingConfiguration
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli.api.rendering.jinja import CONTEXT_KEY
@@ -539,11 +540,15 @@ def experimental_option(
     )
 
 
-def identifier_argument(sf_object: str, example: str) -> typer.Argument:
+def identifier_argument(
+    sf_object: str, example: str, callback: Callable | None = None
+) -> typer.Argument:
     return typer.Argument(
         ...,
         help=f"Identifier of the {sf_object}. For example: {example}",
         show_default=False,
+        click_type=IdentifierType(),
+        callback=callback,
     )
 
 
@@ -664,3 +669,10 @@ def parse_key_value_variables(variables: Optional[List[str]]) -> List[Variable]:
         key, value = p.split("=", 1)
         result.append(Variable(key.strip(), value.strip()))
     return result
+
+
+class IdentifierType(click.ParamType):
+    name = "TEXT"
+
+    def convert(self, value, param, ctx):
+        return FQN.from_string(value)

--- a/src/snowflake/cli/api/identifiers.py
+++ b/src/snowflake/cli/api/identifiers.py
@@ -35,10 +35,17 @@ class FQN:
     fqn = FQN.from_string("my_name").set_database("db").set_schema("foo")
     """
 
-    def __init__(self, database: str | None, schema: str | None, name: str):
+    def __init__(
+        self,
+        database: str | None,
+        schema: str | None,
+        name: str,
+        signature: str | None = None,
+    ):
         self._database = database
         self._schema = schema
         self._name = name
+        self.signature = signature
 
     @property
     def database(self) -> str | None:
@@ -72,6 +79,8 @@ class FQN:
 
     @property
     def sql_identifier(self) -> str:
+        if self.signature:
+            return f"IDENTIFIER('{self.identifier}'){self.signature}"
         return f"IDENTIFIER('{self.identifier}')"
 
     def __str__(self):
@@ -98,9 +107,13 @@ class FQN:
         else:
             database = None
             schema = result.group("first_qualifier")
-        if signature := result.group("signature"):
-            unqualified_name = unqualified_name + signature
-        return cls(name=unqualified_name, schema=schema, database=database)
+
+        signature = None
+        if result.group("signature"):
+            signature = result.group("signature")
+        return cls(
+            name=unqualified_name, schema=schema, database=database, signature=signature
+        )
 
     @classmethod
     def from_stage(cls, stage: str) -> "FQN":

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -147,11 +147,11 @@ class SqlExecutionMixin:
                 self.use(object_type=ObjectType.WAREHOUSE, name=prev_wh)
 
     def create_password_secret(
-        self, name: str, username: str, password: str
+        self, name: FQN, username: str, password: str
     ) -> SnowflakeCursor:
         return self._execute_query(
             f"""
-            create secret {name}
+            create secret {name.sql_identifier}
             type = password
             username = '{username}'
             password = '{password}'
@@ -159,11 +159,11 @@ class SqlExecutionMixin:
         )
 
     def create_api_integration(
-        self, name: str, api_provider: str, allowed_prefix: str, secret: Optional[str]
+        self, name: FQN, api_provider: str, allowed_prefix: str, secret: Optional[str]
     ) -> SnowflakeCursor:
         return self._execute_query(
             f"""
-            create api integration {name}
+            create api integration {name.sql_identifier}
             api_provider = {api_provider}
             api_allowed_prefixes = ('{allowed_prefix}')
             allowed_authentication_secrets = ({secret if secret else ''})

--- a/src/snowflake/cli/plugins/git/manager.py
+++ b/src/snowflake/cli/plugins/git/manager.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import List
 
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.plugins.stage.manager import (
     USER_STAGE_PREFIX,
     StageManager,
@@ -63,15 +64,15 @@ class GitManager(StageManager):
     def show_tags(self, repo_name: str, like: str) -> SnowflakeCursor:
         return self._execute_query(f"show git tags like '{like}' in {repo_name}")
 
-    def fetch(self, repo_name: str) -> SnowflakeCursor:
-        return self._execute_query(f"alter git repository {repo_name} fetch")
+    def fetch(self, fqn: FQN) -> SnowflakeCursor:
+        return self._execute_query(f"alter git repository {fqn} fetch")
 
     def create(
-        self, repo_name: str, api_integration: str, url: str, secret: str
+        self, repo_name: FQN, api_integration: str, url: str, secret: str
     ) -> SnowflakeCursor:
         query = dedent(
             f"""
-            create git repository {repo_name}
+            create git repository {repo_name.sql_identifier}
             api_integration = {api_integration}
             origin = '{url}'
             """

--- a/src/snowflake/cli/plugins/notebook/commands.py
+++ b/src/snowflake/cli/plugins/notebook/commands.py
@@ -17,9 +17,10 @@ import logging
 import typer
 from snowflake.cli.api.commands.flags import identifier_argument
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.types import MessageResult
 from snowflake.cli.plugins.notebook.manager import NotebookManager
-from snowflake.cli.plugins.notebook.types import NotebookName, NotebookStagePath
+from snowflake.cli.plugins.notebook.types import NotebookStagePath
 from typing_extensions import Annotated
 
 app = SnowTyperFactory(
@@ -39,7 +40,7 @@ NotebookFile: NotebookStagePath = typer.Option(
 
 @app.command(requires_connection=True)
 def execute(
-    identifier: str = NOTEBOOK_IDENTIFIER,
+    identifier: FQN = NOTEBOOK_IDENTIFIER,
     **options,
 ):
     """
@@ -52,7 +53,7 @@ def execute(
 
 @app.command(requires_connection=True)
 def get_url(
-    identifier: str = NOTEBOOK_IDENTIFIER,
+    identifier: FQN = NOTEBOOK_IDENTIFIER,
     **options,
 ):
     """Return a url to a notebook."""
@@ -62,7 +63,7 @@ def get_url(
 
 @app.command(name="open", requires_connection=True)
 def open_cmd(
-    identifier: str = NOTEBOOK_IDENTIFIER,
+    identifier: FQN = NOTEBOOK_IDENTIFIER,
     **options,
 ):
     """Opens a notebook in default browser"""
@@ -73,7 +74,7 @@ def open_cmd(
 
 @app.command(requires_connection=True)
 def create(
-    identifier: Annotated[NotebookName, NOTEBOOK_IDENTIFIER],
+    identifier: Annotated[FQN, NOTEBOOK_IDENTIFIER],
     notebook_file: Annotated[NotebookStagePath, NotebookFile],
     **options,
 ):

--- a/src/snowflake/cli/plugins/notebook/manager.py
+++ b/src/snowflake/cli/plugins/notebook/manager.py
@@ -60,8 +60,8 @@ class NotebookManager(SqlExecutionMixin):
             FROM '{stage_path.parent}'
             QUERY_WAREHOUSE = '{get_cli_context().connection.warehouse}'
             MAIN_FILE = '{stage_path.name}';
-
-            ALTER NOTEBOOK {notebook_fqn.sql_identifier} ADD LIVE VERSION FROM LAST;
+            // Cannot use IDENTIFIER(...)
+            ALTER NOTEBOOK {notebook_fqn.identifier} ADD LIVE VERSION FROM LAST;
             """
         )
         self._execute_queries(queries=queries)

--- a/src/snowflake/cli/plugins/notebook/manager.py
+++ b/src/snowflake/cli/plugins/notebook/manager.py
@@ -20,23 +20,23 @@ from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.connection.util import make_snowsight_url
 from snowflake.cli.plugins.notebook.exceptions import NotebookStagePathError
-from snowflake.cli.plugins.notebook.types import NotebookName, NotebookStagePath
+from snowflake.cli.plugins.notebook.types import NotebookStagePath
 
 
 class NotebookManager(SqlExecutionMixin):
-    def execute(self, notebook_name: NotebookName):
-        query = f"EXECUTE NOTEBOOK {notebook_name}()"
+    def execute(self, notebook_name: FQN):
+        query = f"EXECUTE NOTEBOOK {notebook_name.sql_identifier}()"
         return self._execute_query(query=query)
 
-    def get_url(self, notebook_name: NotebookName):
-        fqn = FQN.from_string(notebook_name).using_connection(self._conn)
+    def get_url(self, notebook_name: FQN):
+        fqn = notebook_name.using_connection(self._conn)
         return make_snowsight_url(
             self._conn,
             f"/#/notebooks/{fqn.url_identifier}",
         )
 
     @staticmethod
-    def parse_stage_as_path(notebook_file: NotebookName) -> Path:
+    def parse_stage_as_path(notebook_file: str) -> Path:
         """Parses notebook file path to pathlib.Path."""
         if not notebook_file.endswith(".ipynb"):
             raise NotebookStagePathError(notebook_file)
@@ -48,20 +48,20 @@ class NotebookManager(SqlExecutionMixin):
 
     def create(
         self,
-        notebook_name: NotebookName,
+        notebook_name: FQN,
         notebook_file: NotebookStagePath,
     ) -> str:
-        notebook_fqn = FQN.from_string(notebook_name).using_connection(self._conn)
+        notebook_fqn = notebook_name.using_connection(self._conn)
         stage_path = self.parse_stage_as_path(notebook_file)
 
         queries = dedent(
             f"""
-            CREATE OR REPLACE NOTEBOOK {notebook_fqn.identifier}
+            CREATE OR REPLACE NOTEBOOK {notebook_fqn.sql_identifier}
             FROM '{stage_path.parent}'
             QUERY_WAREHOUSE = '{get_cli_context().connection.warehouse}'
             MAIN_FILE = '{stage_path.name}';
 
-            ALTER NOTEBOOK {notebook_fqn.identifier} ADD LIVE VERSION FROM LAST;
+            ALTER NOTEBOOK {notebook_fqn.sql_identifier} ADD LIVE VERSION FROM LAST;
             """
         )
         self._execute_queries(queries=queries)

--- a/src/snowflake/cli/plugins/notebook/types.py
+++ b/src/snowflake/cli/plugins/notebook/types.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NotebookName = str
 NotebookStagePath = str

--- a/src/snowflake/cli/plugins/object/command_aliases.py
+++ b/src/snowflake/cli/plugins/object/command_aliases.py
@@ -20,6 +20,7 @@ import typer
 from click import ClickException
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.plugins.object.commands import (
     ScopeOption,
     describe,
@@ -72,7 +73,7 @@ def add_object_command_aliases(
     if "drop" not in ommit_commands:
 
         @app.command("drop", requires_connection=True)
-        def drop_cmd(name: str = name_argument, **options):
+        def drop_cmd(name: FQN = name_argument, **options):
             return drop(
                 object_type=object_type.value.cli_name,
                 object_name=name,
@@ -84,7 +85,7 @@ def add_object_command_aliases(
     if "describe" not in ommit_commands:
 
         @app.command("describe", requires_connection=True)
-        def describe_cmd(name: str = name_argument, **options):
+        def describe_cmd(name: FQN = name_argument, **options):
             return describe(
                 object_type=object_type.value.cli_name,
                 object_name=name,

--- a/src/snowflake/cli/plugins/object/commands.py
+++ b/src/snowflake/cli/plugins/object/commands.py
@@ -18,9 +18,14 @@ from typing import List, Optional, Tuple
 
 import typer
 from click import ClickException
-from snowflake.cli.api.commands.flags import like_option, parse_key_value_variables
+from snowflake.cli.api.commands.flags import (
+    IdentifierType,
+    like_option,
+    parse_key_value_variables,
+)
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.constants import SUPPORTED_OBJECTS, VALID_SCOPES
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.types import MessageResult, QueryResult
 from snowflake.cli.api.project.util import is_valid_identifier
 from snowflake.cli.plugins.object.manager import ObjectManager
@@ -31,7 +36,9 @@ app = SnowTyperFactory(
 )
 
 
-NameArgument = typer.Argument(help="Name of the object.", show_default=False)
+NameArgument = typer.Argument(
+    help="Name of the object.", show_default=False, click_type=IdentifierType()
+)
 ObjectArgument = typer.Argument(
     help="Type of object. For example table, database, compute-pool.",
     case_sensitive=False,
@@ -112,8 +119,8 @@ def list_(
     help=f"Drops Snowflake object of given name and type. {SUPPORTED_TYPES_MSG}",
     requires_connection=True,
 )
-def drop(object_type: str = ObjectArgument, object_name: str = NameArgument, **options):
-    return QueryResult(ObjectManager().drop(object_type=object_type, name=object_name))
+def drop(object_type: str = ObjectArgument, object_name: FQN = NameArgument, **options):
+    return QueryResult(ObjectManager().drop(object_type=object_type, fqn=object_name))
 
 
 # Image repository is the only supported object that does not have a DESCRIBE command.
@@ -125,10 +132,10 @@ DESCRIBE_SUPPORTED_TYPES_MSG = f"\n\nSupported types: {', '.join(obj for obj in 
     requires_connection=True,
 )
 def describe(
-    object_type: str = ObjectArgument, object_name: str = NameArgument, **options
+    object_type: str = ObjectArgument, object_name: FQN = NameArgument, **options
 ):
     return QueryResult(
-        ObjectManager().describe(object_type=object_type, name=object_name)
+        ObjectManager().describe(object_type=object_type, fqn=object_name)
     )
 
 

--- a/src/snowflake/cli/plugins/object/manager.py
+++ b/src/snowflake/cli/plugins/object/manager.py
@@ -22,6 +22,7 @@ from snowflake.cli.api.constants import (
     OBJECT_TO_NAMES,
     ObjectNames,
 )
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.rest_api import RestApi
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector import ProgrammingError
@@ -53,22 +54,22 @@ class ObjectManager(SqlExecutionMixin):
             query += f" in {scope[0].replace('-', ' ')} {scope[1]}"
         return self._execute_query(query, **kwargs)
 
-    def drop(self, *, object_type: str, name: str) -> SnowflakeCursor:
+    def drop(self, *, object_type: str, fqn: FQN) -> SnowflakeCursor:
         object_name = _get_object_names(object_type).sf_name
-        return self._execute_query(f"drop {object_name} {name}")
+        return self._execute_query(f"drop {object_name} {fqn.sql_identifier}")
 
-    def describe(self, *, object_type: str, name: str):
+    def describe(self, *, object_type: str, fqn: FQN):
         # Image repository is the only supported object that does not have a DESCRIBE command.
         if object_type == "image-repository":
             raise ClickException(
                 f"Describe is currently not supported for object of type image-repository"
             )
         object_name = _get_object_names(object_type).sf_name
-        return self._execute_query(f"describe {object_name} {name}")
+        return self._execute_query(f"describe {object_name} {fqn.sql_identifier}")
 
-    def object_exists(self, *, object_type: str, name: str):
+    def object_exists(self, *, object_type: str, fqn: FQN):
         try:
-            self.describe(object_type=object_type, name=name)
+            self.describe(object_type=object_type, fqn=fqn)
             return True
         except ProgrammingError:
             return False

--- a/src/snowflake/cli/plugins/snowpark/commands.py
+++ b/src/snowflake/cli/plugins/snowpark/commands.py
@@ -167,9 +167,7 @@ def deploy(
     stage_name = snowpark.stage_name
     stage_manager = StageManager()
     stage_name = FQN.from_string(stage_name).using_context()
-    stage_manager.create(
-        stage_name=stage_name, comment="deployments managed by Snowflake CLI"
-    )
+    stage_manager.create(fqn=stage_name, comment="deployments managed by Snowflake CLI")
 
     snowflake_dependencies = _read_snowflake_requrements_file(
         paths.snowflake_requirements_file
@@ -245,7 +243,7 @@ def _find_existing_objects(
         try:
             current_state = om.describe(
                 object_type=object_type.value.sf_name,
-                name=identifier,
+                fqn=FQN.from_string(identifier),
             )
             existing_objects[identifier] = current_state
         except ProgrammingError:
@@ -497,7 +495,7 @@ def list_(
 @app.command("drop", requires_connection=True)
 def drop(
     object_type: _SnowparkObject = ObjectTypeArgument,
-    identifier: str = IdentifierArgument,
+    identifier: FQN = IdentifierArgument,
     **options,
 ):
     """Drop procedure or function."""
@@ -507,7 +505,7 @@ def drop(
 @app.command("describe", requires_connection=True)
 def describe(
     object_type: _SnowparkObject = ObjectTypeArgument,
-    identifier: str = IdentifierArgument,
+    identifier: FQN = IdentifierArgument,
     **options,
 ):
     """Provides description of a procedure or function."""

--- a/src/snowflake/cli/plugins/snowpark/package/manager.py
+++ b/src/snowflake/cli/plugins/snowpark/package/manager.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.plugins.snowpark.package.utils import prepare_app_zip
 from snowflake.cli.plugins.stage.manager import StageManager
@@ -30,7 +31,7 @@ def upload(file: Path, stage: str, overwrite: bool):
         temp_app_zip_path = prepare_app_zip(SecurePath(file), temp_dir)
         sm = StageManager()
 
-        sm.create(sm.get_stage_from_path(stage))
+        sm.create(FQN.from_string(sm.get_stage_from_path(stage)))
         put_response = sm.put(
             temp_app_zip_path.path, stage, overwrite=overwrite
         ).fetchone()

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -23,11 +23,13 @@ from click import ClickException
 from snowflake.cli.api.commands.flags import (
     IfNotExistsOption,
     ReplaceOption,
+    identifier_argument,
     like_option,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.types import (
     CollectionResult,
     MessageResult,
@@ -48,18 +50,18 @@ app = SnowTyperFactory(
 )
 
 
-def _repo_name_callback(name: str):
-    if not is_valid_object_name(name, max_depth=2, allow_quoted=False):
+def _repo_name_callback(name: FQN):
+    if not is_valid_object_name(name.identifier, max_depth=2, allow_quoted=False):
         raise ClickException(
             f"'{name}' is not a valid image repository name. Note that image repository names must be unquoted identifiers. The same constraint also applies to database and schema names where you create an image repository."
         )
     return name
 
 
-REPO_NAME_ARGUMENT = typer.Argument(
-    help="Name of the image repository.",
+REPO_NAME_ARGUMENT = identifier_argument(
+    sf_object="image repository",
+    example="my_repository",
     callback=_repo_name_callback,
-    show_default=False,
 )
 
 add_object_command_aliases(
@@ -76,7 +78,7 @@ add_object_command_aliases(
 
 @app.command(requires_connection=True)
 def create(
-    name: str = REPO_NAME_ARGUMENT,
+    name: FQN = REPO_NAME_ARGUMENT,
     replace: bool = ReplaceOption(),
     if_not_exists: bool = IfNotExistsOption(),
     **options,
@@ -86,21 +88,21 @@ def create(
     """
     return SingleQueryResult(
         ImageRepositoryManager().create(
-            name=name, replace=replace, if_not_exists=if_not_exists
+            name=name.identifier, replace=replace, if_not_exists=if_not_exists
         )
     )
 
 
 @app.command("list-images", requires_connection=True)
 def list_images(
-    name: str = REPO_NAME_ARGUMENT,
+    name: FQN = REPO_NAME_ARGUMENT,
     **options,
 ) -> CollectionResult:
     """Lists images in the given repository."""
     repository_manager = ImageRepositoryManager()
     database = repository_manager.get_database()
     schema = repository_manager.get_schema()
-    url = repository_manager.get_repository_url(name)
+    url = repository_manager.get_repository_url(name.identifier)
     api_url = repository_manager.get_repository_api_url(url)
     bearer_login = RegistryManager().login_to_registry(api_url)
     repos = []
@@ -136,7 +138,7 @@ def list_images(
 
 @app.command("list-tags", requires_connection=True)
 def list_tags(
-    name: str = REPO_NAME_ARGUMENT,
+    name: FQN = REPO_NAME_ARGUMENT,
     image_name: str = typer.Option(
         ...,
         "--image-name",
@@ -150,7 +152,7 @@ def list_tags(
     """Lists tags for the given image in a repository."""
 
     repository_manager = ImageRepositoryManager()
-    url = repository_manager.get_repository_url(name)
+    url = repository_manager.get_repository_url(name.identifier)
     api_url = repository_manager.get_repository_api_url(url)
     bearer_login = RegistryManager().login_to_registry(api_url)
 
@@ -187,10 +189,14 @@ def list_tags(
 
 @app.command("url", requires_connection=True)
 def repo_url(
-    name: str = REPO_NAME_ARGUMENT,
+    name: FQN = REPO_NAME_ARGUMENT,
     **options,
 ):
     """Returns the URL for the given repository."""
     return MessageResult(
-        (ImageRepositoryManager().get_repository_url(repo_name=name, with_scheme=False))
+        (
+            ImageRepositoryManager().get_repository_url(
+                repo_name=name.identifier, with_scheme=False
+            )
+        )
     )

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -23,10 +23,12 @@ from click import ClickException
 from snowflake.cli.api.commands.flags import (
     IfNotExistsOption,
     OverrideableOption,
+    identifier_argument,
     like_option,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.types import (
     CommandResult,
     QueryJsonValueResult,
@@ -52,19 +54,18 @@ app = SnowTyperFactory(
 )
 
 
-def _service_name_callback(name: str) -> str:
-    if not is_valid_object_name(name, max_depth=2, allow_quoted=False):
+def _service_name_callback(name: FQN) -> FQN:
+    if not is_valid_object_name(name.identifier, max_depth=2, allow_quoted=False):
         raise ClickException(
             f"'{name}' is not a valid service name. Note service names must be unquoted identifiers. The same constraint also applies to database and schema names where you create a service."
         )
     return name
 
 
-ServiceNameArgument = typer.Argument(
-    ...,
-    help="Name of the service.",
+ServiceNameArgument = identifier_argument(
+    sf_object="service pool",
+    example="my_service",
     callback=_service_name_callback,
-    show_default=False,
 )
 
 SpecPathOption = typer.Option(
@@ -116,7 +117,7 @@ add_object_command_aliases(
 
 @app.command(requires_connection=True)
 def create(
-    name: str = ServiceNameArgument,
+    name: FQN = ServiceNameArgument,
     compute_pool: str = typer.Option(
         ...,
         "--compute-pool",
@@ -145,7 +146,7 @@ def create(
         min_instances, max_instances, "instances"
     )
     cursor = ServiceManager().create(
-        service_name=name,
+        service_name=name.identifier,
         min_instances=min_instances,
         max_instances=max_instances,
         compute_pool=compute_pool,
@@ -161,17 +162,17 @@ def create(
 
 
 @app.command(requires_connection=True)
-def status(name: str = ServiceNameArgument, **options) -> CommandResult:
+def status(name: FQN = ServiceNameArgument, **options) -> CommandResult:
     """
     Retrieves the status of a service.
     """
-    cursor = ServiceManager().status(service_name=name)
+    cursor = ServiceManager().status(service_name=name.identifier)
     return QueryJsonValueResult(cursor)
 
 
 @app.command(requires_connection=True)
 def logs(
-    name: str = ServiceNameArgument,
+    name: FQN = ServiceNameArgument,
     container_name: str = typer.Option(
         ...,
         "--container-name",
@@ -193,7 +194,7 @@ def logs(
     Retrieves local logs from a service container.
     """
     results = ServiceManager().logs(
-        service_name=name,
+        service_name=name.identifier,
         instance_id=instance_id,
         container_name=container_name,
         num_lines=num_lines,
@@ -205,7 +206,7 @@ def logs(
 
 @app.command(requires_connection=True)
 def upgrade(
-    name: str = ServiceNameArgument,
+    name: FQN = ServiceNameArgument,
     spec_path: Path = SpecPathOption,
     **options,
 ):
@@ -213,20 +214,20 @@ def upgrade(
     Updates an existing service with a new specification file.
     """
     return SingleQueryResult(
-        ServiceManager().upgrade_spec(service_name=name, spec_path=spec_path)
+        ServiceManager().upgrade_spec(service_name=name.identifier, spec_path=spec_path)
     )
 
 
 @app.command("list-endpoints", requires_connection=True)
-def list_endpoints(name: str = ServiceNameArgument, **options):
+def list_endpoints(name: FQN = ServiceNameArgument, **options):
     """
     Lists the endpoints in a service.
     """
-    return QueryResult(ServiceManager().list_endpoints(service_name=name))
+    return QueryResult(ServiceManager().list_endpoints(service_name=name.identifier))
 
 
 @app.command(requires_connection=True)
-def suspend(name: str = ServiceNameArgument, **options) -> CommandResult:
+def suspend(name: FQN = ServiceNameArgument, **options) -> CommandResult:
     """
     Suspends the service, shutting down and deleting all its containers.
     """
@@ -234,7 +235,7 @@ def suspend(name: str = ServiceNameArgument, **options) -> CommandResult:
 
 
 @app.command(requires_connection=True)
-def resume(name: str = ServiceNameArgument, **options) -> CommandResult:
+def resume(name: FQN = ServiceNameArgument, **options) -> CommandResult:
     """
     Resumes the service from a SUSPENDED state.
     """
@@ -243,7 +244,7 @@ def resume(name: str = ServiceNameArgument, **options) -> CommandResult:
 
 @app.command("set", requires_connection=True)
 def set_property(
-    name: str = ServiceNameArgument,
+    name: FQN = ServiceNameArgument,
     min_instances: Optional[int] = MinInstancesOption(default=None, show_default=False),
     max_instances: Optional[int] = MaxInstancesOption(show_default=False),
     query_warehouse: Optional[str] = QueryWarehouseOption(show_default=False),
@@ -255,7 +256,7 @@ def set_property(
     Sets one or more properties for the service.
     """
     cursor = ServiceManager().set_property(
-        service_name=name,
+        service_name=name.identifier,
         min_instances=min_instances,
         max_instances=max_instances,
         query_warehouse=query_warehouse,
@@ -267,7 +268,7 @@ def set_property(
 
 @app.command("unset", requires_connection=True)
 def unset_property(
-    name: str = ServiceNameArgument,
+    name: FQN = ServiceNameArgument,
     min_instances: bool = MinInstancesOption(
         default=False,
         help=f"Reset the MIN_INSTANCES property - {_MIN_INSTANCES_HELP}",
@@ -301,7 +302,7 @@ def unset_property(
     Resets one or more properties for the service to their default value(s).
     """
     cursor = ServiceManager().unset_property(
-        service_name=name,
+        service_name=name.identifier,
         min_instances=min_instances,
         max_instances=max_instances,
         query_warehouse=query_warehouse,

--- a/src/snowflake/cli/plugins/stage/commands.py
+++ b/src/snowflake/cli/plugins/stage/commands.py
@@ -26,11 +26,13 @@ from snowflake.cli.api.commands.flags import (
     ExecuteVariablesOption,
     OnErrorOption,
     PatternOption,
+    identifier_argument,
     like_option,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.output.types import (
     CollectionResult,
@@ -56,7 +58,7 @@ app = SnowTyperFactory(
     help="Manages stages.",
 )
 
-StageNameArgument = typer.Argument(..., help="Name of the stage.", show_default=False)
+StageNameArgument = identifier_argument(sf_object="stage", example="@my_stage")
 
 add_object_command_aliases(
     app=app,
@@ -142,17 +144,17 @@ def copy(
 
 
 @app.command("create", requires_connection=True)
-def stage_create(stage_name: str = StageNameArgument, **options) -> CommandResult:
+def stage_create(stage_name: FQN = StageNameArgument, **options) -> CommandResult:
     """
     Creates a named stage if it does not already exist.
     """
-    cursor = StageManager().create(stage_name=stage_name)
+    cursor = StageManager().create(fqn=stage_name)
     return SingleQueryResult(cursor)
 
 
 @app.command("remove", requires_connection=True)
 def stage_remove(
-    stage_name: str = StageNameArgument,
+    stage_name: FQN = StageNameArgument,
     file_name: str = typer.Argument(
         ...,
         help="Name of the file to remove.",
@@ -164,7 +166,7 @@ def stage_remove(
     Removes a file from a stage.
     """
 
-    cursor = StageManager().remove(stage_name=stage_name, path=file_name)
+    cursor = StageManager().remove(stage_name=stage_name.identifier, path=file_name)
     return SingleQueryResult(cursor)
 
 

--- a/src/snowflake/cli/plugins/stage/manager.py
+++ b/src/snowflake/cli/plugins/stage/manager.py
@@ -168,7 +168,9 @@ class StageManager(SqlExecutionMixin):
         self._python_exe_procedure = None
 
     @staticmethod
-    def get_standard_stage_prefix(name: str) -> str:
+    def get_standard_stage_prefix(name: str | FQN) -> str:
+        if isinstance(name, FQN):
+            name = name.identifier
         # Handle embedded stages
         if name.startswith("snow://") or name.startswith("@"):
             return name
@@ -300,8 +302,8 @@ class StageManager(SqlExecutionMixin):
             quoted_stage_name = self.quote_stage_name(f"{stage_name}{path}")
             return self._execute_query(f"remove {quoted_stage_name}")
 
-    def create(self, stage_name: str, comment: Optional[str] = None) -> SnowflakeCursor:
-        query = f"create stage if not exists {stage_name}"
+    def create(self, fqn: FQN, comment: Optional[str] = None) -> SnowflakeCursor:
+        query = f"create stage if not exists {fqn.sql_identifier}"
         if comment:
             query += f" comment='{comment}'"
         return self._execute_query(query)

--- a/src/snowflake/cli/plugins/streamlit/commands.py
+++ b/src/snowflake/cli/plugins/streamlit/commands.py
@@ -26,7 +26,11 @@ from snowflake.cli.api.commands.decorators import (
     with_experimental_behaviour,
     with_project_definition,
 )
-from snowflake.cli.api.commands.flags import ReplaceOption, like_option
+from snowflake.cli.api.commands.flags import (
+    ReplaceOption,
+    identifier_argument,
+    like_option,
+)
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.exceptions import NoProjectDefinitionError
@@ -53,19 +57,8 @@ app = SnowTyperFactory(
 )
 log = logging.getLogger(__name__)
 
-
-class IdentifierType(click.ParamType):
-    name = "TEXT"
-
-    def convert(self, value, param, ctx):
-        return FQN.from_string(value)
-
-
-StreamlitNameArgument = typer.Argument(
-    ...,
-    help="Name of the Streamlit app.",
-    show_default=False,
-    click_type=IdentifierType(),
+StreamlitNameArgument = identifier_argument(
+    sf_object="Streamlit app", example="my_streamlit"
 )
 OpenOption = typer.Option(
     False,

--- a/src/snowflake/cli/plugins/streamlit/manager.py
+++ b/src/snowflake/cli/plugins/streamlit/manager.py
@@ -170,7 +170,7 @@ class StreamlitManager(SqlExecutionMixin):
             stage_name = stage_name or "streamlit"
             stage_name = FQN.from_string(stage_name).using_connection(self._conn)
 
-            stage_manager.create(stage_name=stage_name)
+            stage_manager.create(fqn=stage_name)
 
             root_location = stage_manager.get_standard_stage_prefix(
                 f"{stage_name}/{streamlit_name_for_root_location}"

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -3671,7 +3671,9 @@
    Creates a new compute pool.                                                    
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | *  --family                                TEXT             Name of the      |
@@ -3794,7 +3796,9 @@
    Provides description of compute pool.                                          
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -3865,7 +3869,9 @@
    Drops compute pool with given name.                                            
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4008,7 +4014,9 @@
    Resumes the compute pool from a SUSPENDED state.                               
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4079,7 +4087,9 @@
    Sets one or more properties for the compute pool.                              
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --min-nodes                               INTEGER RANGE     Minimum number   |
@@ -4176,7 +4186,9 @@
    exists.                                                                        
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    pool_name      TEXT  Name of the compute pool. [required]               |
+  | *    pool_name      TEXT  Identifier of the compute pool. For example:       |
+  |                           my_compute_pool                                    |
+  |                           [required]                                         |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4247,7 +4259,9 @@
    Deletes all services running on the compute pool.                              
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4319,7 +4333,9 @@
    then releasing compute pool nodes.                                             
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4390,7 +4406,9 @@
    Resets one or more properties for the compute pool to their default value(s).  
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the compute pool. [required]                    |
+  | *    name      TEXT  Identifier of the compute pool. For example:            |
+  |                      my_compute_pool                                         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --auto-resume                  Reset the AUTO_RESUME property - The compute  |
@@ -4738,7 +4756,9 @@
    Creates a new image repository in the current schema.                          
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the image repository. [required]                |
+  | *    name      TEXT  Identifier of the image repository. For example:        |
+  |                      my_repository                                           |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --replace                  Replace this object if it already exists.         |
@@ -4812,7 +4832,9 @@
    Drops image repository with given name.                                        
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the image repository. [required]                |
+  | *    name      TEXT  Identifier of the image repository. For example:        |
+  |                      my_repository                                           |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4883,7 +4905,9 @@
    Lists images in the given repository.                                          
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the image repository. [required]                |
+  | *    name      TEXT  Identifier of the image repository. For example:        |
+  |                      my_repository                                           |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -4954,7 +4978,9 @@
    Lists tags for the given image in a repository.                                
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the image repository. [required]                |
+  | *    name      TEXT  Identifier of the image repository. For example:        |
+  |                      my_repository                                           |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | *  --image-name,--image_name  -i      TEXT  Fully qualified name of the      |
@@ -5106,7 +5132,9 @@
    Returns the URL for the given repository.                                      
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the image repository. [required]                |
+  | *    name      TEXT  Identifier of the image repository. For example:        |
+  |                      my_repository                                           |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -5434,7 +5462,8 @@
    Creates a new service in the current schema.                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | *  --compute-pool                          TEXT             Compute pool to  |
@@ -5567,7 +5596,8 @@
    Provides description of service.                                               
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -5638,7 +5668,8 @@
    Drops service with given name.                                                 
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -5709,7 +5740,8 @@
    Lists the endpoints in a service.                                              
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -5856,7 +5888,8 @@
    Retrieves local logs from a service container.                                 
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | *  --container-name          TEXT     Name of the container. [required]      |
@@ -5933,7 +5966,8 @@
    Resumes the service from a SUSPENDED state.                                    
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -6004,7 +6038,8 @@
    Sets one or more properties for the service.                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --min-instances                           INTEGER RANGE     Minimum number   |
@@ -6104,7 +6139,8 @@
    Retrieves the status of a service.                                             
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -6175,7 +6211,8 @@
    Suspends the service, shutting down and deleting all its containers.           
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -6246,7 +6283,8 @@
    Resets one or more properties for the service to their default value(s).       
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --min-instances              Reset the MIN_INSTANCES property - Minimum      |
@@ -6330,7 +6368,8 @@
    Updates an existing service with a new specification file.                     
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the service. [required]                         |
+  | *    name      TEXT  Identifier of the service pool. For example: my_service |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | *  --spec-path          FILE  Path to service specification file. [required] |
@@ -6638,7 +6677,8 @@
    Creates a named stage if it does not already exist.                            
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    stage_name      TEXT  Name of the stage. [required]                     |
+  | *    stage_name      TEXT  Identifier of the stage. For example: @my_stage   |
+  |                            [required]                                        |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -6709,7 +6749,8 @@
    Provides description of stage.                                                 
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the stage. [required]                           |
+  | *    name      TEXT  Identifier of the stage. For example: @my_stage         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -6852,7 +6893,8 @@
    Drops stage with given name.                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the stage. [required]                           |
+  | *    name      TEXT  Identifier of the stage. For example: @my_stage         |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -7013,7 +7055,8 @@
    Lists the stage contents.                                                      
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    stage_name      TEXT  Name of the stage. [required]                     |
+  | *    stage_name      TEXT  Identifier of the stage. For example: @my_stage   |
+  |                            [required]                                        |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --pattern          TEXT  Regex pattern for filtering files by name. For      |
@@ -7163,7 +7206,8 @@
    Removes a file from a stage.                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    stage_name      TEXT  Name of the stage. [required]                     |
+  | *    stage_name      TEXT  Identifier of the stage. For example: @my_stage   |
+  |                            [required]                                        |
   | *    file_name       TEXT  Name of the file to remove. [required]            |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
@@ -7342,7 +7386,9 @@
    Provides description of streamlit.                                             
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the Streamlit app. [required]                   |
+  | *    name      TEXT  Identifier of the Streamlit app. For example:           |
+  |                      my_streamlit                                            |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -7413,7 +7459,9 @@
    Drops streamlit with given name.                                               
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the Streamlit app. [required]                   |
+  | *    name      TEXT  Identifier of the Streamlit app. For example:           |
+  |                      my_streamlit                                            |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -7484,7 +7532,9 @@
    Returns a URL to the specified Streamlit app                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name      TEXT  Name of the Streamlit app. [required]                   |
+  | *    name      TEXT  Identifier of the Streamlit app. For example:           |
+  |                      my_streamlit                                            |
+  |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --open            Whether to open the Streamlit app in a browser.            |
@@ -7632,7 +7682,9 @@
    Shares a Streamlit app with another role.                                      
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    name         TEXT  Name of the Streamlit app. [required]                |
+  | *    name         TEXT  Identifier of the Streamlit app. For example:        |
+  |                         my_streamlit                                         |
+  |                         [required]                                           |
   | *    to_role      TEXT  Role with which to share the Streamlit app.          |
   |                         [required]                                           |
   +------------------------------------------------------------------------------+

--- a/tests/api/test_fqn.py
+++ b/tests/api/test_fqn.py
@@ -84,17 +84,19 @@ def test_set_schema():
         # Callables
         (
             "db.schema.function(string, int, variant)",
-            "db.schema.function(string, int, variant)",
+            "db.schema.function",
         ),
         (
             'db.schema."fun tion"(string, int, variant)',
-            'db.schema."fun tion"(string, int, variant)',
+            'db.schema."fun tion"',
         ),
     ],
 )
 def test_from_string(fqn_str, identifier):
     fqn = FQN.from_string(fqn_str)
     assert fqn.identifier == identifier
+    if fqn.signature:
+        assert fqn.signature == "(string, int, variant)"
 
 
 @pytest.mark.parametrize(

--- a/tests/api/utils/test_naming_utils.py
+++ b/tests/api/utils/test_naming_utils.py
@@ -19,7 +19,7 @@ from snowflake.cli.api.identifiers import FQN
 @pytest.mark.parametrize(
     "qualified_name, expected",
     [
-        ("func(number, number)", ("func(number, number)", None, None)),
+        ("func(number, number)", ("func", None, None)),
         ("name", ("name", None, None)),
         ("schema.name", ("name", "schema", None)),
         ("db.schema.name", ("name", "schema", "db")),
@@ -31,3 +31,5 @@ def test_from_fully_qualified_name(qualified_name, expected):
     assert fqn.name == name
     assert fqn.schema == schema
     assert fqn.database == database
+    if fqn.signature:
+        assert fqn.signature == "(number, number)"

--- a/tests/git/test_git_commands.py
+++ b/tests/git/test_git_commands.py
@@ -239,7 +239,7 @@ def test_setup_no_secret_existing_api(
     )
     assert ctx.get_query() == dedent(
         """
-        create git repository repo_name
+        create git repository IDENTIFIER('repo_name')
         api_integration = existing_api_integration
         origin = 'https://github.com/an-example-repo.git'
         """
@@ -271,14 +271,14 @@ def test_setup_no_secret_create_api(mock_om_describe, mock_connector, runner, mo
     )
     assert ctx.get_query() == dedent(
         """
-        create api integration repo_name_api_integration
+        create api integration IDENTIFIER('repo_name_api_integration')
         api_provider = git_https_api
         api_allowed_prefixes = ('https://github.com/an-example-repo.git')
         allowed_authentication_secrets = ()
         enabled = true
         
         
-        create git repository repo_name
+        create git repository IDENTIFIER('repo_name')
         api_integration = repo_name_api_integration
         origin = 'https://github.com/an-example-repo.git'
         """
@@ -319,7 +319,7 @@ def test_setup_existing_secret_existing_api(
     )
     assert ctx.get_query() == dedent(
         """
-        create git repository repo_name
+        create git repository IDENTIFIER('repo_name')
         api_integration = existing_api_integration
         origin = 'https://github.com/an-example-repo.git'
         git_credentials = existing_secret
@@ -359,14 +359,14 @@ def test_setup_existing_secret_create_api(
     )
     assert ctx.get_query() == dedent(
         """
-        create api integration repo_name_api_integration
+        create api integration IDENTIFIER('repo_name_api_integration')
         api_provider = git_https_api
         api_allowed_prefixes = ('https://github.com/an-example-repo.git')
         allowed_authentication_secrets = (existing_secret)
         enabled = true
 
 
-        create git repository repo_name
+        create git repository IDENTIFIER('repo_name')
         api_integration = repo_name_api_integration
         origin = 'https://github.com/an-example-repo.git'
         git_credentials = existing_secret
@@ -408,20 +408,20 @@ def test_setup_create_secret_create_api(
     )
     assert ctx.get_query() == dedent(
         """
-        create secret repo_name_secret
+        create secret IDENTIFIER('repo_name_secret')
         type = password
         username = 'john_doe'
         password = 'admin123'
         
         
-        create api integration new_integration
+        create api integration IDENTIFIER('new_integration')
         api_provider = git_https_api
         api_allowed_prefixes = ('https://github.com/an-example-repo.git')
         allowed_authentication_secrets = (repo_name_secret)
         enabled = true
         
         
-        create git repository repo_name
+        create git repository IDENTIFIER('repo_name')
         api_integration = new_integration
         origin = 'https://github.com/an-example-repo.git'
         git_credentials = repo_name_secret

--- a/tests/notebook/test_notebook_commands.py
+++ b/tests/notebook/test_notebook_commands.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 import typer
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.plugins.notebook.manager import NotebookManager
 
 
@@ -24,7 +25,7 @@ def test_execute(mock_execute, runner):
 
     assert result.exit_code == 0, result.output
     assert result.output == "Notebook my_notebook executed.\n"
-    mock_execute.assert_called_once_with(notebook_name="my_notebook")
+    mock_execute.assert_called_once_with(notebook_name=FQN.from_string("my_notebook"))
 
 
 @mock.patch.object(NotebookManager, "get_url")
@@ -34,7 +35,7 @@ def test_get_url(mock_url, runner):
 
     assert result.exit_code == 0, result.output
     assert result.output == "http://my.url\n"
-    mock_url.assert_called_once_with(notebook_name="my_notebook")
+    mock_url.assert_called_once_with(notebook_name=FQN.from_string("my_notebook"))
 
 
 @mock.patch.object(NotebookManager, "get_url")
@@ -45,7 +46,7 @@ def test_open(mock_launch, mock_url, runner):
 
     assert result.exit_code == 0, result.output
     assert result.output == "http://my.url\n"
-    mock_url.assert_called_once_with(notebook_name="my_notebook")
+    mock_url.assert_called_once_with(notebook_name=FQN.from_string("my_notebook"))
     mock_launch.assert_called_once_with("http://my.url")
 
 
@@ -61,6 +62,6 @@ def test_create(mock_create, runner):
     assert result.exit_code == 0, result.output
 
     mock_create.assert_called_once_with(
-        notebook_name=notebook_name,
+        notebook_name=FQN.from_string("my_notebook"),
         notebook_file=notebook_file,
     )

--- a/tests/notebook/test_notebook_manager.py
+++ b/tests/notebook/test_notebook_manager.py
@@ -17,14 +17,17 @@ from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.plugins.notebook.exceptions import NotebookStagePathError
 from snowflake.cli.plugins.notebook.manager import NotebookManager
 
 
 @mock.patch.object(NotebookManager, "_execute_query")
 def test_execute(mock_execute):
-    _ = NotebookManager().execute(notebook_name="MY_NOTEBOOK")
-    mock_execute.assert_called_once_with(query="EXECUTE NOTEBOOK MY_NOTEBOOK()")
+    _ = NotebookManager().execute(notebook_name=FQN.from_string("MY_NOTEBOOK"))
+    mock_execute.assert_called_once_with(
+        query="EXECUTE NOTEBOOK IDENTIFIER('MY_NOTEBOOK')()"
+    )
 
 
 @mock.patch("snowflake.cli.plugins.notebook.manager.make_snowsight_url")
@@ -32,7 +35,7 @@ def test_get_url(mock_url):
     mock_url.return_value = "my_url"
     conn_mock = MagicMock(database="nb_database", schema="nb_schema")
     with mock.patch.object(NotebookManager, "_conn", conn_mock):
-        result = NotebookManager().get_url(notebook_name="MY_NOTEBOOK")
+        result = NotebookManager().get_url(notebook_name=FQN.from_string("MY_NOTEBOOK"))
 
     assert result == "my_url"
     mock_url.assert_called_once_with(
@@ -50,17 +53,17 @@ def test_create(mock_ctx, mock_execute, mock_url):
 
     with mock.patch.object(NotebookManager, "_conn", cn_mock):
         _ = NotebookManager().create(
-            notebook_name="my_notebook",
+            notebook_name=FQN.from_string("MY_NOTEBOOK"),
             notebook_file="@stage/nb file.ipynb",
         )
         expected_query = dedent(
             """
-            CREATE OR REPLACE NOTEBOOK nb_db.nb_schema.my_notebook
+            CREATE OR REPLACE NOTEBOOK IDENTIFIER('nb_db.nb_schema.MY_NOTEBOOK')
             FROM '@stage'
             QUERY_WAREHOUSE = 'MY_WH'
             MAIN_FILE = 'nb file.ipynb';
 
-            ALTER NOTEBOOK nb_db.nb_schema.my_notebook ADD LIVE VERSION FROM LAST;
+            ALTER NOTEBOOK IDENTIFIER('nb_db.nb_schema.MY_NOTEBOOK') ADD LIVE VERSION FROM LAST;
             """
         )
         mock_execute.assert_called_once_with(queries=expected_query)

--- a/tests/notebook/test_notebook_manager.py
+++ b/tests/notebook/test_notebook_manager.py
@@ -62,8 +62,8 @@ def test_create(mock_ctx, mock_execute, mock_url):
             FROM '@stage'
             QUERY_WAREHOUSE = 'MY_WH'
             MAIN_FILE = 'nb file.ipynb';
-
-            ALTER NOTEBOOK IDENTIFIER('nb_db.nb_schema.MY_NOTEBOOK') ADD LIVE VERSION FROM LAST;
+            // Cannot use IDENTIFIER(...)
+            ALTER NOTEBOOK nb_db.nb_schema.MY_NOTEBOOK ADD LIVE VERSION FROM LAST;
             """
         )
         mock_execute.assert_called_once_with(queries=expected_query)

--- a/tests/snowpark/test_function.py
+++ b/tests/snowpark/test_function.py
@@ -52,7 +52,7 @@ def test_deploy_function(
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(project_dir).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project"
         f" auto_compress=false parallel=4 overwrite=True",
         dedent(
@@ -100,7 +100,7 @@ def test_deploy_function_with_external_access(
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(project_dir).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project"
         f" auto_compress=false parallel=4 overwrite=True",
         dedent(
@@ -184,7 +184,7 @@ def test_deploy_function_no_changes(
         }
     ]
     assert queries == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(project_dir).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project auto_compress=false parallel=4 overwrite=True",
     ]
 
@@ -222,7 +222,7 @@ def test_deploy_function_needs_update_because_packages_changes(
         }
     ]
     assert queries == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(project_dir).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project auto_compress=false parallel=4 overwrite=True",
         dedent(
             """\
@@ -272,7 +272,7 @@ def test_deploy_function_needs_update_because_handler_changes(
         }
     ]
     assert queries == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(project_dir).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project"
         f" auto_compress=false parallel=4 overwrite=True",
         dedent(

--- a/tests/snowpark/test_package.py
+++ b/tests/snowpark/test_package.py
@@ -89,10 +89,12 @@ class TestPackage:
         assert os.path.isfile("totally-awesome-package.zip"), result.output
 
     @mock.patch("snowflake.cli.plugins.snowpark.package.manager.StageManager")
+    @mock.patch("snowflake.cli.plugins.snowpark.package.manager.FQN.from_string")
     @mock.patch("snowflake.connector.connect")
     def test_package_upload(
         self,
         mock_connector,
+        _,
         mock_stage_manager,
         package_file: str,
         runner,
@@ -140,7 +142,9 @@ class TestPackage:
         assert result.exit_code == 0
         assert mock_execute_queries.call_count == 2
         create, put = mock_execute_queries.call_args_list
-        assert create.args[0] == "create stage if not exists db.schema.stage"
+        assert (
+            create.args[0] == "create stage if not exists IDENTIFIER('db.schema.stage')"
+        )
         assert "db.schema.stage/path/to/file" in put.args[0]
 
     @patch(

--- a/tests/snowpark/test_procedure.py
+++ b/tests/snowpark/test_procedure.py
@@ -21,6 +21,7 @@ from unittest.mock import call
 import pytest
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.errno import DOES_NOT_EXIST_OR_NOT_AUTHORIZED
+from snowflake.cli.api.identifiers import FQN
 from snowflake.connector import ProgrammingError
 
 from tests_common import IS_WINDOWS
@@ -75,7 +76,7 @@ def test_deploy_procedure(
         ]
     )
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(tmp).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project auto_compress=false parallel=4 overwrite=True",
         dedent(
             """\
@@ -139,12 +140,12 @@ def test_deploy_procedure_with_external_access(
         [
             call(
                 object_type=str(ObjectType.PROCEDURE),
-                name="MockDatabase.MockSchema.procedureName(string)",
+                fqn=FQN.from_string("MockDatabase.MockSchema.procedureName(string)"),
             ),
         ]
     )
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.dev_deployment comment='deployments managed by Snowflake CLI'",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.dev_deployment') comment='deployments managed by Snowflake CLI'",
         f"put file://{Path(project_dir).resolve()}/app.zip @MockDatabase.MockSchema.dev_deployment/my_snowpark_project"
         f" auto_compress=false parallel=4 overwrite=True",
         dedent(

--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 import pytest
 from click import ClickException
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.plugins.spcs.common import (
     NoPropertiesProvidedError,
@@ -284,7 +285,8 @@ def test_resume_cli(mock_resume, mock_cursor, runner):
 def test_compute_pool_name_callback(mock_is_valid):
     name = "test_pool"
     mock_is_valid.return_value = True
-    assert _compute_pool_name_callback(name) == name
+    fqn = FQN.from_string(name)
+    assert _compute_pool_name_callback(fqn) == fqn
 
 
 @patch("snowflake.cli.plugins.spcs.compute_pool.commands.is_valid_object_name")
@@ -292,7 +294,7 @@ def test_compute_pool_name_callback_invalid(mock_is_valid):
     name = "test_pool"
     mock_is_valid.return_value = False
     with pytest.raises(ClickException) as e:
-        _compute_pool_name_callback(name)
+        _compute_pool_name_callback(FQN.from_string(name))
     assert "is not a valid compute pool name." in e.value.message
 
 

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 import pytest
 from click import ClickException
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.plugins.object.common import Tag
 from snowflake.cli.plugins.spcs.common import NoPropertiesProvidedError
@@ -617,14 +618,15 @@ def test_invalid_service_name(runner):
     invalid_service_name = "account.db.schema.name"
     result = runner.invoke(["spcs", "service", "status", invalid_service_name])
     assert result.exit_code == 1
-    assert f"'{invalid_service_name}' is not a valid service name." in result.output
+    assert f"'{invalid_service_name}' is not valid" in result.output
 
 
 @patch("snowflake.cli.plugins.spcs.services.commands.is_valid_object_name")
 def test_service_name_parser(mock_is_valid_object_name):
     service_name = "db.schema.test_service"
     mock_is_valid_object_name.return_value = True
-    assert _service_name_callback(service_name) == service_name
+    fqn = FQN.from_string(service_name)
+    assert _service_name_callback(fqn) == fqn
     mock_is_valid_object_name.assert_called_once_with(
         service_name, max_depth=2, allow_quoted=False
     )
@@ -632,10 +634,10 @@ def test_service_name_parser(mock_is_valid_object_name):
 
 @patch("snowflake.cli.plugins.spcs.services.commands.is_valid_object_name")
 def test_service_name_parser_invalid_object_name(mock_is_valid_object_name):
-    invalid_service_name = "account.db.schema.test_service"
+    invalid_service_name = '"db.schema.test_service"'
     mock_is_valid_object_name.return_value = False
     with pytest.raises(ClickException) as e:
-        _service_name_callback(invalid_service_name)
+        _service_name_callback(FQN.from_string(invalid_service_name))
     assert f"'{invalid_service_name}' is not a valid service name." in e.value.message
 
 

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -499,7 +499,9 @@ def test_stage_create(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     result = runner.invoke(["stage", "create", "-c", "empty", "stageName"])
     assert result.exit_code == 0, result.output
-    mock_execute.assert_called_once_with("create stage if not exists stageName")
+    mock_execute.assert_called_once_with(
+        "create stage if not exists IDENTIFIER('stageName')"
+    )
 
 
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
@@ -507,7 +509,9 @@ def test_stage_create_quoted(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     result = runner.invoke(["stage", "create", "-c", "empty", '"stage name"'])
     assert result.exit_code == 0, result.output
-    mock_execute.assert_called_once_with('create stage if not exists "stage name"')
+    mock_execute.assert_called_once_with(
+        """create stage if not exists IDENTIFIER('"stage name"')"""
+    )
 
 
 @mock.patch("snowflake.cli.plugins.object.commands.ObjectManager._execute_query")
@@ -515,7 +519,7 @@ def test_stage_drop(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     result = runner.invoke(["object", "drop", "stage", "stageName", "-c", "empty"])
     assert result.exit_code == 0, result.output
-    mock_execute.assert_called_once_with("drop stage stageName")
+    mock_execute.assert_called_once_with("drop stage IDENTIFIER('stageName')")
 
 
 @mock.patch("snowflake.cli.plugins.object.commands.ObjectManager._execute_query")
@@ -523,7 +527,7 @@ def test_stage_drop_quoted(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     result = runner.invoke(["object", "drop", "stage", '"stage name"', "-c", "empty"])
     assert result.exit_code == 0, result.output
-    mock_execute.assert_called_once_with('drop stage "stage name"')
+    mock_execute.assert_called_once_with("""drop stage IDENTIFIER('"stage name"')""")
 
 
 @mock.patch(f"{STAGE_MANAGER}._execute_query")

--- a/tests/streamlit/test_commands.py
+++ b/tests/streamlit/test_commands.py
@@ -43,7 +43,7 @@ def test_describe_streamlit(mock_connector, runner, mock_ctx):
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        f"describe streamlit {STREAMLIT_NAME}",
+        f"describe streamlit IDENTIFIER('{STREAMLIT_NAME}')",
     ]
 
 
@@ -85,7 +85,7 @@ def test_deploy_only_streamlit_file(
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit')",
         _put_query(
             "streamlit_app.py", "@MockDatabase.MockSchema.streamlit/test_streamlit"
         ),
@@ -136,7 +136,7 @@ def test_deploy_only_streamlit_file_no_stage(
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit')",
         _put_query(
             "streamlit_app.py", "@MockDatabase.MockSchema.streamlit/test_streamlit"
         ),
@@ -186,7 +186,7 @@ def test_deploy_only_streamlit_file_replace(
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit')",
         _put_query(
             "streamlit_app.py", "@MockDatabase.MockSchema.streamlit/test_streamlit"
         ),
@@ -289,7 +289,7 @@ def test_deploy_streamlit_and_environment_files(
     root_path = f"@MockDatabase.MockSchema.streamlit/{STREAMLIT_NAME}"
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit')",
         _put_query("streamlit_app.py", root_path),
         _put_query("environment.yml", root_path),
         dedent(
@@ -330,7 +330,7 @@ def test_deploy_streamlit_and_pages_files(
     root_path = f"@MockDatabase.MockSchema.streamlit/{STREAMLIT_NAME}"
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit')",
         _put_query("streamlit_app.py", root_path),
         _put_query("pages/*", f"{root_path}/pages"),
         dedent(
@@ -370,7 +370,7 @@ def test_deploy_all_streamlit_files(
     root_path = f"@MockDatabase.MockSchema.streamlit/{STREAMLIT_NAME}"
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit')",
         _put_query("streamlit_app.py", root_path),
         _put_query("environment.yml", root_path),
         _put_query("pages/*", f"{root_path}/pages"),
@@ -415,7 +415,7 @@ def test_deploy_put_files_on_stage(
     root_path = f"@MockDatabase.MockSchema.streamlit_stage/{STREAMLIT_NAME}"
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit_stage",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit_stage')",
         _put_query("streamlit_app.py", root_path),
         _put_query("environment.yml", root_path),
         _put_query("pages/*", f"{root_path}/pages"),
@@ -456,7 +456,7 @@ def test_deploy_all_streamlit_files_not_defaults(
     root_path = f"@MockDatabase.MockSchema.streamlit_stage/{STREAMLIT_NAME}"
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
-        "create stage if not exists MockDatabase.MockSchema.streamlit_stage",
+        "create stage if not exists IDENTIFIER('MockDatabase.MockSchema.streamlit_stage')",
         _put_query("main.py", root_path),
         _put_query("streamlit_environment.yml", root_path),
         _put_query("streamlit_pages/*", f"{root_path}/streamlit_pages"),
@@ -759,7 +759,7 @@ def test_drop_streamlit(mock_connector, runner, mock_ctx):
     result = runner.invoke(["object", "drop", "streamlit", STREAMLIT_NAME])
 
     assert result.exit_code == 0, result.output
-    assert ctx.get_query() == f"drop streamlit {STREAMLIT_NAME}"
+    assert ctx.get_query() == f"drop streamlit IDENTIFIER('{STREAMLIT_NAME}')"
 
 
 @mock.patch("snowflake.connector.connect")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Use `IDENTIFIER(...)` function instead of embedding raw string in query.
