### PR TITLE
Introduce entity identifier

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -73,10 +73,12 @@ def _pdf_v2_to_v1(v2_definition: DefinitionV20) -> DefinitionV11:
         )
 
     # NativeApp
-    if app_definition and app_definition.name:
-        pdfv1["native_app"]["name"] = app_definition.name
+    if app_definition and app_definition.fqn.identifier:
+        pdfv1["native_app"]["name"] = app_definition.fqn.identifier
     else:
-        pdfv1["native_app"]["name"] = app_package_definition.name.split("_pkg_")[0]
+        pdfv1["native_app"]["name"] = app_package_definition.fqn.identifier.split(
+            "_pkg_"
+        )[0]
     pdfv1["native_app"]["artifacts"] = [
         _convert_v2_artifact_to_v1_dict(a) for a in app_package_definition.artifacts
     ]
@@ -88,7 +90,7 @@ def _pdf_v2_to_v1(v2_definition: DefinitionV20) -> DefinitionV11:
 
     # Package
     pdfv1["native_app"]["package"] = {}
-    pdfv1["native_app"]["package"]["name"] = app_package_definition.name
+    pdfv1["native_app"]["package"]["name"] = app_package_definition.fqn.identifier
     if app_package_definition.distribution:
         pdfv1["native_app"]["package"][
             "distribution"
@@ -108,7 +110,7 @@ def _pdf_v2_to_v1(v2_definition: DefinitionV20) -> DefinitionV11:
     # Application
     if app_definition:
         pdfv1["native_app"]["application"] = {}
-        pdfv1["native_app"]["application"]["name"] = app_definition.name
+        pdfv1["native_app"]["application"]["name"] = app_definition.fqn.identifier
         if app_definition.debug:
             pdfv1["native_app"]["application"]["debug"] = app_definition.debug
         if app_definition.meta:

--- a/src/snowflake/cli/_plugins/snowpark/common.py
+++ b/src/snowflake/cli/_plugins/snowpark/common.py
@@ -281,7 +281,7 @@ class UdfSprocIdentifier:
                 types.append(arg.arg_type)
                 defaults.append(arg.default)
 
-        identifier = FQN.from_identifier_model(udf_sproc).using_context()
+        identifier = FQN.from_identifier_model_v1(udf_sproc).using_context()
         return cls(identifier, names, types, defaults)
 
 

--- a/src/snowflake/cli/_plugins/streamlit/commands.py
+++ b/src/snowflake/cli/_plugins/streamlit/commands.py
@@ -155,7 +155,7 @@ def streamlit_deploy(
 
     # Get first streamlit
     streamlit: StreamlitEntityModel = streamlits[list(streamlits)[0]]
-    streamlit_id = FQN.from_identifier_model(streamlit).using_context()
+    streamlit_id = streamlit.fqn.using_context()
 
     url = StreamlitManager().deploy(
         streamlit_id=streamlit_id,
@@ -200,14 +200,18 @@ def _migrate_v1_streamlit_to_v2(pd: ProjectDefinition):
     if pd.streamlit.additional_source_files:
         artifacts.extend(pd.streamlit.additional_source_files)
 
+    identifier = {"name": pd.streamlit.name}
+    if pd.streamlit.schema_name:
+        identifier["schema"] = pd.streamlit.schema_name
+    if pd.streamlit.database:
+        identifier["database"] = pd.streamlit.database
+
     data = {
         "definition_version": "2",
         "entities": {
-            "streamlit_app": {
+            pd.streamlit.name: {
                 "type": "streamlit",
-                "name": pd.streamlit.name,
-                "schema": pd.streamlit.schema_name,
-                "database": pd.streamlit.database,
+                "identifier": identifier,
                 "title": pd.streamlit.title,
                 "query_warehouse": pd.streamlit.query_warehouse,
                 "main_file": str(pd.streamlit.main_file),

--- a/src/snowflake/cli/api/identifiers.py
+++ b/src/snowflake/cli/api/identifiers.py
@@ -152,7 +152,7 @@ class FQN:
         if fqn.database and model.database:
             raise FQNInconsistencyError("database", model.name)
         if fqn.schema and model.schema_:
-            raise FQNInconsistencyError("schema2", model.name)
+            raise FQNInconsistencyError("schema", model.name)
 
         return fqn.set_database(model.database).set_schema(model.schema_)
 

--- a/src/snowflake/cli/api/project/schemas/entities/application_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/application_entity_model.py
@@ -31,9 +31,6 @@ from snowflake.cli.api.project.schemas.updatable_model import (
 
 class ApplicationEntityModel(EntityModelBase):
     type: Literal["application"] = DiscriminatorField()  # noqa A003
-    name: str = Field(
-        title="Name of the application created when this entity is deployed"
-    )
     from_: TargetField[ApplicationPackageEntityModel] = Field(
         alias="from",
         title="An application package this entity should be created from",

--- a/src/snowflake/cli/api/project/schemas/entities/application_package_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/application_package_entity_model.py
@@ -30,9 +30,6 @@ from snowflake.cli.api.project.schemas.updatable_model import (
 
 class ApplicationPackageEntityModel(EntityModelBase):
     type: Literal["application package"] = DiscriminatorField()  # noqa: A003
-    name: str = Field(
-        title="Name of the application package created when this entity is deployed"
-    )
     artifacts: List[Union[PathMapping, str]] = Field(
         title="List of paths or file source/destination pairs to add to the deploy root",
     )

--- a/src/snowflake/cli/api/project/schemas/entities/common.py
+++ b/src/snowflake/cli/api/project/schemas/entities/common.py
@@ -64,14 +64,19 @@ class EntityModelBase(ABC, UpdatableModel):
     identifier: Optional[Union[Identifier | str]] = Field(
         title="Entity identifier", default=None
     )
-    _key: Optional[str] = PrivateAttr(default=None)
+    # Set by parent model in post validation. To reference it use `entity_id`.
+    _entity_id: str = PrivateAttr(default=None)
 
-    def set_key(self, value: str):
-        self._key = value
+    @property
+    def entity_id(self):
+        return self._entity_id
+
+    def set_entity_id(self, value: str):
+        self._entity_id = value
 
     def validate_identifier(self):
         """Helper that's used by ProjectDefinition validator."""
-        if not self._key and not self.identifier:
+        if not self._entity_id and not self.identifier:
             raise ValueError("Missing entity identifier")
 
     @property
@@ -80,8 +85,8 @@ class EntityModelBase(ABC, UpdatableModel):
             return FQN.from_string(self.identifier)
         if isinstance(self.identifier, Identifier):
             return FQN.from_identifier_model_v2(self.identifier)
-        if self._key:
-            return FQN.from_string(self._key)
+        if self.entity_id:
+            return FQN.from_string(self.entity_id)
 
 
 TargetType = TypeVar("TargetType")

--- a/src/snowflake/cli/api/project/schemas/entities/common.py
+++ b/src/snowflake/cli/api/project/schemas/entities/common.py
@@ -83,10 +83,6 @@ class EntityModelBase(ABC, UpdatableModel):
         if self._key:
             return FQN.from_string(self._key)
 
-    @property
-    def name(self) -> str:
-        return self.fqn.identifier
-
 
 TargetType = TypeVar("TargetType")
 

--- a/src/snowflake/cli/api/project/schemas/entities/common.py
+++ b/src/snowflake/cli/api/project/schemas/entities/common.py
@@ -15,9 +15,11 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar, Union
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
+from snowflake.cli.api.identifiers import FQN
+from snowflake.cli.api.project.schemas.identifier_model import Identifier
 from snowflake.cli.api.project.schemas.native_app.application import (
     PostDeployHook,
 )
@@ -59,6 +61,31 @@ class EntityModelBase(ABC, UpdatableModel):
         return cls.model_fields["type"].annotation.__args__[0]
 
     meta: Optional[MetaField] = Field(title="Meta fields", default=None)
+    identifier: Optional[Union[Identifier | str]] = Field(
+        title="Entity identifier", default=None
+    )
+    _key: Optional[str] = PrivateAttr(default=None)
+
+    def set_key(self, value: str):
+        self._key = value
+
+    def validate_identifier(self):
+        """Helper that's used by ProjectDefinition validator."""
+        if not self._key and not self.identifier:
+            raise ValueError("Missing entity identifier")
+
+    @property
+    def fqn(self) -> FQN:
+        if isinstance(self.identifier, str):
+            return FQN.from_string(self.identifier)
+        if isinstance(self.identifier, Identifier):
+            return FQN.from_identifier_model_v2(self.identifier)
+        if self._key:
+            return FQN.from_string(self._key)
+
+    @property
+    def name(self) -> str:
+        return self.fqn.identifier
 
 
 TargetType = TypeVar("TargetType")

--- a/src/snowflake/cli/api/project/schemas/entities/streamlit_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/streamlit_entity_model.py
@@ -18,13 +18,12 @@ from typing import List, Literal, Optional
 
 from pydantic import Field, model_validator
 from snowflake.cli.api.project.schemas.entities.common import EntityModelBase
-from snowflake.cli.api.project.schemas.identifier_model import ObjectIdentifierModel
 from snowflake.cli.api.project.schemas.updatable_model import (
     DiscriminatorField,
 )
 
 
-class StreamlitEntityModel(EntityModelBase, ObjectIdentifierModel(object_name="Streamlit")):  # type: ignore
+class StreamlitEntityModel(EntityModelBase):
     type: Literal["streamlit"] = DiscriminatorField()  # noqa: A003
     title: Optional[str] = Field(
         title="Human-readable title for the Streamlit dashboard", default=None

--- a/src/snowflake/cli/api/project/schemas/identifier_model.py
+++ b/src/snowflake/cli/api/project/schemas/identifier_model.py
@@ -17,7 +17,16 @@ from __future__ import annotations
 from typing import Optional, cast
 
 from pydantic import Field
-from snowflake.cli.api.project.schemas.updatable_model import IdentifierField
+from snowflake.cli.api.project.schemas.updatable_model import (
+    IdentifierField,
+    UpdatableModel,
+)
+
+
+class Identifier(UpdatableModel):
+    name: str = Field(title="Entity name")
+    schema_: str = Field(title="Entity schema", alias="schema", default=None)
+    database: str = Field(title="Entity database", default=None)
 
 
 class ObjectIdentifierBaseModel:

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -137,6 +137,16 @@ class DefinitionV20(_ProjectDefinitionBase):
 
     @field_validator("entities", mode="after")
     @classmethod
+    def validate_entities_identifiers(
+        cls, entities: Dict[str, Entity]
+    ) -> Dict[str, Entity]:
+        for key, entity in entities.items():
+            entity.set_key(key)
+            entity.validate_identifier()
+        return entities
+
+    @field_validator("entities", mode="after")
+    @classmethod
     def validate_entities(
         cls, entities: Dict[str, EntityModel]
     ) -> Dict[str, EntityModel]:

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -138,10 +138,10 @@ class DefinitionV20(_ProjectDefinitionBase):
     @field_validator("entities", mode="after")
     @classmethod
     def validate_entities_identifiers(
-        cls, entities: Dict[str, Entity]
-    ) -> Dict[str, Entity]:
+        cls, entities: Dict[str, EntityModel]
+    ) -> Dict[str, EntityModel]:
         for key, entity in entities.items():
-            entity.set_key(key)
+            entity.set_entity_id(key)
             entity.validate_identifier()
         return entities
 

--- a/src/snowflake/cli/api/project/schemas/updatable_model.py
+++ b/src/snowflake/cli/api/project/schemas/updatable_model.py
@@ -155,7 +155,9 @@ class UpdatableModel(BaseModel):
         setattr(
             cls,
             f"_field_validator_with_verbose_name_to_avoid_name_conflict_{field_name}",
-            field_validator(field_name, mode="wrap")(validator_skipping_templated_str),
+            field_validator(field_name, mode="wrap", check_fields=False)(
+                validator_skipping_templated_str
+            ),
         )
 
     def update_from_dict(self, update_values: Dict[str, Any]):

--- a/src/snowflake/cli/api/project/schemas/updatable_model.py
+++ b/src/snowflake/cli/api/project/schemas/updatable_model.py
@@ -131,7 +131,10 @@ class UpdatableModel(BaseModel):
 
         # Add Pydantic validation wrapper around all fields except `DiscriminatorField`s
         for field_name in field_annotations:
-            if not cls._is_entity_type_field(field_values.get(field_name)):
+            field = field_values.get(field_name)
+            if field is None:
+                continue
+            if not cls._is_entity_type_field(field):
                 cls._add_validator(field_name)
 
     @classmethod
@@ -155,9 +158,7 @@ class UpdatableModel(BaseModel):
         setattr(
             cls,
             f"_field_validator_with_verbose_name_to_avoid_name_conflict_{field_name}",
-            field_validator(field_name, mode="wrap", check_fields=False)(
-                validator_skipping_templated_str
-            ),
+            field_validator(field_name, mode="wrap")(validator_skipping_templated_str),
         )
 
     def update_from_dict(self, update_values: Dict[str, Any]):

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -26,7 +26,7 @@ from snowflake.cli.api.project.schemas.project_definition import (
     build_project_definition,
 )
 from snowflake.cli.api.project.schemas.updatable_model import context
-from snowflake.cli.api.rendering.jinja import CONTEXT_KEY
+from snowflake.cli.api.rendering.jinja import CONTEXT_KEY, FUNCTION_KEY
 from snowflake.cli.api.rendering.project_definition_templates import (
     get_project_definition_cli_jinja_env,
 )
@@ -338,7 +338,7 @@ def render_definition_template(
     _validate_env_section(definition.get("env", {}))
 
     # add available templating functions
-    project_context["fn"] = get_templating_functions()
+    project_context[FUNCTION_KEY] = get_templating_functions()
 
     referenced_vars = _get_referenced_vars_in_definition(template_env, definition)
 

--- a/tests/api/project/schemas/test_updatable_model.py
+++ b/tests/api/project/schemas/test_updatable_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from pydantic import Field, ValidationError, field_validator
+from pydantic import ValidationError, field_validator
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel, context
 
 
@@ -50,7 +50,7 @@ def test_updatable_model_with_sub_class_models():
 
 def test_updatable_model_with_validators():
     class TestModel(UpdatableModel):
-        a: str = Field()
+        a: str
 
         @field_validator("a", mode="before")
         @classmethod
@@ -99,7 +99,7 @@ def test_updatable_model_with_validators():
 
 def test_updatable_model_with_plain_validator():
     class TestModel(UpdatableModel):
-        a: str = Field()
+        a: str
 
         @field_validator("a", mode="plain")
         @classmethod
@@ -130,7 +130,7 @@ def test_updatable_model_with_plain_validator():
 
 def test_updatable_model_with_int_and_templates():
     class TestModel(UpdatableModel):
-        a: int = Field()
+        a: int
 
     result = TestModel(a="123")
     assert result.a == 123
@@ -150,7 +150,7 @@ def test_updatable_model_with_int_and_templates():
 
 def test_updatable_model_with_bool_and_templates():
     class TestModel(UpdatableModel):
-        a: bool = Field()
+        a: bool
 
     result = TestModel(a="true")
     assert result.a is True
@@ -170,10 +170,10 @@ def test_updatable_model_with_bool_and_templates():
 
 def test_updatable_model_with_sub_classes_and_template_values():
     class ParentModel(UpdatableModel):
-        a: str = Field()
+        a: str
 
     class ChildModel(ParentModel):
-        b: int = Field()
+        b: int
 
     result = ChildModel(a="any_value", b="123")
     assert result.b == 123
@@ -193,7 +193,7 @@ def test_updatable_model_with_sub_classes_and_template_values():
 
 def test_updatable_model_with_sub_classes_and_template_values_and_custom_validator_in_parent():
     class ParentModel(UpdatableModel):
-        a: str = Field()
+        a: str
 
         @field_validator("a", mode="before")
         @classmethod
@@ -203,7 +203,7 @@ def test_updatable_model_with_sub_classes_and_template_values_and_custom_validat
             return value
 
     class ChildModel(ParentModel):
-        b: str = Field()
+        b: str
 
     result = ChildModel(a="expected_value", b="any_value")
     assert result.a == "expected_value"
@@ -223,10 +223,10 @@ def test_updatable_model_with_sub_classes_and_template_values_and_custom_validat
 
 def test_updatable_model_with_sub_classes_and_template_values_and_custom_validator_in_child():
     class ParentModel(UpdatableModel):
-        a: str = Field()
+        a: str
 
     class ChildModel(ParentModel):
-        b: str = Field()
+        b: str
 
         @field_validator("b", mode="before")
         @classmethod

--- a/tests/api/project/schemas/test_updatable_model.py
+++ b/tests/api/project/schemas/test_updatable_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from pydantic import ValidationError, field_validator
+from pydantic import Field, ValidationError, field_validator
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel, context
 
 
@@ -50,7 +50,7 @@ def test_updatable_model_with_sub_class_models():
 
 def test_updatable_model_with_validators():
     class TestModel(UpdatableModel):
-        a: str
+        a: str = Field()
 
         @field_validator("a", mode="before")
         @classmethod
@@ -99,7 +99,7 @@ def test_updatable_model_with_validators():
 
 def test_updatable_model_with_plain_validator():
     class TestModel(UpdatableModel):
-        a: str
+        a: str = Field()
 
         @field_validator("a", mode="plain")
         @classmethod
@@ -130,7 +130,7 @@ def test_updatable_model_with_plain_validator():
 
 def test_updatable_model_with_int_and_templates():
     class TestModel(UpdatableModel):
-        a: int
+        a: int = Field()
 
     result = TestModel(a="123")
     assert result.a == 123
@@ -150,7 +150,7 @@ def test_updatable_model_with_int_and_templates():
 
 def test_updatable_model_with_bool_and_templates():
     class TestModel(UpdatableModel):
-        a: bool
+        a: bool = Field()
 
     result = TestModel(a="true")
     assert result.a is True
@@ -170,10 +170,10 @@ def test_updatable_model_with_bool_and_templates():
 
 def test_updatable_model_with_sub_classes_and_template_values():
     class ParentModel(UpdatableModel):
-        a: str
+        a: str = Field()
 
     class ChildModel(ParentModel):
-        b: int
+        b: int = Field()
 
     result = ChildModel(a="any_value", b="123")
     assert result.b == 123
@@ -193,7 +193,7 @@ def test_updatable_model_with_sub_classes_and_template_values():
 
 def test_updatable_model_with_sub_classes_and_template_values_and_custom_validator_in_parent():
     class ParentModel(UpdatableModel):
-        a: str
+        a: str = Field()
 
         @field_validator("a", mode="before")
         @classmethod
@@ -203,7 +203,7 @@ def test_updatable_model_with_sub_classes_and_template_values_and_custom_validat
             return value
 
     class ChildModel(ParentModel):
-        b: str
+        b: str = Field()
 
     result = ChildModel(a="expected_value", b="any_value")
     assert result.a == "expected_value"
@@ -223,10 +223,10 @@ def test_updatable_model_with_sub_classes_and_template_values_and_custom_validat
 
 def test_updatable_model_with_sub_classes_and_template_values_and_custom_validator_in_child():
     class ParentModel(UpdatableModel):
-        a: str
+        a: str = Field()
 
     class ChildModel(ParentModel):
-        b: str
+        b: str = Field()
 
         @field_validator("b", mode="before")
         @classmethod

--- a/tests/api/test_fqn.py
+++ b/tests/api/test_fqn.py
@@ -127,7 +127,7 @@ def test_from_string_fails_if_pattern_does_not_match(fqn_str):
     ],
 )
 def test_from_identifier_model(model, expected):
-    fqn = FQN.from_identifier_model(model)
+    fqn = FQN.from_identifier_model_v1(model)
     assert fqn.identifier == expected
 
 
@@ -140,7 +140,7 @@ def test_from_identifier_model(model, expected):
 )
 def test_from_identifier_model_fails_if_name_is_fqn_and_schema_or_db(model):
     with pytest.raises(FQNInconsistencyError) as err:
-        FQN.from_identifier_model(model)
+        FQN.from_identifier_model_v1(model)
     assert (
         f"provided but name '{model.name}' is fully qualified name" in err.value.message
     )
@@ -152,7 +152,7 @@ def test_using_connection():
     assert fqn.identifier == "database_test.test_schema.name"
 
 
-@mock.patch("snowflake.cli.api.identifiers.get_cli_context")
+@mock.patch("snowflake.cli.api.cli_global_context.get_cli_context")
 def test_using_context(mock_ctx):
     mock_ctx().connection = MagicMock(database="database_test", schema="test_schema")
     fqn = FQN.from_string("name").using_context()

--- a/tests/nativeapp/test_v2_to_v1.py
+++ b/tests/nativeapp/test_v2_to_v1.py
@@ -41,13 +41,13 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg1": {
                         "type": "application package",
-                        "name": "pkg",
+                        "identifier": "pkg",
                         "artifacts": [],
                         "manifest": "",
                     },
                     "pkg2": {
                         "type": "application package",
-                        "name": "pkg",
+                        "identifier": "pkg",
                         "artifacts": [],
                         "manifest": "",
                     },
@@ -62,18 +62,18 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "pkg",
+                        "identifier": "pkg",
                         "artifacts": [],
                         "manifest": "",
                     },
                     "app1": {
                         "type": "application",
-                        "name": "pkg",
+                        "identifier": "pkg",
                         "from": {"target": "pkg"},
                     },
                     "app2": {
                         "type": "application",
-                        "name": "pkg",
+                        "identifier": "pkg",
                         "from": {"target": "pkg"},
                     },
                 },
@@ -87,7 +87,7 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "pkg_name",
+                        "identifier": "pkg_name",
                         "artifacts": [{"src": "app/*", "dest": "./"}],
                         "manifest": "",
                         "stage": "app.stage",
@@ -107,7 +107,7 @@ from tests.testing_utils.mock_config import mock_config_key
                     },
                     "app": {
                         "type": "application",
-                        "name": "app_name",
+                        "identifier": "app_name",
                         "from": {"target": "pkg"},
                         "debug": True,
                         "meta": {
@@ -186,14 +186,14 @@ def test_decorator_error_when_no_project_exists():
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "package_name",
+                        "identifier": "package_name",
                         "artifacts": [{"src": "app/*", "dest": "./"}],
                         "manifest": "",
                         "stage": "app.stage",
                     },
                     "app": {
                         "type": "application",
-                        "name": "application_name",
+                        "identifier": "application_name",
                         "from": {"target": "pkg"},
                         "meta": {
                             "role": "app_role",
@@ -214,7 +214,7 @@ def test_decorator_error_when_no_project_exists():
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "package_name",
+                        "identifier": "package_name",
                         "artifacts": [{"src": "app/*", "dest": "./"}],
                         "manifest": "",
                         "stage": "app.stage",
@@ -230,7 +230,7 @@ def test_decorator_error_when_no_project_exists():
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "appname_pkg_username",
+                        "identifier": "appname_pkg_username",
                         "artifacts": [{"src": "app/*", "dest": "./"}],
                         "manifest": "",
                         "stage": "app.stage",

--- a/tests/project/test_project_definition_v2.py
+++ b/tests/project/test_project_definition_v2.py
@@ -46,7 +46,6 @@ from tests.testing_utils.mock_config import mock_config_key
         [
             {"entities": {"pkg": {"type": "application package"}}},
             [
-                "missing the following field: 'entities.pkg.application package.name'",
                 "missing the following field: 'entities.pkg.application package.artifacts'",
                 "missing the following field: 'entities.pkg.application package.manifest'",
             ],
@@ -56,7 +55,7 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "",
+                        "identifier": "",
                         "artifacts": [],
                         "manifest": "",
                     }
@@ -69,7 +68,7 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "",
+                        "identifier": "",
                         "artifacts": [],
                         "manifest": "",
                         "bundle_root": "",
@@ -88,7 +87,7 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "",
+                        "identifier": "",
                         "artifacts": [],
                         "manifest": "",
                         "distribution": "invalid",
@@ -101,7 +100,6 @@ from tests.testing_utils.mock_config import mock_config_key
         [
             {"entities": {"app": {"type": "application"}}},
             [
-                "Your project definition is missing the following field: 'entities.app.application.name'",
                 "Your project definition is missing the following field: 'entities.app.application.from'",
             ],
         ],
@@ -110,7 +108,7 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "app": {
                         "type": "application",
-                        "name": "",
+                        "identifier": "",
                         "from": {"target": "non_existing"},
                     }
                 }
@@ -122,13 +120,13 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "",
+                        "identifier": "",
                         "artifacts": [],
                         "manifest": "",
                     },
                     "app": {
                         "type": "application",
-                        "name": "",
+                        "identifier": "",
                         "from": {"target": "pkg"},
                     },
                 }
@@ -141,7 +139,7 @@ from tests.testing_utils.mock_config import mock_config_key
                 "entities": {
                     "pkg": {
                         "type": "application package",
-                        "name": "",
+                        "identifier": "",
                         "artifacts": [],
                         "manifest": "",
                         "meta": {
@@ -152,7 +150,7 @@ from tests.testing_utils.mock_config import mock_config_key
                     },
                     "app": {
                         "type": "application",
-                        "name": "",
+                        "identifier": "",
                         "from": {"target": "pkg"},
                         "meta": {
                             "warehouse": "warehouse",
@@ -182,13 +180,48 @@ def test_project_definition_v2_schema(definition_input, expected_error):
                 raise err
 
 
+def test_identifiers():
+    definition_input = {
+        "definition_version": "2",
+        "entities": {
+            "A": {
+                "type": "application package",
+                "artifacts": [],
+                "manifest": "",
+            },
+            "B": {"type": "streamlit", "identifier": "foo_streamlit"},
+            "C": {
+                "type": "application",
+                "from": {"target": "A"},
+                "identifier": {"name": "foo_app", "schema": "schema_value"},
+            },
+            "D": {
+                "type": "application",
+                "from": {"target": "A"},
+                "identifier": {
+                    "name": "foo_app_2",
+                    "schema": "schema_value",
+                    "database": "db_value",
+                },
+            },
+        },
+    }
+    project = DefinitionV20(**definition_input)
+    entities = project.entities
+
+    assert entities["A"].fqn.identifier == "A"
+    assert entities["B"].fqn.identifier == "foo_streamlit"
+    assert entities["C"].fqn.identifier == "schema_value.foo_app"
+    assert entities["D"].fqn.identifier == "db_value.schema_value.foo_app_2"
+
+
 def test_defaults_are_applied():
     definition_input = {
         "definition_version": "2",
         "entities": {
             "pkg": {
                 "type": "application package",
-                "name": "",
+                "identifier": "",
                 "artifacts": [],
                 "manifest": "",
             }
@@ -206,7 +239,7 @@ def test_defaults_do_not_override_values():
         "entities": {
             "pkg": {
                 "type": "application package",
-                "name": "",
+                "identifier": "",
                 "artifacts": [],
                 "manifest": "",
                 "stage": "pkg_stage",

--- a/tests/project/test_project_definition_v2.py
+++ b/tests/project/test_project_definition_v2.py
@@ -210,9 +210,16 @@ def test_identifiers():
     entities = project.entities
 
     assert entities["A"].fqn.identifier == "A"
+    assert entities["A"].entity_id == "A"
+
     assert entities["B"].fqn.identifier == "foo_streamlit"
+    assert entities["B"].entity_id == "B"
+
     assert entities["C"].fqn.identifier == "schema_value.foo_app"
+    assert entities["C"].entity_id == "C"
+
     assert entities["D"].fqn.identifier == "db_value.schema_value.foo_app_2"
+    assert entities["D"].entity_id == "D"
 
 
 def test_defaults_are_applied():

--- a/tests/streamlit/__snapshots__/test_commands.ambr
+++ b/tests/streamlit/__snapshots__/test_commands.ambr
@@ -6,10 +6,10 @@
   | were encountered:                                                            |
   | For field entities.my_streamlit.streamlit you provided '{'artifacts':        |
   | ['streamlit_app.py', 'foo_bar.py', 'pages/', 'environment.yml'],             |
-  | 'main_file': 'streamlit_app.py', 'name': 'test_streamlit_deploy_snowcli',    |
-  | 'query_warehouse': 'xsmall', 'stage': 'streamlit', 'title': 'My Fancy        |
-  | Streamlit', 'type': 'streamlit'}'. This caused: Value error, Specified       |
-  | artifact foo_bar.py does not exist locally.                                  |
+  | 'identifier': 'test_streamlit_deploy_snowcli', 'main_file':                  |
+  | 'streamlit_app.py', 'query_warehouse': 'xsmall', 'stage': 'streamlit',       |
+  | 'title': 'My Fancy Streamlit', 'type': 'streamlit'}'. This caused: Value     |
+  | error, Specified artifact foo_bar.py does not exist locally.                 |
   +------------------------------------------------------------------------------+
   
   '''
@@ -21,7 +21,7 @@
   | were encountered:                                                            |
   | For field entities.my_streamlit.streamlit you provided '{'artifacts':        |
   | ['streamlit_app.py', 'utils/utils.py', 'pages/', 'environment.yml'],         |
-  | 'main_file': 'foo_bar.py', 'name': 'test_streamlit_deploy_snowcli',          |
+  | 'identifier': 'test_streamlit_deploy_snowcli', 'main_file': 'foo_bar.py',    |
   | 'query_warehouse': 'xsmall', 'stage': 'streamlit', 'title': 'My Fancy        |
   | Streamlit', 'type': 'streamlit'}'. This caused: Value error, Specified main  |
   | file foo_bar.py is not included in artifacts.                                |

--- a/tests/test_data/projects/example_streamlit_v2/snowflake.yml
+++ b/tests/test_data/projects/example_streamlit_v2/snowflake.yml
@@ -2,7 +2,7 @@ definition_version: 2
 entities:
   my_streamlit:
     type: "streamlit"
-    name: test_streamlit_deploy_snowcli
+    identifier: test_streamlit_deploy_snowcli
     title: "My Fancy Streamlit"
     stage: streamlit
     query_warehouse: xsmall

--- a/tests/test_data/projects/integration_external_v2/package/001-shared.sql
+++ b/tests/test_data/projects/integration_external_v2/package/001-shared.sql
@@ -1,5 +1,5 @@
 -- package script (1/2)
 
-create schema if not exists &{ ctx.entities.pkg.name }.my_shared_content;
-grant usage on schema &{ ctx.entities.pkg.name }.my_shared_content
-  to share in application package &{ ctx.entities.pkg.name };
+create schema if not exists &{ ctx.entities.pkg.identifier }.my_shared_content;
+grant usage on schema &{ ctx.entities.pkg.identifier }.my_shared_content
+  to share in application package &{ ctx.entities.pkg.identifier };

--- a/tests/test_data/projects/integration_external_v2/package/002-shared.sql
+++ b/tests/test_data/projects/integration_external_v2/package/002-shared.sql
@@ -1,12 +1,12 @@
 -- package script (2/2)
 
-create or replace table &{ ctx.entities.pkg.name }.my_shared_content.shared_table (
+create or replace table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (
   col1 number,
   col2 varchar
 );
 
-insert into &{ ctx.entities.pkg.name }.my_shared_content.shared_table (col1, col2)
+insert into &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (col1, col2)
   values (1, 'hello');
 
-grant select on table &{ ctx.entities.pkg.name }.my_shared_content.shared_table
-  to share in application package &{ ctx.entities.pkg.name };
+grant select on table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table
+  to share in application package &{ ctx.entities.pkg.identifier };

--- a/tests/test_data/projects/integration_external_v2/snowflake.yml
+++ b/tests/test_data/projects/integration_external_v2/snowflake.yml
@@ -3,7 +3,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: integration_external_pkg_<% ctx.env.USER %>
+    identifier: integration_external_pkg_<% ctx.env.USER %>
     artifacts:
       - src: app/*
         dest: ./

--- a/tests/test_data/projects/integration_templated_v2/package/001-shared.sql
+++ b/tests/test_data/projects/integration_templated_v2/package/001-shared.sql
@@ -1,5 +1,5 @@
 -- package script (1/2)
 
-create schema if not exists &{ ctx.entities.pkg.name }.my_shared_content;
-grant usage on schema &{ ctx.entities.pkg.name }.my_shared_content
-  to share in application package &{ ctx.entities.pkg.name };
+create schema if not exists &{ ctx.entities.pkg.identifier }.my_shared_content;
+grant usage on schema &{ ctx.entities.pkg.identifier }.my_shared_content
+  to share in application package &{ ctx.entities.pkg.identifier };

--- a/tests/test_data/projects/integration_templated_v2/package/002-shared.sql
+++ b/tests/test_data/projects/integration_templated_v2/package/002-shared.sql
@@ -1,12 +1,12 @@
 -- package script (2/2)
 
-create or replace table &{ ctx.entities.pkg.name }.my_shared_content.shared_table (
+create or replace table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (
   col1 number,
   col2 varchar
 );
 
-insert into &{ ctx.entities.pkg.name }.my_shared_content.shared_table (col1, col2)
+insert into &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (col1, col2)
   values (1, 'hello');
 
-grant select on table &{ ctx.entities.pkg.name }.my_shared_content.shared_table
-  to share in application package &{ ctx.entities.pkg.name };
+grant select on table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table
+  to share in application package &{ ctx.entities.pkg.identifier };

--- a/tests/test_data/projects/integration_templated_v2/snowflake.yml
+++ b/tests/test_data/projects/integration_templated_v2/snowflake.yml
@@ -3,7 +3,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: integration_<% ctx.env.INTERMEDIATE_CI_ENV %>_pkg_<% ctx.env.USER %>
+    identifier: integration_<% ctx.env.INTERMEDIATE_CI_ENV %>_pkg_<% ctx.env.USER %>
     artifacts:
       - src: <% ctx.env.APP_DIR %>/*
         dest: ./

--- a/tests/test_data/projects/integration_v2/package/001-shared.sql
+++ b/tests/test_data/projects/integration_v2/package/001-shared.sql
@@ -1,5 +1,5 @@
 -- package script (1/2)
 
-create schema if not exists &{ ctx.entities.pkg.name }.my_shared_content;
-grant usage on schema &{ ctx.entities.pkg.name }.my_shared_content
-  to share in application package &{ ctx.entities.pkg.name };
+create schema if not exists &{ ctx.entities.pkg.identifier }.my_shared_content;
+grant usage on schema &{ ctx.entities.pkg.identifier }.my_shared_content
+  to share in application package &{ ctx.entities.pkg.identifier };

--- a/tests/test_data/projects/integration_v2/package/002-shared.sql
+++ b/tests/test_data/projects/integration_v2/package/002-shared.sql
@@ -1,12 +1,12 @@
 -- package script (2/2)
 
-create or replace table &{ ctx.entities.pkg.name }.my_shared_content.shared_table (
+create or replace table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (
   col1 number,
   col2 varchar
 );
 
-insert into &{ ctx.entities.pkg.name }.my_shared_content.shared_table (col1, col2)
+insert into &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (col1, col2)
   values (1, 'hello');
 
-grant select on table &{ ctx.entities.pkg.name }.my_shared_content.shared_table
-  to share in application package &{ ctx.entities.pkg.name };
+grant select on table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table
+  to share in application package &{ ctx.entities.pkg.identifier };

--- a/tests/test_data/projects/integration_v2/snowflake.yml
+++ b/tests/test_data/projects/integration_v2/snowflake.yml
@@ -3,7 +3,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: integration_pkg_<% ctx.env.USER %>
+    identifier: integration_pkg_<% ctx.env.USER %>
     artifacts:
       - src: app/*
         dest: ./

--- a/tests/workspace/utils.py
+++ b/tests/workspace/utils.py
@@ -45,7 +45,7 @@ MOCK_SNOWFLAKE_YML_V1_FILE = dedent(
     """\
         definition_version: 1
         native_app:
-            identifier: myapp
+            name: myapp
             source_stage: app_src.stage
             artifacts:
                 - src: app/*

--- a/tests/workspace/utils.py
+++ b/tests/workspace/utils.py
@@ -26,7 +26,7 @@ MOCK_SNOWFLAKE_YML_FILE = dedent(
     entities:
         pkg:
             type: application package
-            name: myapp_pkg
+            identifier: myapp_pkg
             artifacts:
                 - setup.sql
                 - app/README.md
@@ -35,7 +35,7 @@ MOCK_SNOWFLAKE_YML_FILE = dedent(
             manifest: app/manifest.yml
         app:
             type: application
-            name: myapp
+            identifier: myapp
             from:
                 target: pkg
     """
@@ -45,7 +45,7 @@ MOCK_SNOWFLAKE_YML_V1_FILE = dedent(
     """\
         definition_version: 1
         native_app:
-            name: myapp
+            identifier: myapp
             source_stage: app_src.stage
             artifacts:
                 - src: app/*

--- a/tests_integration/config/connection_configs.toml
+++ b/tests_integration/config/connection_configs.toml
@@ -14,5 +14,6 @@
 
 [connections.default]
 [connections.integration]
+authenticator = "SNOWFLAKE_JWT"
 schema = "public"
 role = "INTEGRATION_TESTS"

--- a/tests_integration/nativeapp/test_bundle.py
+++ b/tests_integration/nativeapp/test_bundle.py
@@ -62,7 +62,7 @@ def override_snowflake_yml_artifacts(
                     "entities": {
                         "pkg": {
                             "type": "application package",
-                            "name": "myapp_pkg_<% ctx.env.USER %>",
+                            "identifier": "myapp_pkg_<% ctx.env.USER %>",
                             "artifacts": artifacts_section,
                             "manifest": "app/manifest.yml",
                             "deploy_root": str(deploy_root),

--- a/tests_integration/nativeapp/test_debug_mode.py
+++ b/tests_integration/nativeapp/test_debug_mode.py
@@ -61,7 +61,7 @@ def set_yml_application_debug(snowflake_yml: Path, debug: Optional[bool]):
         if "app" not in pdf["entities"]:
             pdf["entities"]["app"] = {
                 "type": "application",
-                "name": "integration_<% ctx.env.USER %>",
+                "identifier": "integration_<% ctx.env.USER %>",
                 "from": {"target": "pkg"},
             }
         if debug is None and "debug" in pdf["entities"]["app"]:

--- a/tests_integration/test_data/projects/napp_application_post_deploy_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_application_post_deploy_v2/snowflake.yml
@@ -3,7 +3,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: myapp_pkg_<% ctx.env.USER %>
+    identifier: myapp_pkg_<% ctx.env.USER %>
     artifacts:
       - src: app/*
         dest: ./
@@ -14,7 +14,7 @@ entities:
         - sql_script: scripts/package_post_deploy2.sql
   app:
     type: application
-    name: myapp_<% ctx.env.USER %>
+    identifier: myapp_<% ctx.env.USER %>
     from:
       target: pkg
     meta:

--- a/tests_integration/test_data/projects/napp_create_db_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_create_db_v2/snowflake.yml
@@ -4,7 +4,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: myapp_pkg_<% ctx.env.USER %>
+    identifier: myapp_pkg_<% ctx.env.USER %>
     stage: app_src.stage
     artifacts:
       - src: app/*
@@ -12,6 +12,6 @@ entities:
     manifest: app/manifest.yml
   app:
     type: application
-    name: myapp_<% ctx.env.USER %>
+    identifier: myapp_<% ctx.env.USER %>
     from:
       target: pkg

--- a/tests_integration/test_data/projects/napp_deploy_prefix_matches_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_deploy_prefix_matches_v2/snowflake.yml
@@ -4,7 +4,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: myapp_pkg_<% ctx.env.USER %>
+    identifier: myapp_pkg_<% ctx.env.USER %>
     artifacts:
       - src: app/*
         dest: ./
@@ -14,6 +14,6 @@ entities:
     manifest: app/manifest.yml
   app:
     type: application
-    name: myapp_<% ctx.env.USER %>
+    identifier: myapp_<% ctx.env.USER %>
     from:
       target: pkg

--- a/tests_integration/test_data/projects/napp_init_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_init_v2/snowflake.yml
@@ -4,13 +4,13 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: myapp_pkg_<% ctx.env.USER %>
+    identifier: myapp_pkg_<% ctx.env.USER %>
     artifacts:
       - src: app/*
         dest: ./
     manifest: app/manifest.yml
   app:
     type: application
-    name: myapp_<% ctx.env.USER %>
+    identifier: myapp_<% ctx.env.USER %>
     from:
       target: pkg

--- a/tests_integration/test_data/projects/project_definition_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/project_definition_v2/snowflake.yml
@@ -3,7 +3,7 @@ definition_version: 2
 entities:
   pkg:
     type: application package
-    name: my_app_pkg_<% ctx.env.foo %>
+    identifier: my_app_pkg_<% ctx.env.foo %>
     artifacts:
       - src: src/**/*
         dest: /
@@ -21,7 +21,7 @@ entities:
       - sql_script: scripts/post_pkg_deploy.sql
   app:
     type: application
-    name: my_app_<% ctx.env.foo %>
+    identifier: my_app_<% ctx.env.foo %>
     from:
       target: pkg
     meta:

--- a/tests_integration/test_data/projects/streamlit_v2/snowflake.yml
+++ b/tests_integration/test_data/projects/streamlit_v2/snowflake.yml
@@ -2,7 +2,8 @@ definition_version: 2
 entities:
   my_streamlit:
     type: "streamlit"
-    name: test_streamlit_deploy_snowcli
+    identifier:
+      name: test_streamlit_deploy_snowcli
     title: "My Fancy Streamlit"
     stage: streamlit
     query_warehouse: xsmall

--- a/tests_integration/test_streamlit.py
+++ b/tests_integration/test_streamlit.py
@@ -168,9 +168,10 @@ def test_streamlit_deploy_experimental_twice(
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "pdf_version, param_path", [("1", "streamlit"), ("2", "entities.my_streamlit")]
+    "pdf_version, param_path",
+    [("1", "streamlit"), ("2", "entities.my_streamlit.identifier")],
 )
-def test_fully_qualified_name_v1(
+def test_fully_qualified_name(
     alter_snowflake_yml,
     test_database,
     project_directory,
@@ -191,7 +192,7 @@ def test_fully_qualified_name_v1(
     # test fully qualified name as name
     with project_directory(f"streamlit_v{pdf_version}") as tmp_dir:
         streamlit_name = "streamlit_fqn"
-        snowflake_yml = tmp_dir / "snowflake.yml"
+        snowflake_yml: Path = tmp_dir / "snowflake.yml"
 
         # FQN with "default" values
         alter_snowflake_yml(
@@ -199,6 +200,7 @@ def test_fully_qualified_name_v1(
             parameter_path=f"{param_path}.name",
             value=f"{database}.{default_schema}.{streamlit_name}",
         )
+
         result = runner.invoke_with_connection_json(["streamlit", "deploy"])
         assert result.exit_code == 0
         assert result.json == {


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

This change introduces unified approach for entities identifiers. Following options are possible
```yml
entities:
  key_only:
      ...

  fqn.as.key:
      ...

  name_only:
    identifier: name
    ...

  fqn_name_only:
    identifier: database.schema.name
    ...

  fqn_schema:
    identifier:
      name: name
      schema: schema
    ...

  fqn_database:
    identifier:
      name: name
      schema: schema
      database: database
    ...
```

If `identifier` specifier is missing then entity key is used as id. On entity level there's `fqn` property that returns `FQN` object representing fully qualified name.
