### PR TITLE
SNOW-1623250 Add current test name to test resource env var in tests

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/project_model.py
+++ b/src/snowflake/cli/_plugins/nativeapp/project_model.py
@@ -142,7 +142,7 @@ class NativeAppProjectModel:
             # explicitly specified, the default is generated here,
             # so we have to append the test resource suffix here
             name = default_app_package(self.project_identifier)
-            return append_test_resource_suffix(name)
+            return to_identifier(append_test_resource_suffix(name))
 
     @cached_property
     def package_role(self) -> str:
@@ -167,7 +167,7 @@ class NativeAppProjectModel:
             # explicitly specified, the default is generated here,
             # so we have to append the test resource suffix here
             name = default_application(self.project_identifier)
-            return append_test_resource_suffix(name)
+            return to_identifier(append_test_resource_suffix(name))
 
     @cached_property
     def app_role(self) -> str:

--- a/src/snowflake/cli/_plugins/nativeapp/project_model.py
+++ b/src/snowflake/cli/_plugins/nativeapp/project_model.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import os
 from functools import cached_property
 from pathlib import Path
 from typing import List, Optional
@@ -33,13 +32,11 @@ from snowflake.cli.api.project.schemas.native_app.application import (
 from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.util import (
-    concat_identifiers,
+    append_test_resource_suffix,
     extract_schema,
     to_identifier,
 )
 from snowflake.connector import DictCursor
-
-RESOURCE_SUFFIX_VAR = "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX"
 
 
 def current_role() -> str:
@@ -139,10 +136,13 @@ class NativeAppProjectModel:
     @property
     def package_name(self) -> str:
         if self.definition.package and self.definition.package.name:
-            name = self.definition.package.name
+            return to_identifier(self.definition.package.name)
         else:
+            # V1.0 PDF doesn't support templating, so if the identifier isn't
+            # explicitly specified, the default is generated here,
+            # so we have to append the test resource suffix here
             name = default_app_package(self.project_identifier)
-        return concat_identifiers([name, resource_suffix()])
+            return append_test_resource_suffix(name)
 
     @cached_property
     def package_role(self) -> str:
@@ -161,10 +161,13 @@ class NativeAppProjectModel:
     @property
     def app_name(self) -> str:
         if self.definition.application and self.definition.application.name:
-            name = to_identifier(self.definition.application.name)
+            return to_identifier(self.definition.application.name)
         else:
-            name = to_identifier(default_application(self.project_identifier))
-        return concat_identifiers([name, resource_suffix()])
+            # V1.0 PDF doesn't support templating, so if the identifier isn't
+            # explicitly specified, the default is generated here,
+            # so we have to append the test resource suffix here
+            name = default_application(self.project_identifier)
+            return append_test_resource_suffix(name)
 
     @cached_property
     def app_role(self) -> str:
@@ -215,12 +218,3 @@ class NativeAppProjectModel:
             deploy_root=self.deploy_root,
             generated_root=self.generated_root,
         )
-
-
-def resource_suffix() -> str:
-    """
-    A suffix that should be added to account-level Native App resources.
-
-    This is an internal concern that is currently only used in tests.
-    """
-    return os.environ.get(RESOURCE_SUFFIX_VAR, "")

--- a/src/snowflake/cli/api/project/schemas/entities/application_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/application_entity_model.py
@@ -52,10 +52,5 @@ class ApplicationEntityModel(EntityModelBase):
         )
         with_suffix = append_test_resource_suffix(identifier)
         if isinstance(input_value, Identifier):
-            data = dict(name=with_suffix)
-            if input_value.schema_:
-                data["schema"] = input_value.schema_
-            if input_value.database:
-                data["database"] = input_value.database
-            return Identifier(**data)
+            return input_value.model_copy(update=dict(name=with_suffix))
         return with_suffix

--- a/src/snowflake/cli/api/project/schemas/entities/application_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/application_entity_model.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from snowflake.cli.api.project.schemas.entities.application_package_entity_model import (
     ApplicationPackageEntityModel,
 )
@@ -24,9 +24,11 @@ from snowflake.cli.api.project.schemas.entities.common import (
     EntityModelBase,
     TargetField,
 )
+from snowflake.cli.api.project.schemas.identifier_model import Identifier
 from snowflake.cli.api.project.schemas.updatable_model import (
     DiscriminatorField,
 )
+from snowflake.cli.api.project.util import append_test_resource_suffix
 
 
 class ApplicationEntityModel(EntityModelBase):
@@ -39,3 +41,21 @@ class ApplicationEntityModel(EntityModelBase):
         title="Whether to enable debug mode when using a named stage to create an application object",
         default=None,
     )
+
+    @field_validator("identifier")
+    @classmethod
+    def append_test_resource_suffix_to_identifier(
+        cls, input_value: Identifier | str
+    ) -> Identifier | str:
+        identifier = (
+            input_value.name if isinstance(input_value, Identifier) else input_value
+        )
+        with_suffix = append_test_resource_suffix(identifier)
+        if isinstance(input_value, Identifier):
+            data = dict(name=with_suffix)
+            if input_value.schema_:
+                data["schema"] = input_value.schema_
+            if input_value.database:
+                data["database"] = input_value.database
+            return Identifier(**data)
+        return with_suffix

--- a/src/snowflake/cli/api/project/schemas/entities/application_package_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/application_package_entity_model.py
@@ -16,16 +16,18 @@ from __future__ import annotations
 
 from typing import List, Literal, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from snowflake.cli.api.project.schemas.entities.common import (
     EntityModelBase,
 )
+from snowflake.cli.api.project.schemas.identifier_model import Identifier
 from snowflake.cli.api.project.schemas.native_app.package import DistributionOptions
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.schemas.updatable_model import (
     DiscriminatorField,
     IdentifierField,
 )
+from snowflake.cli.api.project.util import append_test_resource_suffix
 
 
 class ApplicationPackageEntityModel(EntityModelBase):
@@ -60,3 +62,21 @@ class ApplicationPackageEntityModel(EntityModelBase):
     manifest: str = Field(
         title="Path to manifest.yml",
     )
+
+    @field_validator("identifier")
+    @classmethod
+    def append_test_resource_suffix_to_identifier(
+        cls, input_value: Identifier | str
+    ) -> Identifier | str:
+        identifier = (
+            input_value.name if isinstance(input_value, Identifier) else input_value
+        )
+        with_suffix = append_test_resource_suffix(identifier)
+        if isinstance(input_value, Identifier):
+            data = dict(name=with_suffix)
+            if input_value.schema_:
+                data["schema"] = input_value.schema_
+            if input_value.database:
+                data["database"] = input_value.database
+            return Identifier(**data)
+        return with_suffix

--- a/src/snowflake/cli/api/project/schemas/entities/application_package_entity_model.py
+++ b/src/snowflake/cli/api/project/schemas/entities/application_package_entity_model.py
@@ -73,10 +73,5 @@ class ApplicationPackageEntityModel(EntityModelBase):
         )
         with_suffix = append_test_resource_suffix(identifier)
         if isinstance(input_value, Identifier):
-            data = dict(name=with_suffix)
-            if input_value.schema_:
-                data["schema"] = input_value.schema_
-            if input_value.database:
-                data["database"] = input_value.database
-            return Identifier(**data)
+            return input_value.model_copy(update=dict(name=with_suffix))
         return with_suffix

--- a/src/snowflake/cli/api/project/schemas/native_app/application.py
+++ b/src/snowflake/cli/api/project/schemas/native_app/application.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from snowflake.cli.api.project.schemas.updatable_model import (
     IdentifierField,
     UpdatableModel,
 )
+from snowflake.cli.api.project.util import append_test_resource_suffix
 
 
 class SqlScriptHookType(UpdatableModel):
@@ -52,6 +53,11 @@ class Application(UpdatableModel):
         title="Actions that will be executed after the application object is created/upgraded",
         default=None,
     )
+
+    @field_validator("name")
+    @classmethod
+    def append_test_resource_suffix_to_name(cls, input_value: str) -> str:
+        return append_test_resource_suffix(input_value)
 
 
 class ApplicationV11(Application):

--- a/src/snowflake/cli/api/project/schemas/native_app/package.py
+++ b/src/snowflake/cli/api/project/schemas/native_app/package.py
@@ -22,6 +22,7 @@ from snowflake.cli.api.project.schemas.updatable_model import (
     IdentifierField,
     UpdatableModel,
 )
+from snowflake.cli.api.project.util import append_test_resource_suffix
 
 DistributionOptions = Literal["internal", "external", "INTERNAL", "EXTERNAL"]
 
@@ -49,6 +50,11 @@ class Package(UpdatableModel):
         title="Actions that will be executed after the application package object is created/updated",
         default=None,
     )
+
+    @field_validator("name")
+    @classmethod
+    def append_test_resource_suffix_to_name(cls, input_value: str) -> str:
+        return append_test_resource_suffix(input_value)
 
     @field_validator("scripts")
     @classmethod

--- a/src/snowflake/cli/api/project/schemas/updatable_model.py
+++ b/src/snowflake/cli/api/project/schemas/updatable_model.py
@@ -160,7 +160,8 @@ class UpdatableModel(BaseModel):
 
         setattr(
             cls,
-            f"_field_validator_with_verbose_name_to_avoid_name_conflict_{field_name}",
+            # Unique name so that subclasses get a unique instance of this validator
+            f"_{cls.__module__}.{cls.__name__}_validate_{field_name}",
             field_validator(field_name, mode="wrap")(validator_skipping_templated_str),
         )
 

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -268,7 +268,7 @@ def append_test_resource_suffix(identifier: str) -> str:
     suffix = os.environ.get(TEST_RESOURCE_SUFFIX_VAR, "")
     if identifier_to_str(identifier).endswith(identifier_to_str(suffix)):
         # If the suffix has already been added, don't add it again
-        return to_identifier(identifier)
+        return identifier
     if is_valid_quoted_identifier(identifier) or is_valid_quoted_identifier(suffix):
         # If either identifier is already quoted, use concat_identifier
         # to add the suffix inside the quotes

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -34,6 +34,9 @@ UNQUOTED_IDENTIFIER_REGEX = r"([a-zA-Z_])([a-zA-Z0-9_$]{0,254})"
 QUOTED_IDENTIFIER_REGEX = r'"((""|[^"]){0,255})"'
 VALID_IDENTIFIER_REGEX = f"(?:{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})"
 
+# An env var that is used to suffix the names of some account-level resources
+TEST_RESOURCE_SUFFIX_VAR = "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX"
+
 
 def encode_uri_component(s: str) -> str:
     """
@@ -191,12 +194,6 @@ def extract_schema(qualified_name: str):
     return None
 
 
-def generate_user_env(username: str) -> dict:
-    return {
-        "USER": username,
-    }
-
-
 def first_set_env(*keys: str):
     for k in keys:
         v = os.getenv(k)
@@ -259,3 +256,16 @@ def identifier_to_show_like_pattern(identifier: str) -> str:
     matching this identifier
     """
     return f"'{escape_like_pattern(unquote_identifier(identifier))}'"
+
+
+def append_test_resource_suffix(identifier: str) -> str:
+    """
+    Append a suffix that should be added to specified account-level resources.
+
+    This is an internal concern that is currently only used in tests
+    to isolate concurrent runs and to add the test name to resources.
+    """
+    suffix = os.environ.get(TEST_RESOURCE_SUFFIX_VAR, "")
+    if identifier_to_str(identifier).endswith(identifier_to_str(suffix)):
+        return to_identifier(identifier)
+    return concat_identifiers([identifier, suffix])

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -267,5 +267,12 @@ def append_test_resource_suffix(identifier: str) -> str:
     """
     suffix = os.environ.get(TEST_RESOURCE_SUFFIX_VAR, "")
     if identifier_to_str(identifier).endswith(identifier_to_str(suffix)):
+        # If the suffix has already been added, don't add it again
         return to_identifier(identifier)
-    return concat_identifiers([identifier, suffix])
+    if is_valid_quoted_identifier(identifier) or is_valid_quoted_identifier(suffix):
+        # If either identifier is already quoted, use concat_identifier
+        # to add the suffix inside the quotes
+        return concat_identifiers([identifier, suffix])
+    # Otherwise just append the string, don't add quotes
+    # in case the user doesn't want them
+    return f"{identifier}{suffix}"

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -370,7 +370,7 @@ def render_definition_template(
 
     project_definition = build_project_definition(**definition)
 
-    # Use the values originally provided by the user as the definition
+    # Use the values originally provided by the user as the template context
     # This intentionally doesn't reflect any field changes made by
     # validators, to minimize user surprise when templating values
     project_context[CONTEXT_KEY] = definition

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import copy
-import json
 from typing import Any, Optional
 
 from jinja2 import Environment, TemplateSyntaxError, nodes
@@ -371,17 +370,11 @@ def render_definition_template(
 
     project_definition = build_project_definition(**definition)
 
-    # Dump the model instead of using "definition" since model
-    # validators can change field values. Round-trip as JSON
-    # to serialize non-scalar types like Path to strings
-    project_context[CONTEXT_KEY] = json.loads(
-        project_definition.model_dump_json(
-            exclude_none=True,
-            warnings=False,
-            by_alias=True,
-            round_trip=True,
-        )
-    )
+    # Use the values originally provided by the user as the definition
+    # This intentionally doesn't reflect any field changes made by
+    # validators, to minimize user surprise when templating values
+    project_context[CONTEXT_KEY] = definition
+
     # Use `ProjectEnvironment` in project context in order to
     # handle env variables overrides from OS env and from CLI arguments.
     project_context[CONTEXT_KEY]["env"] = ProjectEnvironment(

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from typing import Any, Optional
 
 from jinja2 import Environment, TemplateSyntaxError, nodes
@@ -369,7 +370,17 @@ def render_definition_template(
     )
 
     project_definition = build_project_definition(**definition)
-    project_context[CONTEXT_KEY] = definition
+
+    # Dump the model instead of using "definition" since model
+    # validators can change field values
+    project_context[CONTEXT_KEY] = json.loads(
+        project_definition.model_dump_json(
+            exclude_none=True,
+            warnings=False,
+            by_alias=True,
+            round_trip=True,
+        )
+    )
     # Use `ProjectEnvironment` in project context in order to
     # handle env variables overrides from OS env and from CLI arguments.
     project_context[CONTEXT_KEY]["env"] = ProjectEnvironment(

--- a/src/snowflake/cli/api/utils/definition_rendering.py
+++ b/src/snowflake/cli/api/utils/definition_rendering.py
@@ -372,7 +372,8 @@ def render_definition_template(
     project_definition = build_project_definition(**definition)
 
     # Dump the model instead of using "definition" since model
-    # validators can change field values
+    # validators can change field values. Round-trip as JSON
+    # to serialize non-scalar types like Path to strings
     project_context[CONTEXT_KEY] = json.loads(
         project_definition.model_dump_json(
             exclude_none=True,

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -717,7 +717,7 @@ def test_non_str_scalar_with_templates():
                 },
                 "application": {
                     "name": "test_app_username",
-                    "debug": "true",
+                    "debug": True,
                 },
             },
             "env": ProjectEnvironment(default_env={}, override_env={}),

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -717,7 +717,7 @@ def test_non_str_scalar_with_templates():
                 },
                 "application": {
                     "name": "test_app_username",
-                    "debug": True,
+                    "debug": "true",
                 },
             },
             "env": ProjectEnvironment(default_env={}, override_env={}),

--- a/tests/api/utils/test_definition_rendering.py
+++ b/tests/api/utils/test_definition_rendering.py
@@ -868,10 +868,10 @@ def test_defaults_native_app_pkg_name(
 )
 @mock.patch.dict(
     os.environ,
-    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "hehe"},
+    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "_suffix"},
     clear=True,
 )
-def test_identifier_suffixing(definition):
+def test_identifier_suffixing_defaults(definition):
     project_properties = render_definition_template(definition, {})
     project_definition = project_properties.project_definition
     if definition["definition_version"] == "1.1":
@@ -882,8 +882,29 @@ def test_identifier_suffixing(definition):
         # v2+
         app = project_definition.entities["myapp"].identifier
         package = project_definition.entities["mypackage"].identifier
-    assert app == "myapp_usernamehehe"
-    assert package == "myapp_pkg_usernamehehe"
+    assert app == "myapp_username_suffix"
+    assert package == "myapp_pkg_username_suffix"
+
+
+@mock.patch.dict(
+    os.environ,
+    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "_suffix"},
+    clear=True,
+)
+def test_identifier_suffixing_quoted_defaults():
+    definition = {
+        "definition_version": "1.1",
+        "native_app": {
+            "name": "my.app",
+            "artifacts": [],
+        },
+    }
+    project_properties = render_definition_template(definition, {})
+    project_definition = project_properties.project_definition
+    app = project_definition.native_app.application.name
+    package = project_definition.native_app.package.name
+    assert app == '"my.app_username_suffix"'
+    assert package == '"my.app_pkg_username_suffix"'
 
 
 @pytest.mark.parametrize(
@@ -892,8 +913,10 @@ def test_identifier_suffixing(definition):
         {
             "definition_version": "1.1",
             "native_app": {
-                "name": "my@app",
+                "name": "my.app",
                 "artifacts": [],
+                "package": {"name": "my.app_pkg_<% ctx.env.USER %>"},
+                "application": {"name": "my.app_<% ctx.env.USER %>"},
             },
         },
         {
@@ -901,12 +924,12 @@ def test_identifier_suffixing(definition):
             "entities": {
                 "myapp": {
                     "type": "application",
-                    "identifier": "my@app_<% ctx.env.USER %>",
+                    "identifier": "my.app_<% ctx.env.USER %>",
                     "from": {"target": "mypackage"},
                 },
                 "mypackage": {
                     "type": "application package",
-                    "identifier": "my@app_pkg_<% ctx.env.USER %>",
+                    "identifier": "my.app_pkg_<% ctx.env.USER %>",
                     "manifest": "manifest.xml",
                     "artifacts": [],
                 },
@@ -917,10 +940,10 @@ def test_identifier_suffixing(definition):
 )
 @mock.patch.dict(
     os.environ,
-    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "hehe!"},
+    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "_suffix!"},
     clear=True,
 )
-def test_identifier_suffixing_quoted(definition):
+def test_identifier_suffixing_quoted_explicit(definition):
     project_properties = render_definition_template(definition, {})
     project_definition = project_properties.project_definition
     if definition["definition_version"] == "1.1":
@@ -931,5 +954,52 @@ def test_identifier_suffixing_quoted(definition):
         # v2+
         app = project_definition.entities["myapp"].identifier
         package = project_definition.entities["mypackage"].identifier
-    assert app == '"my@app_usernamehehe!"'
-    assert package == '"my@app_pkg_usernamehehe!"'
+    assert app == "my.app_username_suffix!"
+    assert package == "my.app_pkg_username_suffix!"
+
+
+@mock.patch.dict(
+    os.environ,
+    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "_suffix"},
+    clear=True,
+)
+def test_identifier_suffixing_nested_refer_to_str():
+    definition = {
+        "definition_version": "1.1",
+        "native_app": {
+            "name": "myapp",
+            "artifacts": [],
+            # suffix is appended twice since we run validators before rendering on non-templated strings to get defaults
+            "package": {"name": "pkg"},
+            "application": {"name": "<% ctx.native_app.package.name %>_app"},
+        },
+    }
+    project_properties = render_definition_template(definition, {})
+    project_definition = project_properties.project_definition
+    app = project_definition.native_app.application.name
+    assert app == "pkg_suffix_app_suffix"  # suffix is added twice
+
+
+@pytest.mark.xfail(
+    reason="Suffix is not added twice. Validator is skipped before the render phase because the name is templated"
+)
+@mock.patch.dict(
+    os.environ,
+    {"USER": "username", "SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX": "_suffix"},
+    clear=True,
+)
+def test_identifier_suffixing_nested_refer_to_var():
+    definition = {
+        "definition_version": "1.1",
+        "native_app": {
+            "name": "myapp",
+            "artifacts": [],
+            # suffix is not appended twice since we skip validators on templated strings when we get defaults
+            "package": {"name": "pkg_<% ctx.env.USER %>"},
+            "application": {"name": "<% ctx.native_app.package.name %>_app"},
+        },
+    }
+    project_properties = render_definition_template(definition, {})
+    project_definition = project_properties.project_definition
+    app = project_definition.native_app.application.name
+    assert app == "pkg_username_suffix_app_suffix"

--- a/tests/nativeapp/test_project_model.py
+++ b/tests/nativeapp/test_project_model.py
@@ -24,7 +24,6 @@ import pytest
 import yaml
 from snowflake.cli._plugins.nativeapp.bundle_context import BundleContext
 from snowflake.cli._plugins.nativeapp.project_model import (
-    RESOURCE_SUFFIX_VAR,
     NativeAppProjectModel,
 )
 from snowflake.cli.api.project.definition import load_project
@@ -33,6 +32,7 @@ from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMappin
 from snowflake.cli.api.project.schemas.project_definition import (
     build_project_definition,
 )
+from snowflake.cli.api.project.util import TEST_RESOURCE_SUFFIX_VAR
 
 CURRENT_ROLE = "current_role"
 
@@ -86,7 +86,7 @@ def test_project_model_all_defaults(
 @mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")
 @mock.patch.dict(
     os.environ,
-    {"USER": "test_user", RESOURCE_SUFFIX_VAR: "_suffix!"},
+    {"USER": "test_user", TEST_RESOURCE_SUFFIX_VAR: "_suffix!"},
     clear=True,
 )
 def test_project_model_default_package_app_name_with_suffix(
@@ -185,7 +185,7 @@ def test_project_model_all_explicit(mock_connect, mock_ctx):
 @mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")
 @mock.patch.dict(
     os.environ,
-    {"USER": "test_user", RESOURCE_SUFFIX_VAR: "_suffix!"},
+    {"USER": "test_user", TEST_RESOURCE_SUFFIX_VAR: "_suffix!"},
     clear=True,
 )
 def test_project_model_explicit_package_app_name_with_suffix(

--- a/tests/test_data/projects/integration_external_v2/package/001-shared.sql
+++ b/tests/test_data/projects/integration_external_v2/package/001-shared.sql
@@ -1,5 +1,5 @@
 -- package script (1/2)
 
-create schema if not exists &{ ctx.entities.pkg.identifier }.my_shared_content;
-grant usage on schema &{ ctx.entities.pkg.identifier }.my_shared_content
-  to share in application package &{ ctx.entities.pkg.identifier };
+create schema if not exists &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content;
+grant usage on schema &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content
+  to share in application package &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX };

--- a/tests/test_data/projects/integration_external_v2/package/002-shared.sql
+++ b/tests/test_data/projects/integration_external_v2/package/002-shared.sql
@@ -1,12 +1,12 @@
 -- package script (2/2)
 
-create or replace table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (
+create or replace table &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table (
   col1 number,
   col2 varchar
 );
 
-insert into &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (col1, col2)
+insert into &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table (col1, col2)
   values (1, 'hello');
 
-grant select on table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table
-  to share in application package &{ ctx.entities.pkg.identifier };
+grant select on table &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table
+  to share in application package &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX };

--- a/tests/test_data/projects/integration_templated_v2/package/001-shared.sql
+++ b/tests/test_data/projects/integration_templated_v2/package/001-shared.sql
@@ -1,5 +1,5 @@
 -- package script (1/2)
 
-create schema if not exists &{ ctx.entities.pkg.identifier }.my_shared_content;
-grant usage on schema &{ ctx.entities.pkg.identifier }.my_shared_content
-  to share in application package &{ ctx.entities.pkg.identifier };
+create schema if not exists &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content;
+grant usage on schema &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content
+  to share in application package &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX };

--- a/tests/test_data/projects/integration_templated_v2/package/002-shared.sql
+++ b/tests/test_data/projects/integration_templated_v2/package/002-shared.sql
@@ -1,12 +1,12 @@
 -- package script (2/2)
 
-create or replace table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (
+create or replace table &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table (
   col1 number,
   col2 varchar
 );
 
-insert into &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (col1, col2)
+insert into &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table (col1, col2)
   values (1, 'hello');
 
-grant select on table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table
-  to share in application package &{ ctx.entities.pkg.identifier };
+grant select on table &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table
+  to share in application package &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX };

--- a/tests/test_data/projects/integration_v2/package/001-shared.sql
+++ b/tests/test_data/projects/integration_v2/package/001-shared.sql
@@ -1,5 +1,5 @@
 -- package script (1/2)
 
-create schema if not exists &{ ctx.entities.pkg.identifier }.my_shared_content;
-grant usage on schema &{ ctx.entities.pkg.identifier }.my_shared_content
-  to share in application package &{ ctx.entities.pkg.identifier };
+create schema if not exists &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content;
+grant usage on schema &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content
+  to share in application package &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX };

--- a/tests/test_data/projects/integration_v2/package/002-shared.sql
+++ b/tests/test_data/projects/integration_v2/package/002-shared.sql
@@ -1,12 +1,12 @@
 -- package script (2/2)
 
-create or replace table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (
+create or replace table &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table (
   col1 number,
   col2 varchar
 );
 
-insert into &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table (col1, col2)
+insert into &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table (col1, col2)
   values (1, 'hello');
 
-grant select on table &{ ctx.entities.pkg.identifier }.my_shared_content.shared_table
-  to share in application package &{ ctx.entities.pkg.identifier };
+grant select on table &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX }.my_shared_content.shared_table
+  to share in application package &{ ctx.entities.pkg.identifier }&{ ctx.env.SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX };

--- a/tests_integration/nativeapp/test_bundle.py
+++ b/tests_integration/nativeapp/test_bundle.py
@@ -15,18 +15,12 @@
 import os
 import os.path
 import yaml
-import uuid
-
-from snowflake.cli.api.project.util import generate_user_env
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import enable_definition_v2_feature_flag
 from tests_integration.testing_utils import (
     assert_that_result_failed_with_message_containing,
 )
-
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
 
 
 @pytest.fixture(scope="function", params=["napp_init_v1", "napp_init_v2"])
@@ -35,10 +29,7 @@ def template_setup(runner, project_directory, request):
     with enable_definition_v2_feature_flag:
         with project_directory(test_project) as project_root:
             # Vanilla bundle on the unmodified template
-            result = runner.invoke_json(
-                ["app", "bundle"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_json(["app", "bundle"])
             assert result.exit_code == 0
 
             # The newly created deploy_root is explicitly deleted here, as bundle should take care of it.
@@ -99,10 +90,7 @@ def test_nativeapp_bundle_does_explicit_copy(
         ],
     )
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 0
     assert not os.path.exists("app/snowflake.yml")
     app_path = Path("output", "deploy", "app")
@@ -142,10 +130,7 @@ def test_nativeapp_bundle_throws_error_due_to_project_root_deploy_root_mismatch(
 
     assert deploy_root_as_file.is_file()
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
 
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
@@ -170,10 +155,7 @@ def test_nativeapp_bundle_throws_error_due_to_project_root_deploy_root_mismatch(
         deploy_root=deploy_root,
     )
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
 
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
@@ -189,10 +171,7 @@ def test_nativeapp_bundle_throws_error_on_incorrect_src_glob(template_setup):
     # incorrect glob
     override_snowflake_yml_artifacts(definition_version, artifacts_section=["app/?"])
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
         result,
@@ -211,10 +190,7 @@ def test_nativeapp_bundle_throws_error_on_bad_src(template_setup):
         definition_version, artifacts_section=[f"{src_path}"]
     )
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
         result, "Source path must be a relative path"
@@ -230,10 +206,7 @@ def test_nativeapp_bundle_throws_error_on_bad_dest(template_setup):
         definition_version, artifacts_section=[{"src": "app/*", "dest": "/"}]
     )
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
         result, "The specified destination path is outside of the deploy root"
@@ -251,10 +224,7 @@ def test_nativeapp_bundle_throws_error_on_bad_dest(template_setup):
         ],
     )
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
         result, "Destination path must be a relative path"
@@ -274,10 +244,7 @@ def test_nativeapp_bundle_throws_error_on_too_many_files_to_dest(template_setup)
         ],
     )
 
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 1
     assert_that_result_failed_with_message_containing(
         result,
@@ -292,9 +259,6 @@ def test_nativeapp_bundle_deletes_existing_deploy_root(template_setup):
 
     existing_deploy_root_dest = Path(project_root, "output", "deploy", "dummy.txt")
     existing_deploy_root_dest.mkdir(parents=True, exist_ok=False)
-    result = runner.invoke_json(
-        ["app", "bundle"],
-        env=TEST_ENV,
-    )
+    result = runner.invoke_json(["app", "bundle"])
     assert result.exit_code == 0
     assert not existing_deploy_root_dest.exists()

--- a/tests_integration/nativeapp/test_debug_mode.py
+++ b/tests_integration/nativeapp/test_debug_mode.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import yaml
-import uuid
 from typing import Optional
 
-from snowflake.cli.api.project.util import generate_user_env
 from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.errors import ProgrammingError
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import pushd, enable_definition_v2_feature_flag
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
+USER_NAME = os.environ.get("USER", "")
 
 
 class ApplicationNotFoundError(Exception):
@@ -93,6 +91,7 @@ def set_yml_application_debug(snowflake_yml: Path, debug: Optional[bool]):
 def test_nativeapp_controlled_debug_mode(
     runner,
     snowflake_session,
+    resource_suffix,
     project_definition_files: List[Path],
 ):
     project_name = "integration"
@@ -105,15 +104,12 @@ def test_nativeapp_controlled_debug_mode(
         assert "debug:" not in snowflake_yml.read_text()
 
         # make sure the app doesn't (yet) exist
-        app_name = f"{project_name}_{USER_NAME}".upper()
+        app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
         with pytest.raises(ApplicationNotFoundError):
             is_debug_mode(snowflake_session, app_name)
 
         # deploy the application
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
         try:
@@ -123,17 +119,13 @@ def test_nativeapp_controlled_debug_mode(
 
             # let's set debug mode to false out-of-band
             result = runner.invoke_with_connection_json(
-                ["sql", "-q", f"alter application {app_name} set debug_mode = false"],
-                env=TEST_ENV,
+                ["sql", "-q", f"alter application {app_name} set debug_mode = false"]
             )
             assert result.exit_code == 0
             assert not is_debug_mode(snowflake_session, app_name)
 
             # re-deploying the app should not change debug mode
-            result = runner.invoke_with_connection_json(
-                ["app", "run"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "run"])
             assert result.exit_code == 0
             assert not is_debug_mode(snowflake_session, app_name)
 
@@ -142,24 +134,15 @@ def test_nativeapp_controlled_debug_mode(
             assert "debug:" in snowflake_yml.read_text()
 
             # now, re-deploying the app will set debug_mode to true
-            result = runner.invoke_with_connection_json(
-                ["app", "run"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "run"])
             assert result.exit_code == 0
             assert is_debug_mode(snowflake_session, app_name)
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_debug_mode.py
+++ b/tests_integration/nativeapp/test_debug_mode.py
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
 from typing import Optional
 
+import yaml
 from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.errors import ProgrammingError
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import pushd, enable_definition_v2_feature_flag
-
-USER_NAME = os.environ.get("USER", "")
 
 
 class ApplicationNotFoundError(Exception):
@@ -91,6 +88,7 @@ def set_yml_application_debug(snowflake_yml: Path, debug: Optional[bool]):
 def test_nativeapp_controlled_debug_mode(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -104,7 +102,7 @@ def test_nativeapp_controlled_debug_mode(
         assert "debug:" not in snowflake_yml.read_text()
 
         # make sure the app doesn't (yet) exist
-        app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+        app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
         with pytest.raises(ApplicationNotFoundError):
             is_debug_mode(snowflake_session, app_name)
 

--- a/tests_integration/nativeapp/test_deploy.py
+++ b/tests_integration/nativeapp/test_deploy.py
@@ -30,14 +30,12 @@ from tests_integration.testing_utils import (
     assert_that_result_is_usage_error,
 )
 
-USER_NAME = os.environ.get("USER", "")
-
 
 @pytest.fixture
-def sanitize_deploy_output(resource_suffix):
+def sanitize_deploy_output(default_username, resource_suffix):
     def _sanitize_deploy_output(output):
         deploy_root = Path("output/deploy").resolve()
-        user_and_suffix = f"{USER_NAME}{resource_suffix}"
+        user_and_suffix = f"{default_username}{resource_suffix}"
         return output.replace(user_and_suffix, "@@USER@@").replace(
             str(deploy_root), "@@DEPLOY_ROOT@@"
         )
@@ -54,6 +52,7 @@ def test_nativeapp_deploy(
     project_directory,
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
     snapshot,
@@ -67,8 +66,10 @@ def test_nativeapp_deploy(
 
         try:
             # package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -133,6 +134,7 @@ def test_nativeapp_deploy_prune(
     runner,
     snapshot,
     print_paths_as_posix,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
@@ -151,7 +153,9 @@ def test_nativeapp_deploy_prune(
             assert sanitize_deploy_output(result.output) == snapshot
 
             # verify the file does not exist on the stage
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
                 ["stage", "list-files", f"{package_name}.{stage_name}"]
@@ -181,6 +185,7 @@ def test_nativeapp_deploy_files(
     runner,
     snapshot,
     print_paths_as_posix,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
@@ -201,7 +206,9 @@ def test_nativeapp_deploy_files(
 
         try:
             # manifest and script files exist, readme doesn't exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
                 ["stage", "list-files", f"{package_name}.{stage_name}"]
@@ -232,6 +239,7 @@ def test_nativeapp_deploy_nested_directories(
     runner,
     snapshot,
     print_paths_as_posix,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
@@ -247,7 +255,9 @@ def test_nativeapp_deploy_nested_directories(
         assert sanitize_deploy_output(result.output) == snapshot
 
         try:
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
                 ["stage", "list-files", f"{package_name}.{stage_name}"]
@@ -274,6 +284,7 @@ def test_nativeapp_deploy_directory(
     test_project,
     project_directory,
     runner,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
@@ -293,7 +304,9 @@ def test_nativeapp_deploy_directory(
         assert result.exit_code == 0
 
         try:
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
                 ["stage", "list-files", f"{package_name}.{stage_name}"]
@@ -418,6 +431,7 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
     runner,
     snapshot,
     print_paths_as_posix,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
@@ -429,7 +443,9 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
             assert result.exit_code == 0
             assert sanitize_deploy_output(result.output) == snapshot
 
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
                 ["stage", "list-files", f"{package_name}.{stage_name}"]
@@ -510,6 +526,7 @@ def test_nativeapp_deploy_dot(
     runner,
     snapshot,
     print_paths_as_posix,
+    default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
@@ -520,7 +537,9 @@ def test_nativeapp_deploy_dot(
             assert result.exit_code == 0
             assert sanitize_deploy_output(result.output) == snapshot
 
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
                 ["stage", "list-files", f"{package_name}.{stage_name}"]

--- a/tests_integration/nativeapp/test_deploy.py
+++ b/tests_integration/nativeapp/test_deploy.py
@@ -15,10 +15,7 @@
 import os
 import uuid
 
-from snowflake.cli._plugins.nativeapp.project_model import RESOURCE_SUFFIX_VAR
-from snowflake.cli.api.project.util import generate_user_env
-
-
+from snowflake.cli.api.project.util import TEST_RESOURCE_SUFFIX_VAR
 from tests.nativeapp.utils import touch
 
 from tests.project.fixtures import *
@@ -33,15 +30,19 @@ from tests_integration.testing_utils import (
     assert_that_result_is_usage_error,
 )
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
+USER_NAME = os.environ.get("USER", "")
 
 
-def sanitize_deploy_output(output):
-    deploy_root = Path("output/deploy").resolve()
-    return output.replace(USER_NAME, "@@USER@@").replace(
-        str(deploy_root), "@@DEPLOY_ROOT@@"
-    )
+@pytest.fixture
+def sanitize_deploy_output(resource_suffix):
+    def _sanitize_deploy_output(output):
+        deploy_root = Path("output/deploy").resolve()
+        user_and_suffix = f"{USER_NAME}{resource_suffix}"
+        return output.replace(user_and_suffix, "@@USER@@").replace(
+            str(deploy_root), "@@DEPLOY_ROOT@@"
+        )
+
+    return _sanitize_deploy_output
 
 
 # Tests a simple flow of executing "snow app deploy", verifying that an application package was created, and an application was not
@@ -53,22 +54,21 @@ def test_nativeapp_deploy(
     project_directory,
     runner,
     snowflake_session,
+    resource_suffix,
+    sanitize_deploy_output,
     snapshot,
     print_paths_as_posix,
 ):
     project_name = "myapp"
     with project_directory(test_project):
-        result = runner.invoke_with_connection(
-            ["app", "deploy"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection(["app", "deploy"])
         assert result.exit_code == 0
         assert sanitize_deploy_output(result.output) == snapshot
 
         try:
             # package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -81,8 +81,7 @@ def test_nativeapp_deploy(
             # manifest file exists
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
 
@@ -97,100 +96,13 @@ def test_nativeapp_deploy(
             )
 
             # re-deploying should be a no-op; make sure we don't issue any PUT commands
-            result = runner.invoke_with_connection_json(
-                ["app", "deploy", "--debug"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "deploy", "--debug"])
             assert result.exit_code == 0
             assert "Successfully uploaded chunk 0 of file" not in result.output
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
-            assert result.exit_code == 0
-
-
-@pytest.mark.integration
-@enable_definition_v2_feature_flag
-@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_nativeapp_deploy_with_resource_suffix(
-    test_project,
-    project_directory,
-    runner,
-    snowflake_session,
-):
-    suffix = f"_some_suffix_{uuid.uuid4().hex}"
-    test_env_with_suffix = TEST_ENV | {RESOURCE_SUFFIX_VAR: suffix}
-    with project_directory(test_project):
-        result = runner.invoke_with_connection(
-            ["app", "deploy"],
-            env=test_env_with_suffix,
-        )
-        assert result.exit_code == 0
-
-        try:
-            # package exist
-            assert row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"show application packages like '%{suffix}'",
-                )
-            )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=test_env_with_suffix,
-            )
-            assert result.exit_code == 0
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=test_env_with_suffix,
-            )
-            assert result.exit_code == 0
-
-
-@pytest.mark.integration
-@enable_definition_v2_feature_flag
-@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_nativeapp_deploy_with_resource_suffix_quoted(
-    test_project,
-    project_directory,
-    runner,
-    snowflake_session,
-):
-    suffix = f"_must.be.quoted!!!_{uuid.uuid4().hex}"
-    test_env_with_quoted_suffix = TEST_ENV | {RESOURCE_SUFFIX_VAR: suffix}
-    with project_directory(test_project):
-        result = runner.invoke_with_connection(
-            ["app", "deploy"],
-            env=test_env_with_quoted_suffix,
-        )
-        assert result.exit_code == 0
-
-        try:
-            # package exist
-            assert row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"show application packages like '%{suffix}'",
-                )
-            )
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=test_env_with_quoted_suffix,
-            )
-            assert result.exit_code == 0
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=test_env_with_quoted_suffix,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -221,13 +133,12 @@ def test_nativeapp_deploy_prune(
     runner,
     snapshot,
     print_paths_as_posix,
+    resource_suffix,
+    sanitize_deploy_output,
 ):
     project_name = "myapp"
     with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "deploy"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "deploy"])
         assert result.exit_code == 0
 
         try:
@@ -235,19 +146,15 @@ def test_nativeapp_deploy_prune(
             os.remove(os.path.join("app", "README.md"))
 
             # deploy
-            result = runner.invoke_with_connection(
-                command.split(),
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(command.split())
             assert result.exit_code == 0
             assert sanitize_deploy_output(result.output) == snapshot
 
             # verify the file does not exist on the stage
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             for name in contains:
                 assert contains_row_with(stage_files.json, {"name": name})
@@ -255,18 +162,12 @@ def test_nativeapp_deploy_prune(
                 assert not_contains_row_with(stage_files.json, {"name": name})
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -280,6 +181,8 @@ def test_nativeapp_deploy_files(
     runner,
     snapshot,
     print_paths_as_posix,
+    resource_suffix,
+    sanitize_deploy_output,
 ):
     project_name = "myapp"
     with project_directory(test_project):
@@ -291,19 +194,17 @@ def test_nativeapp_deploy_files(
                 "app/manifest.yml",
                 "app/setup_script.sql",
                 "--no-validate",
-            ],
-            env=TEST_ENV,
+            ]
         )
         assert result.exit_code == 0
         assert sanitize_deploy_output(result.output) == snapshot
 
         try:
             # manifest and script files exist, readme doesn't exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
             assert contains_row_with(
@@ -312,18 +213,12 @@ def test_nativeapp_deploy_files(
             assert not_contains_row_with(stage_files.json, {"name": "stage/README.md"})
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -337,6 +232,8 @@ def test_nativeapp_deploy_nested_directories(
     runner,
     snapshot,
     print_paths_as_posix,
+    resource_suffix,
+    sanitize_deploy_output,
 ):
     project_name = "myapp"
     with project_directory(test_project):
@@ -344,36 +241,28 @@ def test_nativeapp_deploy_nested_directories(
         touch("app/nested/dir/file.txt")
 
         result = runner.invoke_with_connection(
-            ["app", "deploy", "app/nested/dir/file.txt", "--no-validate"],
-            env=TEST_ENV,
+            ["app", "deploy", "app/nested/dir/file.txt", "--no-validate"]
         )
         assert result.exit_code == 0
         assert sanitize_deploy_output(result.output) == snapshot
 
         try:
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(
                 stage_files.json, {"name": "stage/nested/dir/file.txt"}
             )
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -385,46 +274,39 @@ def test_nativeapp_deploy_directory(
     test_project,
     project_directory,
     runner,
+    resource_suffix,
+    sanitize_deploy_output,
 ):
     project_name = "myapp"
     with project_directory(test_project):
         touch("app/dir/file.txt")
         result = runner.invoke_with_connection(
-            ["app", "deploy", "app/dir", "--no-recursive", "--no-validate"],
-            env=TEST_ENV,
+            ["app", "deploy", "app/dir", "--no-recursive", "--no-validate"]
         )
         assert_that_result_failed_with_message_containing(
             result, "Add the -r flag to deploy directories."
         )
 
         result = runner.invoke_with_connection(
-            ["app", "deploy", "app/dir", "-r", "--no-validate"],
-            env=TEST_ENV,
+            ["app", "deploy", "app/dir", "-r", "--no-validate"]
         )
         assert result.exit_code == 0
 
         try:
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(stage_files.json, {"name": "stage/dir/file.txt"})
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -441,17 +323,13 @@ def test_nativeapp_deploy_directory_no_recursive(
         try:
             touch("app/nested/dir/file.txt")
             result = runner.invoke_with_connection_json(
-                ["app", "deploy", "app/nested", "--no-validate"],
-                env=TEST_ENV,
+                ["app", "deploy", "app/nested", "--no-validate"]
             )
             assert result.exit_code == 1, result.output
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -467,18 +345,14 @@ def test_nativeapp_deploy_unknown_path(
     with project_directory(test_project):
         try:
             result = runner.invoke_with_connection_json(
-                ["app", "deploy", "does_not_exist", "--no-validate"],
-                env=TEST_ENV,
+                ["app", "deploy", "does_not_exist", "--no-validate"]
             )
             assert result.exit_code == 1
             assert "The following path does not exist:" in result.output
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -494,18 +368,14 @@ def test_nativeapp_deploy_path_with_no_mapping(
     with project_directory(test_project):
         try:
             result = runner.invoke_with_connection_json(
-                ["app", "deploy", "snowflake.yml", "--no-validate"],
-                env=TEST_ENV,
+                ["app", "deploy", "snowflake.yml", "--no-validate"]
             )
             assert result.exit_code == 1
             assert "No artifact found for" in result.output
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -522,8 +392,7 @@ def test_nativeapp_deploy_rejects_pruning_when_path_is_specified(
         try:
             os.unlink("app/README.md")
             result = runner.invoke_with_connection_json(
-                ["app", "deploy", "app/README.md", "--prune"],
-                env=TEST_ENV,
+                ["app", "deploy", "app/README.md", "--prune"]
             )
 
             assert_that_result_is_usage_error(
@@ -533,10 +402,7 @@ def test_nativeapp_deploy_rejects_pruning_when_path_is_specified(
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -552,23 +418,21 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
     runner,
     snapshot,
     print_paths_as_posix,
+    resource_suffix,
+    sanitize_deploy_output,
 ):
     project_name = "myapp"
 
     with project_directory(test_project):
         try:
-            result = runner.invoke_with_connection(
-                ["app", "deploy", "-r", "app"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "deploy", "-r", "app"])
             assert result.exit_code == 0
             assert sanitize_deploy_output(result.output) == snapshot
 
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
             assert contains_row_with(
@@ -583,13 +447,11 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
             )
 
             result = runner.invoke_with_connection(
-                ["app", "deploy", "-r", "lib/parent/child/c"],
-                env=TEST_ENV,
+                ["app", "deploy", "-r", "lib/parent/child/c"]
             )
             assert result.exit_code == 0
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(
                 stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
@@ -602,13 +464,11 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
             )
 
             result = runner.invoke_with_connection(
-                ["app", "deploy", "lib/parent/child/a.py"],
-                env=TEST_ENV,
+                ["app", "deploy", "lib/parent/child/a.py"]
             )
             assert result.exit_code == 0
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(
                 stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
@@ -620,14 +480,10 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
                 stage_files.json, {"name": "stage/parent-lib/child/b.py"}
             )
 
-            result = runner.invoke_with_connection(
-                ["app", "deploy", "lib", "-r"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "deploy", "lib", "-r"])
             assert result.exit_code == 0
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(
                 stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
@@ -640,10 +496,7 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
             )
 
         finally:
-            result = runner.invoke_with_connection(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -657,22 +510,20 @@ def test_nativeapp_deploy_dot(
     runner,
     snapshot,
     print_paths_as_posix,
+    resource_suffix,
+    sanitize_deploy_output,
 ):
     project_name = "myapp"
     with project_directory(test_project):
         try:
-            result = runner.invoke_with_connection(
-                ["app", "deploy", "-r", "."],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "deploy", "-r", "."])
             assert result.exit_code == 0
             assert sanitize_deploy_output(result.output) == snapshot
 
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
             stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
             stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"],
-                env=TEST_ENV,
+                ["stage", "list-files", f"{package_name}.{stage_name}"]
             )
             assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
             assert contains_row_with(
@@ -681,8 +532,5 @@ def test_nativeapp_deploy_dot(
             assert contains_row_with(stage_files.json, {"name": "stage/README.md"})
 
         finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
-
-from snowflake.cli.api.project.util import generate_user_env
 from tests.project.fixtures import *
 from tests_integration.test_utils import enable_definition_v2_feature_flag
 from tests_integration.testing_utils import assert_that_result_is_usage_error
-
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
 
 
 # Tests that snow app events with incompatible flags exits with an error
@@ -50,10 +44,7 @@ def test_app_events_mutually_exclusive_options(
     with project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
-        result = runner.invoke_with_connection(
-            ["app", "events", *command],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection(["app", "events", *command])
         assert_that_result_is_usage_error(
             result,
             f"Parameters '{flag_names[0]}' and '{flag_names[1]}' are incompatible and cannot be used simultaneously.",
@@ -83,10 +74,7 @@ def test_app_events_paired_options(
     with project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
-        result = runner.invoke_with_connection(
-            ["app", "events", *command],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection(["app", "events", *command])
         assert_that_result_is_usage_error(
             result,
             f"Parameters '{flag_names[0]}' and '{flag_names[1]}' are incompatible and cannot be used simultaneously.",
@@ -100,9 +88,6 @@ def test_app_events_reject_invalid_type(test_project, runner, project_directory)
     with project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
-        result = runner.invoke_with_connection(
-            ["app", "events", "--type", "foo"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection(["app", "events", "--type", "foo"])
         assert result.exit_code == 2, result.output
         assert "Invalid value for '--type'" in result.output

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -15,7 +15,6 @@ import os
 import uuid
 
 from snowflake.cli._plugins.nativeapp.init import OFFICIAL_TEMPLATES_GITHUB_URL
-from snowflake.cli.api.project.util import TEST_RESOURCE_SUFFIX_VAR
 from snowflake.cli.api.secure_path import SecurePath
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
@@ -26,7 +25,6 @@ from tests_integration.test_utils import (
     enable_definition_v2_feature_flag,
 )
 
-USER_NAME = os.environ.get("USER", "")
 
 # Tests a simple flow of initiating a new project, executing snow app run and teardown, all with distribution=internal
 @pytest.mark.integration
@@ -37,6 +35,7 @@ def test_nativeapp_init_run_without_modifications(
     project_directory,
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
 ):
     project_name = "myapp"
@@ -46,8 +45,10 @@ def test_nativeapp_init_run_without_modifications(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -82,7 +83,11 @@ def test_nativeapp_init_run_without_modifications(
     "project_definition_files", ["integration", "integration_v2"], indirect=True
 )
 def test_nativeapp_run_existing(
-    runner, snowflake_session, project_definition_files: List[Path], resource_suffix
+    runner,
+    snowflake_session,
+    project_definition_files: List[Path],
+    default_username,
+    resource_suffix,
 ):
     project_name = "integration"
     project_dir = project_definition_files[0].parent
@@ -92,8 +97,10 @@ def test_nativeapp_run_existing(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -145,7 +152,12 @@ def test_nativeapp_run_existing(
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_init_run_handles_spaces(
-    test_project, project_directory, runner, snowflake_session, resource_suffix
+    test_project,
+    project_directory,
+    runner,
+    snowflake_session,
+    default_username,
+    resource_suffix,
 ):
     project_name = "myapp"
     with project_directory(test_project):
@@ -154,8 +166,10 @@ def test_nativeapp_init_run_handles_spaces(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -192,7 +206,11 @@ def test_nativeapp_init_run_handles_spaces(
     indirect=True,
 )
 def test_nativeapp_run_existing_w_external(
-    runner, snowflake_session, project_definition_files: List[Path], resource_suffix
+    runner,
+    snowflake_session,
+    project_definition_files: List[Path],
+    default_username,
+    resource_suffix,
 ):
     project_name = "integration_external"
     project_dir = project_definition_files[0].parent
@@ -202,8 +220,10 @@ def test_nativeapp_run_existing_w_external(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -282,11 +302,11 @@ def test_nativeapp_run_existing_w_external(
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_run_after_deploy(
-    test_project, project_directory, runner, resource_suffix
+    test_project, project_directory, runner, default_username, resource_suffix
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
-    stage_fqn = f"{project_name}_pkg_{USER_NAME}{resource_suffix}.app_src.stage"
+    app_name = f"{project_name}_{default_username}{resource_suffix}"
+    stage_fqn = f"{project_name}_pkg_{default_username}{resource_suffix}.app_src.stage"
 
     with project_directory(test_project):
         try:
@@ -368,6 +388,7 @@ def test_nativeapp_run_orphan(
     snowflake_session,
     project_definition_files: List[Path],
     force_flag,
+    default_username,
     resource_suffix,
 ):
     project_name = "integration"
@@ -378,8 +399,10 @@ def test_nativeapp_run_orphan(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -403,8 +426,10 @@ def test_nativeapp_run_orphan(
             assert result.exit_code == 0, result.output
 
             # package doesn't exist, app not readable
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             assert not_contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -496,11 +521,12 @@ def test_nativeapp_force_cross_upgrade(
     run_args_from,
     run_args_to,
     runner,
+    default_username,
     resource_suffix,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
-    pkg_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}"
+    app_name = f"{project_name}_{default_username}{resource_suffix}"
+    pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
     with project_directory(test_project):
         try:

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -11,15 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import uuid
 
-from snowflake.cli._plugins.nativeapp.project_model import RESOURCE_SUFFIX_VAR
-from snowflake.cli.api.project.util import generate_user_env
-from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli._plugins.nativeapp.init import OFFICIAL_TEMPLATES_GITHUB_URL
-
+from snowflake.cli.api.project.util import TEST_RESOURCE_SUFFIX_VAR
+from snowflake.cli.api.secure_path import SecurePath
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
     pushd,
@@ -28,13 +25,8 @@ from tests_integration.test_utils import (
     row_from_snowflake_session,
     enable_definition_v2_feature_flag,
 )
-from tests_integration.testing_utils.working_directory_utils import (
-    WorkingDirectoryChanger,
-)
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
-
+USER_NAME = os.environ.get("USER", "")
 
 # Tests a simple flow of initiating a new project, executing snow app run and teardown, all with distribution=internal
 @pytest.mark.integration
@@ -45,19 +37,17 @@ def test_nativeapp_init_run_without_modifications(
     project_directory,
     runner,
     snowflake_session,
+    resource_suffix,
 ):
     project_name = "myapp"
     with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -76,112 +66,12 @@ def test_nativeapp_init_run_without_modifications(
             )
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
-            assert result.exit_code == 0
-
-
-@pytest.mark.integration
-@enable_definition_v2_feature_flag
-@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_nativeapp_init_run_with_resource_suffix(
-    test_project,
-    project_directory,
-    runner,
-    snowflake_session,
-):
-    suffix = f"_some_suffix_{uuid.uuid4().hex}"
-    test_env_with_suffix = TEST_ENV | {RESOURCE_SUFFIX_VAR: suffix}
-    with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=test_env_with_suffix,
-        )
-        assert result.exit_code == 0
-
-        try:
-            # app + package exist
-            assert row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"show application packages like '%{suffix}'",
-                )
-            )
-            assert row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"show applications like '%{suffix}'",
-                )
-            )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=test_env_with_suffix,
-            )
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=test_env_with_suffix,
-            )
-            assert result.exit_code == 0
-
-
-@pytest.mark.integration
-@enable_definition_v2_feature_flag
-@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_nativeapp_init_run_with_resource_suffix_quoted(
-    test_project,
-    project_directory,
-    runner,
-    snowflake_session,
-):
-    suffix = f"_must.be.quoted!!!_{uuid.uuid4().hex}"
-    test_env_with_quoted_suffix = TEST_ENV | {RESOURCE_SUFFIX_VAR: suffix}
-    with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=test_env_with_quoted_suffix,
-        )
-        assert result.exit_code == 0
-
-        try:
-            # app + package exist
-            assert row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"show application packages like '%{suffix}'",
-                )
-            )
-            assert row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"show applications like '%{suffix}'",
-                )
-            )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=test_env_with_quoted_suffix,
-            )
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=test_env_with_quoted_suffix,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -192,23 +82,18 @@ def test_nativeapp_init_run_with_resource_suffix_quoted(
     "project_definition_files", ["integration", "integration_v2"], indirect=True
 )
 def test_nativeapp_run_existing(
-    runner,
-    snowflake_session,
-    project_definition_files: List[Path],
+    runner, snowflake_session, project_definition_files: List[Path], resource_suffix
 ):
     project_name = "integration"
     project_dir = project_definition_files[0].parent
     with pushd(project_dir):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -246,18 +131,12 @@ def test_nativeapp_run_existing(
             )
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -266,23 +145,17 @@ def test_nativeapp_run_existing(
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_init_run_handles_spaces(
-    test_project,
-    project_directory,
-    runner,
-    snowflake_session,
+    test_project, project_directory, runner, snowflake_session, resource_suffix
 ):
     project_name = "myapp"
     with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -301,18 +174,12 @@ def test_nativeapp_init_run_handles_spaces(
             )
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -325,23 +192,18 @@ def test_nativeapp_init_run_handles_spaces(
     indirect=True,
 )
 def test_nativeapp_run_existing_w_external(
-    runner,
-    snowflake_session,
-    project_definition_files: List[Path],
+    runner, snowflake_session, project_definition_files: List[Path], resource_suffix
 ):
     project_name = "integration_external"
     project_dir = project_definition_files[0].parent
     with pushd(project_dir):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -392,10 +254,7 @@ def test_nativeapp_run_existing_w_external(
             )
 
             # make sure we always delete the app, --force required for external distribution
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
             expect = snowflake_session.execute_string(
@@ -414,10 +273,7 @@ def test_nativeapp_run_existing_w_external(
 
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -426,37 +282,26 @@ def test_nativeapp_run_existing_w_external(
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_run_after_deploy(
-    test_project,
-    project_directory,
-    runner,
+    test_project, project_directory, runner, resource_suffix
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}"
-    stage_fqn = f"{project_name}_pkg_{USER_NAME}.app_src.stage"
+    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
+    stage_fqn = f"{project_name}_pkg_{USER_NAME}{resource_suffix}.app_src.stage"
 
     with project_directory(test_project):
         try:
             # Run #1
-            result = runner.invoke_with_connection_json(
-                ["app", "run"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "run"])
             assert result.exit_code == 0
 
             # Make a change & deploy
             with open("app/README.md", "a") as file:
                 file.write("### Test")
-            result = runner.invoke_with_connection_json(
-                ["app", "deploy"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "deploy"])
             assert result.exit_code == 0
 
             # Run #2
-            result = runner.invoke_with_connection_json(
-                ["app", "run", "--debug"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "run", "--debug"])
             assert result.exit_code == 0
             assert (
                 f"alter application {app_name} upgrade using @{stage_fqn}"
@@ -464,10 +309,7 @@ def test_nativeapp_run_after_deploy(
             )
 
         finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -507,8 +349,7 @@ def test_nativeapp_init_from_repo_with_single_template(
                     "--template-repo",
                     f"file://{single_template_repo_path.path}",
                     project_name,
-                ],
-                env=TEST_ENV,
+                ]
             )
             assert result.exit_code == 0
         finally:
@@ -527,20 +368,18 @@ def test_nativeapp_run_orphan(
     snowflake_session,
     project_definition_files: List[Path],
     force_flag,
+    resource_suffix,
 ):
     project_name = "integration"
     project_dir = project_definition_files[0].parent
     with pushd(project_dir):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
         try:
             # app + package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -559,14 +398,13 @@ def test_nativeapp_run_orphan(
             )
 
             result = runner.invoke_with_connection(
-                ["sql", "-q", f"drop application package {package_name}"],
-                env=TEST_ENV,
+                ["sql", "-q", f"drop application package {package_name}"]
             )
             assert result.exit_code == 0, result.output
 
             # package doesn't exist, app not readable
-            package_name = f"{project_name}_pkg_{USER_NAME}".upper()
-            app_name = f"{project_name}_{USER_NAME}".upper()
+            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
             assert not_contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -590,7 +428,7 @@ def test_nativeapp_run_orphan(
             else:
                 command = ["app", "run", "--interactive"]  # show prompt in tests
                 _input = "y\n"  # yes to drop app
-            result = runner.invoke_with_connection(command, input=_input, env=TEST_ENV)
+            result = runner.invoke_with_connection(command, input=_input)
             assert result.exit_code == 0, result.output
             if not force_flag:
                 assert (
@@ -617,25 +455,18 @@ def test_nativeapp_run_orphan(
             )
 
             # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown"])
             assert result.exit_code == 0
 
         finally:
             # manually drop the application in case the test failed and it wasn't dropped
             result = runner.invoke_with_connection(
-                ["sql", "-q", f"drop application if exists {app_name} cascade"],
-                env=TEST_ENV,
+                ["sql", "-q", f"drop application if exists {app_name} cascade"]
             )
             assert result.exit_code == 0, result.output
 
             # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -665,18 +496,16 @@ def test_nativeapp_force_cross_upgrade(
     run_args_from,
     run_args_to,
     runner,
+    resource_suffix,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}"
-    pkg_name = f"{project_name}_pkg_{USER_NAME}"
+    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
+    pkg_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}"
 
     with project_directory(test_project):
         try:
             # Create version
-            result = runner.invoke_with_connection(
-                ["app", "version", "create", "v1"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "version", "create", "v1"])
             assert result.exit_code == 0
 
             # Set default release directive
@@ -685,23 +514,18 @@ def test_nativeapp_force_cross_upgrade(
                     "sql",
                     "-q",
                     f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
-                ],
-                env=TEST_ENV,
+                ]
             )
             assert result.exit_code == 0
 
             # Initial run
-            result = runner.invoke_with_connection(
-                ["app", "run"] + run_args_from,
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "run"] + run_args_from)
             assert result.exit_code == 0
 
             # (Cross-)upgrade
             is_cross_upgrade = run_args_from != run_args_to
             result = runner.invoke_with_connection(
-                ["app", "run"] + run_args_to + ["--force"],
-                env=TEST_ENV,
+                ["app", "run"] + run_args_to + ["--force"]
             )
             assert result.exit_code == 0
             if is_cross_upgrade:
@@ -709,8 +533,5 @@ def test_nativeapp_force_cross_upgrade(
 
         finally:
             # Drop the package
-            result = runner.invoke_with_connection(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "teardown", "--force"])
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_large_upload.py
+++ b/tests_integration/nativeapp/test_large_upload.py
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
 import os
-from unittest import mock
 
-from snowflake.cli.api.project.util import generate_user_env
-from snowflake.connector.constants import S3_CHUNK_SIZE
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli._plugins.nativeapp.manager import NativeAppManager
@@ -29,30 +25,9 @@ from snowflake.cli._plugins.stage.md5 import parse_multipart_md5sum
 from tests.project.fixtures import *
 from tests_integration.test_utils import pushd, enable_definition_v2_feature_flag
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
 
 THRESHOLD_BYTES: int | None = None  # if set, passes this option with PUT
 TEMP_FILE_SIZE_BYTES = 200 * 1024 * 1024
-
-from contextlib import contextmanager
-
-
-@contextmanager
-def mocked_testenv():
-    """
-    Mocks all ways we can extract env vars to ensure our ctx.env is correct.
-    """
-    from os import getenv as original_getenv
-
-    def mock_getenv(key: str, default: str | None = None) -> str | None:
-        if key.lower() == "user":
-            return USER_NAME
-        return original_getenv(key, default)
-
-    with mock.patch.dict(os.environ, {"USER": USER_NAME}):  # for DefinitionManager
-        with mock.patch("os.getenv", side_effect=mock_getenv):  # for ctx.env
-            yield
 
 
 @pytest.mark.skip(
@@ -74,67 +49,54 @@ def test_large_upload_skips_reupload(
     """
     project_dir = project_definition_files[0].parent
     with pushd(project_dir):
-        with mocked_testenv():
-            # figure out what the source stage is resolved to
-            dm = DefinitionManager(project_dir)
-            native_app = (
-                dm.project_definition.native_app
-                if hasattr(dm.project_definition, "native_app")
-                else _pdf_v2_to_v1(dm.project_definition).native_app
-            )
-            stage_fqn = NativeAppManager(native_app, project_dir).stage_fqn
+        # figure out what the source stage is resolved to
+        dm = DefinitionManager(project_dir)
+        native_app = (
+            dm.project_definition.native_app
+            if hasattr(dm.project_definition, "native_app")
+            else _pdf_v2_to_v1(dm.project_definition).native_app
+        )
+        stage_fqn = NativeAppManager(native_app, project_dir).stage_fqn
 
-            # deploy the application package
+        # deploy the application package
+        result = runner.invoke_with_connection_json(["app", "deploy"])
+        assert result.exit_code == 0
+
+        temp_file = project_dir / "app" / "big.file"
+        try:
+            # generate a binary file w/random bytes and upload it in multi-part
+            with SecurePath(temp_file).open("wb") as f:
+                f.write(os.urandom(TEMP_FILE_SIZE_BYTES))
+
+            put_command = f"put file://{temp_file.resolve()} @{stage_fqn}/ auto_compress=false parallel=4 overwrite=True"
+            if THRESHOLD_BYTES is not None:
+                put_command += f" threshold={THRESHOLD_BYTES}"
+
+            snowflake_session.execute_string(put_command)
+
+            # ensure that there is, in fact, a file with a multi-part md5sum
             result = runner.invoke_with_connection_json(
-                ["app", "deploy"],
-                env=TEST_ENV,
+                ["stage", "list-files", stage_fqn]
             )
             assert result.exit_code == 0
+            assert isinstance(result.json, list)
+            assert any(
+                [parse_multipart_md5sum(row["md5"]) is not None for row in result.json]
+            )
 
-            temp_file = project_dir / "app" / "big.file"
-            try:
-                # generate a binary file w/random bytes and upload it in multi-part
-                with SecurePath(temp_file).open("wb") as f:
-                    f.write(os.urandom(TEMP_FILE_SIZE_BYTES))
+            # ensure that diff shows there is nothing to re-upload
+            result = runner.invoke_with_connection_json(["app", "diff"])
+            assert result.exit_code == 0
+            assert result.json == {
+                "modified": [],
+                "added": [],
+                "deleted": [],
+            }
 
-                put_command = f"put file://{temp_file.resolve()} @{stage_fqn}/ auto_compress=false parallel=4 overwrite=True"
-                if THRESHOLD_BYTES is not None:
-                    put_command += f" threshold={THRESHOLD_BYTES}"
+        finally:
+            # make sure our file has been deleted
+            temp_file.unlink(missing_ok=True)
 
-                snowflake_session.execute_string(put_command)
-
-                # ensure that there is, in fact, a file with a multi-part md5sum
-                result = runner.invoke_with_connection_json(
-                    ["stage", "list-files", stage_fqn]
-                )
-                assert result.exit_code == 0
-                assert isinstance(result.json, list)
-                assert any(
-                    [
-                        parse_multipart_md5sum(row["md5"]) is not None
-                        for row in result.json
-                    ]
-                )
-
-                # ensure that diff shows there is nothing to re-upload
-                result = runner.invoke_with_connection_json(
-                    ["app", "diff"],
-                    env=TEST_ENV,
-                )
-                assert result.exit_code == 0
-                assert result.json == {
-                    "modified": [],
-                    "added": [],
-                    "deleted": [],
-                }
-
-            finally:
-                # make sure our file has been deleted
-                temp_file.unlink(missing_ok=True)
-
-                # teardown is idempotent, so we can execute it again with no ill effects
-                result = runner.invoke_with_connection_json(
-                    ["app", "teardown", "--force"],
-                    env=TEST_ENV,
-                )
-                assert result.exit_code == 0
+            # teardown is idempotent, so we can execute it again with no ill effects
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
+            assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_open.py
+++ b/tests_integration/nativeapp/test_open.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import re
 from unittest import mock
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import enable_definition_v2_feature_flag
-
-USER_NAME = os.environ.get("USER", "")
 
 
 @pytest.mark.integration
@@ -26,10 +23,15 @@ USER_NAME = os.environ.get("USER", "")
 @mock.patch("typer.launch")
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_open(
-    mock_typer_launch, runner, test_project, project_directory, resource_suffix
+    mock_typer_launch,
+    runner,
+    test_project,
+    project_directory,
+    default_username,
+    resource_suffix,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
+    app_name = f"{project_name}_{default_username}{resource_suffix}"
 
     with project_directory(test_project):
         result = runner.invoke_with_connection_json(["app", "run"])

--- a/tests_integration/nativeapp/test_open.py
+++ b/tests_integration/nativeapp/test_open.py
@@ -11,18 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import uuid
-from unittest import mock
+import os
 import re
-
-from snowflake.cli.api.project.util import generate_user_env
-from tests_integration.test_utils import enable_definition_v2_feature_flag
+from unittest import mock
 
 from tests.project.fixtures import *
+from tests_integration.test_utils import enable_definition_v2_feature_flag
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
+USER_NAME = os.environ.get("USER", "")
 
 
 @pytest.mark.integration
@@ -30,25 +26,16 @@ TEST_ENV = generate_user_env(USER_NAME)
 @mock.patch("typer.launch")
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_open(
-    mock_typer_launch,
-    runner,
-    test_project,
-    project_directory,
+    mock_typer_launch, runner, test_project, project_directory, resource_suffix
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}"
+    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
 
     with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
         try:
-            result = runner.invoke_with_connection_json(
-                ["app", "open"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "open"])
             assert result.exit_code == 0
             assert "Snowflake Native App opened in browser." in result.output
 
@@ -61,7 +48,6 @@ def test_nativeapp_open(
 
         finally:
             result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force", "--cascade"],
-                env=TEST_ENV,
+                ["app", "teardown", "--force", "--cascade"]
             )
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_post_deploy.py
+++ b/tests_integration/nativeapp/test_post_deploy.py
@@ -1,8 +1,8 @@
 # Tests that application post-deploy scripts are executed by creating a post_deploy_log table and having each post-deploy script add a record to it
-import uuid
+import os
+
 import pytest
 
-from snowflake.cli.api.project.util import generate_user_env
 from tests_integration.test_utils import (
     enable_definition_v2_feature_flag,
     row_from_snowflake_session,
@@ -11,46 +11,34 @@ from tests_integration.testing_utils.working_directory_utils import (
     WorkingDirectoryChanger,
 )
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
+USER_NAME = os.environ.get("USER", "")
 
 
 def run(runner, args):
-    result = runner.invoke_with_connection_json(
-        ["app", "run"] + args,
-        env=TEST_ENV,
-    )
+    result = runner.invoke_with_connection_json(["app", "run"] + args)
     assert result.exit_code == 0
 
 
 def deploy(runner, args):
-    result = runner.invoke_with_connection_json(
-        ["app", "deploy"] + args,
-        env=TEST_ENV,
-    )
+    result = runner.invoke_with_connection_json(["app", "deploy"] + args)
     assert result.exit_code == 0
 
 
 def teardown(runner, args):
-    result = runner.invoke_with_connection_json(
-        ["app", "teardown", "--force"] + args,
-        env=TEST_ENV,
-    )
+    result = runner.invoke_with_connection_json(["app", "teardown", "--force"] + args)
     assert result.exit_code == 0
 
 
 def create_version(runner, version, args):
     result = runner.invoke_with_connection_json(
-        ["app", "version", "create", version] + args,
-        env=TEST_ENV,
+        ["app", "version", "create", version] + args
     )
     assert result.exit_code == 0
 
 
 def drop_version(runner, version, args):
     result = runner.invoke_with_connection_json(
-        ["app", "version", "drop", version, "--force"] + args,
-        env=TEST_ENV,
+        ["app", "version", "drop", version, "--force"] + args
     )
     assert result.exit_code == 0
 
@@ -88,6 +76,7 @@ def verify_pkg_post_deploy_log(snowflake_session, pkg_name, expected_rows):
 def test_nativeapp_post_deploy(
     runner,
     snowflake_session,
+    resource_suffix,
     project_directory,
     test_project,
     is_versioned,
@@ -95,8 +84,8 @@ def test_nativeapp_post_deploy(
 ):
     version = "v1"
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}"
-    pkg_name = f"{project_name}_pkg_{USER_NAME}"
+    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
+    pkg_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}"
 
     with project_directory(test_project) as tmp_dir:
         project_args = ["--project", f"{tmp_dir}"] if with_project_flag else []

--- a/tests_integration/nativeapp/test_post_deploy.py
+++ b/tests_integration/nativeapp/test_post_deploy.py
@@ -1,5 +1,4 @@
 # Tests that application post-deploy scripts are executed by creating a post_deploy_log table and having each post-deploy script add a record to it
-import os
 
 import pytest
 
@@ -10,8 +9,6 @@ from tests_integration.test_utils import (
 from tests_integration.testing_utils.working_directory_utils import (
     WorkingDirectoryChanger,
 )
-
-USER_NAME = os.environ.get("USER", "")
 
 
 def run(runner, args):
@@ -76,6 +73,7 @@ def verify_pkg_post_deploy_log(snowflake_session, pkg_name, expected_rows):
 def test_nativeapp_post_deploy(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_directory,
     test_project,
@@ -84,8 +82,8 @@ def test_nativeapp_post_deploy(
 ):
     version = "v1"
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
-    pkg_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}"
+    app_name = f"{project_name}_{default_username}{resource_suffix}"
+    pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
     with project_directory(test_project) as tmp_dir:
         project_args = ["--project", f"{tmp_dir}"] if with_project_flag else []

--- a/tests_integration/nativeapp/test_project_templating.py
+++ b/tests_integration/nativeapp/test_project_templating.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
@@ -20,8 +19,6 @@ from tests_integration.test_utils import (
     row_from_snowflake_session,
     enable_definition_v2_feature_flag,
 )
-
-USER_NAME = os.environ.get("USER", "")
 
 
 # Tests a simple flow of native app with template reading env variables from OS
@@ -35,6 +32,7 @@ USER_NAME = os.environ.get("USER", "")
 def test_nativeapp_project_templating_use_env_from_os(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -53,12 +51,8 @@ def test_nativeapp_project_templating_use_env_from_os(
 
         try:
             # app + package exist
-            package_name = (
-                f"{project_name}_{test_ci_env}_pkg_{USER_NAME}{resource_suffix}".upper()
-            )
-            app_name = (
-                f"{project_name}_{test_ci_env}_{USER_NAME}{resource_suffix}".upper()
-            )
+            package_name = f"{project_name}_{test_ci_env}_pkg_{default_username}{resource_suffix}".upper()
+            app_name = f"{project_name}_{test_ci_env}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -122,6 +116,7 @@ def test_nativeapp_project_templating_use_env_from_os(
 def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -140,12 +135,8 @@ def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
 
         try:
             # app + package exist
-            package_name = (
-                f"{project_name}_{test_ci_env}_pkg_{USER_NAME}{resource_suffix}".upper()
-            )
-            app_name = (
-                f"{project_name}_{test_ci_env}_{USER_NAME}{resource_suffix}".upper()
-            )
+            package_name = f"{project_name}_{test_ci_env}_pkg_{default_username}{resource_suffix}".upper()
+            app_name = f"{project_name}_{test_ci_env}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -209,6 +200,7 @@ def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
 def test_nativeapp_project_templating_use_default_env_from_project(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -227,10 +219,8 @@ def test_nativeapp_project_templating_use_default_env_from_project(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_{default_ci_env}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = (
-                f"{project_name}_{default_ci_env}_{USER_NAME}{resource_suffix}".upper()
-            )
+            package_name = f"{project_name}_{default_ci_env}_pkg_{default_username}{resource_suffix}".upper()
+            app_name = f"{project_name}_{default_ci_env}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -294,6 +284,7 @@ def test_nativeapp_project_templating_use_default_env_from_project(
 def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -314,10 +305,8 @@ def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
 
         try:
             # app + package exist
-            package_name = f"{project_name}_{expected_value}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = (
-                f"{project_name}_{expected_value}_{USER_NAME}{resource_suffix}".upper()
-            )
+            package_name = f"{project_name}_{expected_value}_pkg_{default_username}{resource_suffix}".upper()
+            app_name = f"{project_name}_{expected_value}_{default_username}{resource_suffix}".upper()
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(

--- a/tests_integration/nativeapp/test_teardown.py
+++ b/tests_integration/nativeapp/test_teardown.py
@@ -11,10 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import uuid
-
-from snowflake.cli.api.project.util import generate_user_env
+import os
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
@@ -24,8 +21,8 @@ from tests_integration.test_utils import (
     enable_definition_v2_feature_flag,
 )
 
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
+
+USER_NAME = os.environ.get("USER", "")
 
 
 @pytest.mark.integration
@@ -54,10 +51,11 @@ def test_nativeapp_teardown_cascade(
     project_directory,
     runner,
     snowflake_session,
+    resource_suffix,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}".upper()
-    db_name = f"{project_name}_db_{USER_NAME}".upper()
+    app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+    db_name = f"{project_name}_db_{USER_NAME}{resource_suffix}".upper()
 
     with project_directory(test_project):
         # Replacing the static DB name with a unique one to avoid collisions between tests
@@ -69,10 +67,7 @@ def test_nativeapp_teardown_cascade(
         with open("app/setup_script.sql", "w") as file:
             file.write(setup_script_content)
 
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
         try:
             # Grant permission to create databases
@@ -98,7 +93,9 @@ def test_nativeapp_teardown_cascade(
                 # orphan the app by dropping the application package,
                 # this causes future `show objects owned by application` queries to fail
                 # and `snow app teardown` needs to be resilient against this
-                package_name = f"{project_name}_pkg_{USER_NAME}".upper()
+                package_name = (
+                    f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+                )
                 snowflake_session.execute_string(
                     f"drop application package {package_name}"
                 )
@@ -112,10 +109,7 @@ def test_nativeapp_teardown_cascade(
                 )
 
             # Run the teardown command
-            result = runner.invoke_with_connection_json(
-                command.split(),
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(command.split())
             if expected_error is not None:
                 assert result.exit_code == 1
                 assert expected_error in result.output
@@ -144,8 +138,7 @@ def test_nativeapp_teardown_cascade(
         finally:
             # teardown is idempotent, so we can execute it again with no ill effects
             result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force", "--cascade"],
-                env=TEST_ENV,
+                ["app", "teardown", "--force", "--cascade"]
             )
             assert result.exit_code == 0
 
@@ -156,44 +149,34 @@ def test_nativeapp_teardown_cascade(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_teardown_unowned_app(
     runner,
+    resource_suffix,
     force,
     test_project,
     project_directory,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}"
+    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
 
     with project_directory(test_project):
-        result = runner.invoke_with_connection_json(
-            ["app", "run"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
         try:
             result = runner.invoke_with_connection_json(
-                ["sql", "-q", f"alter application {app_name} set comment = 'foo'"],
-                env=TEST_ENV,
+                ["sql", "-q", f"alter application {app_name} set comment = 'foo'"]
             )
             assert result.exit_code == 0
 
             if force:
                 result = runner.invoke_with_connection_json(
-                    ["app", "teardown", "--force"],
-                    env=TEST_ENV,
+                    ["app", "teardown", "--force"]
                 )
                 assert result.exit_code == 0
             else:
-                result = runner.invoke_with_connection_json(
-                    ["app", "teardown"],
-                    env=TEST_ENV,
-                )
+                result = runner.invoke_with_connection_json(["app", "teardown"])
                 assert result.exit_code == 1
 
         finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0
 
 
@@ -203,18 +186,16 @@ def test_nativeapp_teardown_unowned_app(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_teardown_pkg_versions(
     runner,
+    resource_suffix,
     default_release_directive,
     test_project,
     project_directory,
 ):
     project_name = "myapp"
-    pkg_name = f"{project_name}_pkg_{USER_NAME}"
+    pkg_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}"
 
     with project_directory(test_project):
-        result = runner.invoke_with_connection(
-            ["app", "version", "create", "v1"],
-            env=TEST_ENV,
-        )
+        result = runner.invoke_with_connection(["app", "version", "create", "v1"])
         assert result.exit_code == 0
 
         try:
@@ -225,16 +206,12 @@ def test_nativeapp_teardown_pkg_versions(
                         "sql",
                         "-q",
                         f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
-                    ],
-                    env=TEST_ENV,
+                    ]
                 )
                 assert result.exit_code == 0
 
             # try to teardown; fail because we have a version
-            result = runner.invoke_with_connection(
-                ["app", "teardown"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "teardown"])
             assert result.exit_code == 1
             assert f"Drop versions first, or use --force to override." in result.output
 
@@ -242,8 +219,7 @@ def test_nativeapp_teardown_pkg_versions(
             if not default_release_directive:
                 # if we didn't set a release directive, we can drop the version and try again
                 result = runner.invoke_with_connection(
-                    ["app", "version", "drop", "v1", "--force"],
-                    env=TEST_ENV,
+                    ["app", "version", "drop", "v1", "--force"]
                 )
                 assert result.exit_code == 0
             else:
@@ -251,15 +227,9 @@ def test_nativeapp_teardown_pkg_versions(
                 teardown_args = ["--force"]
 
             # either way, we can now tear down the application package
-            result = runner.invoke_with_connection(
-                ["app", "teardown"] + teardown_args,
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "teardown"] + teardown_args)
             assert result.exit_code == 0
 
         finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_teardown.py
+++ b/tests_integration/nativeapp/test_teardown.py
@@ -22,9 +22,6 @@ from tests_integration.test_utils import (
 )
 
 
-USER_NAME = os.environ.get("USER", "")
-
-
 @pytest.mark.integration
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize(
@@ -51,11 +48,12 @@ def test_nativeapp_teardown_cascade(
     project_directory,
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
-    db_name = f"{project_name}_db_{USER_NAME}{resource_suffix}".upper()
+    app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
+    db_name = f"{project_name}_db_{default_username}{resource_suffix}".upper()
 
     with project_directory(test_project):
         # Replacing the static DB name with a unique one to avoid collisions between tests
@@ -94,7 +92,7 @@ def test_nativeapp_teardown_cascade(
                 # this causes future `show objects owned by application` queries to fail
                 # and `snow app teardown` needs to be resilient against this
                 package_name = (
-                    f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+                    f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
                 )
                 snowflake_session.execute_string(
                     f"drop application package {package_name}"
@@ -149,13 +147,14 @@ def test_nativeapp_teardown_cascade(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_teardown_unowned_app(
     runner,
+    default_username,
     resource_suffix,
     force,
     test_project,
     project_directory,
 ):
     project_name = "myapp"
-    app_name = f"{project_name}_{USER_NAME}{resource_suffix}"
+    app_name = f"{project_name}_{default_username}{resource_suffix}"
 
     with project_directory(test_project):
         result = runner.invoke_with_connection_json(["app", "run"])
@@ -186,13 +185,14 @@ def test_nativeapp_teardown_unowned_app(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_teardown_pkg_versions(
     runner,
+    default_username,
     resource_suffix,
     default_release_directive,
     test_project,
     project_directory,
 ):
     project_name = "myapp"
-    pkg_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}"
+    pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
     with project_directory(test_project):
         result = runner.invoke_with_connection(["app", "version", "create", "v1"])

--- a/tests_integration/nativeapp/test_validate.py
+++ b/tests_integration/nativeapp/test_validate.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
-
-from snowflake.cli.api.project.util import generate_user_env
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
     enable_definition_v2_feature_flag,
 )
-
-USER_NAME = f"user_{uuid.uuid4().hex}"
-TEST_ENV = generate_user_env(USER_NAME)
 
 
 @pytest.mark.integration
@@ -31,17 +25,11 @@ def test_nativeapp_validate(test_project, project_directory, runner):
     with project_directory(test_project):
         try:
             # validate the app's setup script
-            result = runner.invoke_with_connection(
-                ["app", "validate"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "validate"])
             assert result.exit_code == 0, result.output
             assert "Native App validation succeeded." in result.output
         finally:
-            result = runner.invoke_with_connection(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "teardown", "--force"])
             assert result.exit_code == 0, result.output
 
 
@@ -56,18 +44,12 @@ def test_nativeapp_validate_failing(test_project, project_directory, runner):
         try:
             # validate the app's setup script, this will fail
             # because we include an empty file
-            result = runner.invoke_with_connection(
-                ["app", "validate"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "validate"])
             assert result.exit_code == 1, result.output
             assert (
                 "Snowflake Native App setup script failed validation." in result.output
             )
             assert "syntax error" in result.output
         finally:
-            result = runner.invoke_with_connection(
-                ["app", "teardown", "--force"],
-                env=TEST_ENV,
-            )
+            result = runner.invoke_with_connection(["app", "teardown", "--force"])
             assert result.exit_code == 0, result.output

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
@@ -24,7 +23,6 @@ from tests_integration.test_utils import (
     enable_definition_v2_feature_flag,
 )
 
-USER_NAME = os.environ.get("USER", "")
 
 # Tests a simple flow of an existing project, executing snow app version create, drop and teardown, all with distribution=internal
 @pytest.mark.integration
@@ -35,6 +33,7 @@ USER_NAME = os.environ.get("USER", "")
 def test_nativeapp_version_create_and_drop(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -48,7 +47,9 @@ def test_nativeapp_version_create_and_drop(
 
         try:
             # package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(
@@ -98,6 +99,7 @@ def test_nativeapp_version_create_and_drop(
 def test_nativeapp_upgrade(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -111,8 +113,10 @@ def test_nativeapp_upgrade(
 
         try:
             # package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
-            app_name = f"{project_name}_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
+            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
             # app package contains version v1
             expect = snowflake_session.execute_string(
                 f"show versions in application package {package_name}"
@@ -152,6 +156,7 @@ def test_nativeapp_upgrade(
 def test_nativeapp_version_create_3_patches(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -159,7 +164,9 @@ def test_nativeapp_version_create_3_patches(
     project_dir = project_definition_files[0].parent
     with pushd(project_dir):
         try:
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
 
             # create three patches (deploys too)
             for _ in range(3):
@@ -213,6 +220,7 @@ def test_nativeapp_version_create_3_patches(
 def test_nativeapp_version_create_patch_is_integer(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     project_definition_files: List[Path],
 ):
@@ -220,7 +228,9 @@ def test_nativeapp_version_create_patch_is_integer(
     project_dir = project_definition_files[0].parent
     with pushd(project_dir):
         try:
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
 
             # create initial version
             result = runner.invoke_with_connection_json(
@@ -298,6 +308,7 @@ def test_nativeapp_version_create_patch_is_integer(
 def test_nativeapp_version_create_package_no_magic_comment(
     runner,
     snowflake_session,
+    default_username,
     resource_suffix,
     snapshot,
     project_definition_files: List[Path],
@@ -310,7 +321,9 @@ def test_nativeapp_version_create_package_no_magic_comment(
 
         try:
             # package exist
-            package_name = f"{project_name}_pkg_{USER_NAME}{resource_suffix}".upper()
+            package_name = (
+                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+            )
             assert contains_row_with(
                 row_from_snowflake_session(
                     snowflake_session.execute_string(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds the current test name as a suffix on created apps and packages so we can tell which resources are created by which test. The method chosen to inject the name removes the need to pass `env=TEST_ENV` when calling `runner.invoke` and also fixes a bug that was introduced in #1396 due to the use of `--dist-worksteal` and the `TEST_ENV` being a module global (it was possible for a test to drop a resource used by another test concurrently because all tests in a module used the same random identifier).

If necessary for manual queries, the suffix can be retrieved from the `identifier_suffix` fixture.

Also moves the manual setting of the `USER` env var in integration tests to the CLI runner so that we can use `ctx.env.USER` in templates without having to worry about Windows. The default username can be retrieved from the `default_username` fixture if necessary.
