### PR TITLE
Append SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX value to app and package name

### DIFF
--- a/src/snowflake/cli/api/project/definition.py
+++ b/src/snowflake/cli/api/project/definition.py
@@ -102,6 +102,16 @@ def generate_local_override_yml(
     return project.update_from_dict(local)
 
 
+def default_app_package(project_name: str):
+    user = clean_identifier(get_env_username() or DEFAULT_USERNAME)
+    return append_to_identifier(to_identifier(project_name), f"_pkg_{user}")
+
+
 def default_role():
     conn = get_cli_context().connection
     return conn.role
+
+
+def default_application(project_name: str):
+    user = clean_identifier(get_env_username() or DEFAULT_USERNAME)
+    return append_to_identifier(to_identifier(project_name), f"_{user}")

--- a/src/snowflake/cli/api/project/definition.py
+++ b/src/snowflake/cli/api/project/definition.py
@@ -102,16 +102,6 @@ def generate_local_override_yml(
     return project.update_from_dict(local)
 
 
-def default_app_package(project_name: str):
-    user = clean_identifier(get_env_username() or DEFAULT_USERNAME)
-    return append_to_identifier(to_identifier(project_name), f"_pkg_{user}")
-
-
 def default_role():
     conn = get_cli_context().connection
     return conn.role
-
-
-def default_application(project_name: str):
-    user = clean_identifier(get_env_username() or DEFAULT_USERNAME)
-    return append_to_identifier(to_identifier(project_name), f"_{user}")

--- a/tests/nativeapp/test_project_model.py
+++ b/tests/nativeapp/test_project_model.py
@@ -103,8 +103,8 @@ def test_project_model_default_package_app_name_with_suffix(
         project_root=project_dir,
     )
 
-    assert project.package_name == '"minimal_pkg_suffix!"'
-    assert project.app_name == '"minimal_suffix!"'
+    assert project.package_name == '"minimal_pkg_test_user_suffix!"'
+    assert project.app_name == '"minimal_test_user_suffix!"'
 
 
 @mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")

--- a/tests/nativeapp/test_project_model.py
+++ b/tests/nativeapp/test_project_model.py
@@ -23,8 +23,11 @@ from unittest import mock
 import pytest
 import yaml
 from snowflake.cli._plugins.nativeapp.bundle_context import BundleContext
-from snowflake.cli._plugins.nativeapp.project_model import NativeAppProjectModel
-from snowflake.cli.api.project.definition import default_app_package, load_project
+from snowflake.cli._plugins.nativeapp.project_model import (
+    RESOURCE_SUFFIX_VAR,
+    NativeAppProjectModel,
+)
+from snowflake.cli.api.project.definition import load_project
 from snowflake.cli.api.project.schemas.native_app.application import SqlScriptHookType
 from snowflake.cli.api.project.schemas.native_app.path_mapping import PathMapping
 from snowflake.cli.api.project.schemas.project_definition import (
@@ -77,6 +80,31 @@ def test_project_model_all_defaults(
     assert project.app_role == "MockRole"
     assert project.app_post_deploy_hooks is None
     assert project.debug_mode is None
+
+
+@pytest.mark.parametrize("project_definition_files", ["minimal"], indirect=True)
+@mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")
+@mock.patch.dict(
+    os.environ,
+    {"USER": "test_user", RESOURCE_SUFFIX_VAR: "_suffix!"},
+    clear=True,
+)
+def test_project_model_default_package_app_name_with_suffix(
+    mock_connect, project_definition_files: List[Path], mock_ctx
+):
+    ctx = mock_ctx()
+    mock_connect.return_value = ctx
+
+    project_defn = load_project(project_definition_files).project_definition
+
+    project_dir = Path().resolve()
+    project = NativeAppProjectModel(
+        project_definition=project_defn.native_app,
+        project_root=project_dir,
+    )
+
+    assert project.package_name == '"minimal_pkg_suffix!"'
+    assert project.app_name == '"minimal_suffix!"'
 
 
 @mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")
@@ -155,6 +183,61 @@ def test_project_model_all_explicit(mock_connect, mock_ctx):
 
 @pytest.mark.parametrize("project_definition_files", ["minimal"], indirect=True)
 @mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")
+@mock.patch.dict(
+    os.environ,
+    {"USER": "test_user", RESOURCE_SUFFIX_VAR: "_suffix!"},
+    clear=True,
+)
+def test_project_model_explicit_package_app_name_with_suffix(
+    mock_connect, project_definition_files: List[Path], mock_ctx
+):
+    ctx = mock_ctx()
+    mock_connect.return_value = ctx
+
+    project_defition_file_yml = dedent(
+        f"""
+        definition_version: 1.1
+        native_app:
+          name: minimal
+          
+          artifacts:
+            - setup.sql
+            - README.md
+          
+          package:
+            name: minimal_test_pkg
+            role: PkgRole
+            distribution: external
+            warehouse: PkgWarehouse
+            scripts:
+              - scripts/package_setup.sql
+          
+          application:
+            name: minimal_test_app
+            warehouse: AppWarehouse
+            role: AppRole
+            debug: false
+            post_deploy:
+                - sql_script: scripts/app_setup.sql
+    
+    """
+    )
+
+    project_defn = build_project_definition(
+        **yaml.load(project_defition_file_yml, Loader=yaml.BaseLoader)
+    )
+    project_dir = Path().resolve()
+    project = NativeAppProjectModel(
+        project_definition=project_defn.native_app,
+        project_root=project_dir,
+    )
+
+    assert project.package_name == '"minimal_test_pkg_suffix!"'
+    assert project.app_name == '"minimal_test_app_suffix!"'
+
+
+@pytest.mark.parametrize("project_definition_files", ["minimal"], indirect=True)
+@mock.patch("snowflake.cli._app.snow_connector.connect_to_snowflake")
 @mock.patch.dict(os.environ, {"USER": "test_user"}, clear=True)
 def test_project_model_falls_back_to_current_role(
     mock_connect, project_definition_files: List[Path], mock_ctx, mock_cursor
@@ -188,7 +271,7 @@ def test_bundle_context_from_project_model(project_definition_files: List[Path])
     actual_bundle_ctx = project.get_bundle_context()
 
     expected_bundle_ctx = BundleContext(
-        package_name=default_app_package("minimal"),
+        package_name=project.package_name,
         artifacts=[
             PathMapping(src="setup.sql", dest=None),
             PathMapping(src="README.md", dest=None),

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -15,6 +15,7 @@
 import os
 import uuid
 
+from snowflake.cli._plugins.nativeapp.project_model import RESOURCE_SUFFIX_VAR
 from snowflake.cli.api.project.util import generate_user_env
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli._plugins.nativeapp.init import OFFICIAL_TEMPLATES_GITHUB_URL
@@ -86,6 +87,100 @@ def test_nativeapp_init_run_without_modifications(
             result = runner.invoke_with_connection_json(
                 ["app", "teardown", "--force"],
                 env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+
+
+@pytest.mark.integration
+@enable_definition_v2_feature_flag
+@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
+def test_nativeapp_init_run_with_resource_suffix(
+    test_project,
+    project_directory,
+    runner,
+    snowflake_session,
+):
+    suffix = f"_some_suffix_{uuid.uuid4().hex}"
+    test_env_with_suffix = TEST_ENV | {RESOURCE_SUFFIX_VAR: suffix}
+    with project_directory(test_project):
+        result = runner.invoke_with_connection_json(
+            ["app", "run"],
+            env=test_env_with_suffix,
+        )
+        assert result.exit_code == 0
+
+        try:
+            # app + package exist
+            assert row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '%{suffix}'",
+                )
+            )
+            assert row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show applications like '%{suffix}'",
+                )
+            )
+
+            # make sure we always delete the app
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown"],
+                env=test_env_with_suffix,
+            )
+            assert result.exit_code == 0
+
+        finally:
+            # teardown is idempotent, so we can execute it again with no ill effects
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown", "--force"],
+                env=test_env_with_suffix,
+            )
+            assert result.exit_code == 0
+
+
+@pytest.mark.integration
+@enable_definition_v2_feature_flag
+@pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
+def test_nativeapp_init_run_with_resource_suffix_quoted(
+    test_project,
+    project_directory,
+    runner,
+    snowflake_session,
+):
+    suffix = f"_must.be.quoted!!!_{uuid.uuid4().hex}"
+    test_env_with_quoted_suffix = TEST_ENV | {RESOURCE_SUFFIX_VAR: suffix}
+    with project_directory(test_project):
+        result = runner.invoke_with_connection_json(
+            ["app", "run"],
+            env=test_env_with_quoted_suffix,
+        )
+        assert result.exit_code == 0
+
+        try:
+            # app + package exist
+            assert row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '%{suffix}'",
+                )
+            )
+            assert row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show applications like '%{suffix}'",
+                )
+            )
+
+            # make sure we always delete the app
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown"],
+                env=test_env_with_quoted_suffix,
+            )
+            assert result.exit_code == 0
+
+        finally:
+            # teardown is idempotent, so we can execute it again with no ill effects
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown", "--force"],
+                env=test_env_with_quoted_suffix,
             )
             assert result.exit_code == 0
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Prerequisite for #1437. After discussing in-person, we decided to not overwrite the `USER` environment variable in tests and instead add a new `SNOWFLAKE_CLI_TEST_RESOURCE_SUFFIX` env var that will be appended to app package and app identifiers. In #1437, we'll use this variable to generate unique names for these resources so they don't clash during concurrent tests.
