### PR TITLE
Mark test_snowpark_external_access as xfail

### DIFF
--- a/tests_integration/test_snowpark_external_access.py
+++ b/tests_integration/test_snowpark_external_access.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from snowflake.connector import ProgrammingError
 
 from tests.testing_utils.fixtures import alter_snowflake_yml
 from tests_integration.testing_utils import SnowparkTestSetup, SnowparkTestSteps
@@ -20,6 +21,14 @@ from tests_integration.testing_utils import SnowparkTestSetup, SnowparkTestSteps
 STAGE_NAME = "dev_deployment"
 
 
+@pytest.mark.xfail(
+    raises=ProgrammingError,
+    strict=True,
+    reason=(
+        "Fails with \"Integrations do not allow secret 'EXTERNAL_ACCESS_DB.PUBLIC.TEST_SECRET'\" "
+        "without a recent code change"
+    ),
+)
 @pytest.mark.integration
 def test_snowpark_external_access(project_directory, _test_steps, test_database):
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
This test has started to fail with `Integrations do not allow secret 'EXTERNAL_ACCESS_DB.PUBLIC.TEST_SECRET'` without a recent code change: https://github.com/snowflakedb/snowflake-cli/actions/runs/10388238500/job/28767005035?pr=1437#step:7:1272
