### PR TITLE
Print warnings on CREATE or UPGRADE

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@
 * Fix error handling and improve messaging when no artifacts provided
 * Improved error message for incompatible parameters.
 * Fix return values of `snow snowpark list`, `describe` and `drop` commands.
+* Show warnings returned by Snowflake when `snow app run` is successful
 
 
 # v2.7.0

--- a/src/snowflake/cli/_plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/run_processor.py
@@ -72,11 +72,14 @@ UPGRADE_RESTRICTION_CODES = {
 }
 
 
-def print_warnings(create_or_upgrade_cursor: SnowflakeCursor):
+def print_warnings(create_or_upgrade_cursor: Optional[SnowflakeCursor]):
     """
     Shows warnings in the console returned by the CREATE or UPGRADE
     APPLICATION command.
     """
+    if not create_or_upgrade_cursor:
+        return
+
     messages = [row[0] for row in create_or_upgrade_cursor.fetchall()]
     warnings = [m for m in messages if m.lower().startswith("warning:")]
     if warnings:

--- a/src/snowflake/cli/_plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/run_processor.py
@@ -72,12 +72,12 @@ UPGRADE_RESTRICTION_CODES = {
 }
 
 
-def print_warnings(create_or_upgrade_cursor: DictCursor):
+def print_warnings(create_or_upgrade_cursor: SnowflakeCursor):
     """
     Shows warnings in the console returned by the CREATE or UPGRADE
     APPLICATION command.
     """
-    messages = [row["status"] for row in create_or_upgrade_cursor.fetchall()]
+    messages = [row[0] for row in create_or_upgrade_cursor.fetchall()]
     warnings = [m for m in messages if m.lower().startswith("warning:")]
     if warnings:
         for warning in warnings:
@@ -267,7 +267,6 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                         using_clause = install_method.using_clause(self._na_project)
                         upgrade_cursor = self._execute_query(
                             f"alter application {self.app_name} upgrade {using_clause}",
-                            cursor_class=DictCursor,
                         )
                         print_warnings(upgrade_cursor)
 
@@ -323,7 +322,6 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                             comment = {SPECIAL_COMMENT}
                         """
                         ),
-                        cursor_class=DictCursor,
                     )
                     print_warnings(create_cursor)
 

--- a/src/snowflake/cli/_plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/run_processor.py
@@ -72,20 +72,18 @@ UPGRADE_RESTRICTION_CODES = {
 }
 
 
-def print_warnings(create_or_upgrade_cursor: Optional[SnowflakeCursor]):
+def print_messages(create_or_upgrade_cursor: Optional[SnowflakeCursor]):
     """
-    Shows warnings in the console returned by the CREATE or UPGRADE
+    Shows messages in the console returned by the CREATE or UPGRADE
     APPLICATION command.
     """
     if not create_or_upgrade_cursor:
         return
 
     messages = [row[0] for row in create_or_upgrade_cursor.fetchall()]
-    warnings = [m for m in messages if m.lower().startswith("warning:")]
-    if warnings:
-        for warning in warnings:
-            cc.warning(warning)
-        cc.message("")
+    for message in messages:
+        cc.warning(message)
+    cc.message("")
 
 
 class SameAccountInstallMethod:
@@ -271,7 +269,7 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                         upgrade_cursor = self._execute_query(
                             f"alter application {self.app_name} upgrade {using_clause}",
                         )
-                        print_warnings(upgrade_cursor)
+                        print_messages(upgrade_cursor)
 
                         if install_method.is_dev_mode:
                             # if debug_mode is present (controlled), ensure it is up-to-date
@@ -326,7 +324,7 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                         """
                         ),
                     )
-                    print_warnings(create_cursor)
+                    print_messages(create_cursor)
 
                     # hooks always executed after a create or upgrade
                     self.execute_app_post_deploy_hooks()

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -55,6 +55,7 @@ from tests.nativeapp.patch_utils import (
 )
 from tests.nativeapp.utils import (
     NATIVEAPP_MANAGER_EXECUTE,
+    NATIVEAPP_MODULE,
     RUN_PROCESSOR_GET_EXISTING_APP_INFO,
     TYPER_CONFIRM,
     mock_execute_helper,
@@ -200,6 +201,72 @@ def test_create_dev_app_create_new_w_no_additional_privileges(
         policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
     )
     assert mock_execute.mock_calls == expected
+
+
+# Test create_dev_app with no existing application AND create returns a warning
+@mock.patch(RUN_PROCESSOR_GET_EXISTING_APP_INFO, return_value=None)
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock.patch(f"{NATIVEAPP_MODULE}.cc.warning")
+@mock_connection()
+def test_create_dev_app_with_warning(
+    mock_conn,
+    mock_warning,
+    mock_execute,
+    mock_get_existing_app_info,
+    temp_dir,
+    mock_cursor,
+):
+    warning_string = "Warning: grant_callback 'SETUP.CREATE_SERVICE(ARRAY)' does not exist or is not granted to an application role."
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (
+                mock_cursor([{"CURRENT_WAREHOUSE()": "old_wh"}], []),
+                mock.call("select current_warehouse()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [("Application 'MYAPP' created successfully.",), (warning_string,)],
+                    ["status"],
+                ),
+                mock.call(
+                    dedent(
+                        f"""\
+                    create application myapp
+                        from application package app_pkg using @app_pkg.app_src.stage debug_mode = True
+                        comment = {SPECIAL_COMMENT}
+                    """
+                    )
+                ),
+            ),
+            (None, mock.call("use warehouse old_wh")),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir_name=current_working_directory,
+        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
+    )
+
+    run_processor = _get_na_run_processor()
+    assert not mock_diff_result.has_changes()
+    run_processor.create_or_upgrade_app(
+        policy=MagicMock(), install_method=SameAccountInstallMethod.unversioned_dev()
+    )
+    assert mock_execute.mock_calls == expected
+
+    mock_warning.assert_has_calls([mock.call(warning_string)])
 
 
 # Test create_dev_app with no existing application AND create succeeds AND app role != package role


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
When warnings are returned by CREATE APPLICATION or UPGRADE APPLICATION, show them using `cc.warning` as well as an extra line break to draw visual attention to the warnings.

![image](https://github.com/user-attachments/assets/11313e8b-3ad0-40cc-a7d8-d72bc0313169)
