### PR TITLE
SNOW-1621834 Cast version to identifier when creating/dropping app versions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,7 @@
 * Fix the typo in spcs service name argument description. It is the identifier of the **service** instead of the **service pool**.
 * Fix error handling and improve messaging when no artifacts provided.
 * Improved error message for incompatible parameters.
+* Fixed SQL error when running `snow app version create` and `snow app version drop` with a version name that isn't a valid Snowflake unquoted identifier
 
 
 # v2.8.0

--- a/src/snowflake/cli/_plugins/nativeapp/version/version_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/version_processor.py
@@ -39,10 +39,9 @@ from snowflake.cli._plugins.nativeapp.run_processor import NativeAppRunProcessor
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.exceptions import SnowflakeSQLExecutionError
 from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
-from snowflake.cli.api.project.util import unquote_identifier
+from snowflake.cli.api.project.util import to_identifier, unquote_identifier
 from snowflake.cli.api.utils.cursor import (
     find_all_rows,
-    find_first_row,
 )
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
@@ -121,6 +120,8 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
         """
         Defines a new version in an existing application package.
         """
+        # Make the version a valid identifier, adding quotes if necessary
+        version = to_identifier(version)
         with self.use_role(self.package_role):
             cc.step(
                 f"Defining a new version {version} in application package {self.package_name}"
@@ -141,6 +142,8 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
         """
         Add a new patch, optionally a custom one, to an existing version in an application package.
         """
+        # Make the version a valid identifier, adding quotes if necessary
+        version = to_identifier(version)
         with self.use_role(self.package_role):
             cc.step(
                 f"Adding new patch to version {version} defined in application package {self.package_name}"
@@ -156,11 +159,7 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
                 add_version_query, cursor_class=DictCursor
             )
 
-            show_row = find_first_row(
-                result_cursor,
-                lambda row: row[VERSION_COL] == unquote_identifier(version),
-            )
-
+            show_row = result_cursor.fetchall()[0]
             new_patch = show_row["patch"]
             cc.message(
                 f"Patch {new_patch} created for version {version} defined in application package {self.package_name}."
@@ -327,6 +326,9 @@ class NativeAppVersionDropProcessor(NativeAppManager, NativeAppCommandProcessor)
                 raise ClickException(
                     "Manifest.yml file does not contain a value for the version field."
                 )
+
+        # Make the version a valid identifier, adding quotes if necessary
+        version = to_identifier(version)
 
         cc.step(
             dedent(

--- a/tests/nativeapp/test_version_create_processor.py
+++ b/tests/nativeapp/test_version_create_processor.py
@@ -105,8 +105,11 @@ def test_get_existing_release_direction_info(mock_execute, temp_dir, mock_cursor
 
 # Test add_new_version adds a new version to an app pkg correctly
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_add_version(mock_execute, temp_dir, mock_cursor):
-    version = "V1"
+@pytest.mark.parametrize(
+    ["version", "version_identifier"],
+    [("V1", "V1"), ("1.0.0", '"1.0.0"'), ('"1.0.0"', '"1.0.0"')],
+)
+def test_add_version(mock_execute, temp_dir, mock_cursor, version, version_identifier):
     side_effects, expected = mock_execute_helper(
         [
             (
@@ -120,7 +123,7 @@ def test_add_version(mock_execute, temp_dir, mock_cursor):
                     dedent(
                         f"""\
                         alter application package app_pkg
-                            add version V1
+                            add version {version_identifier}
                             using @app_pkg.app_src.stage
                     """
                     ),
@@ -146,8 +149,13 @@ def test_add_version(mock_execute, temp_dir, mock_cursor):
 
 # Test add_new_patch_to_version adds an "auto-increment" patch to an existing version
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_add_new_patch_auto(mock_execute, temp_dir, mock_cursor):
-    version = "V1"
+@pytest.mark.parametrize(
+    ["version", "version_identifier"],
+    [("V1", "V1"), ("1.0.0", '"1.0.0"'), ('"1.0.0"', '"1.0.0"')],
+)
+def test_add_new_patch_auto(
+    mock_execute, temp_dir, mock_cursor, version, version_identifier
+):
     side_effects, expected = mock_execute_helper(
         [
             (
@@ -161,7 +169,7 @@ def test_add_new_patch_auto(mock_execute, temp_dir, mock_cursor):
                     dedent(
                         f"""\
                         alter application package app_pkg
-                            add patch  for version V1
+                            add patch  for version {version_identifier}
                             using @app_pkg.app_src.stage
                     """
                     ),
@@ -187,8 +195,13 @@ def test_add_new_patch_auto(mock_execute, temp_dir, mock_cursor):
 
 # Test add_new_patch_to_version adds a custom patch to an existing version
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_add_new_patch_custom(mock_execute, temp_dir, mock_cursor):
-    version = "V1"
+@pytest.mark.parametrize(
+    ["version", "version_identifier"],
+    [("V1", "V1"), ("1.0.0", '"1.0.0"'), ('"1.0.0"', '"1.0.0"')],
+)
+def test_add_new_patch_custom(
+    mock_execute, temp_dir, mock_cursor, version, version_identifier
+):
     side_effects, expected = mock_execute_helper(
         [
             (
@@ -202,7 +215,7 @@ def test_add_new_patch_custom(mock_execute, temp_dir, mock_cursor):
                     dedent(
                         f"""\
                         alter application package app_pkg
-                            add patch 12 for version V1
+                            add patch 12 for version {version_identifier}
                             using @app_pkg.app_src.stage
                     """
                     ),
@@ -222,7 +235,7 @@ def test_add_new_patch_custom(mock_execute, temp_dir, mock_cursor):
     )
 
     processor = _get_version_create_processor()
-    processor.add_new_patch_to_version(version, "12")
+    processor.add_new_patch_to_version(version, 12)
     assert mock_execute.mock_calls == expected
 
 
@@ -282,7 +295,7 @@ def test_process_no_version_exists_throws_bad_option_exception_one(
         processor.process(
             bundle_map=mock_bundle_map,
             version="v1",
-            patch="12",
+            patch=12,
             policy=policy_param,
             git_policy=policy_param,
             is_interactive=False,
@@ -315,7 +328,7 @@ def test_process_no_version_exists_throws_bad_option_exception_two(
         processor.process(
             bundle_map=mock_bundle_map,
             version="v1",
-            patch="12",
+            patch=12,
             policy=policy_param,
             git_policy=policy_param,
             is_interactive=False,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
When running `snow app version create` and `snow app version drop`, wrap the version in `to_identifier()` so users don't have to specify the quotes around version names that aren't valid identifiers. If the name is already quoted, `to_identifier()` doesn't do anything.
