### PR TITLE
SNOW-1636849 Auto-teardown Native App in integration tests

### DIFF
--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,14 +23,21 @@ def nativeapp_project_directory(project_directory, nativeapp_teardown):
 @pytest.fixture
 def nativeapp_teardown(runner: SnowCLIRunner):
     @contextmanager
-    def _nativeapp_teardown(project_dir: Path | None = None):
+    def _nativeapp_teardown(
+        *,
+        project_dir: Path | None = None,
+        env: dict | None = None,
+    ):
         try:
             yield
         finally:
             args = ["--force", "--cascade"]
             if project_dir:
                 args += ["--project", str(project_dir)]
-            result = runner.invoke_with_connection_json(["app", "teardown", *args])
+            kwargs: dict[str, Any] = {}
+            if env:
+                kwargs["env"] = env
+            result = runner.invoke_with_connection(["app", "teardown", *args], **kwargs)
             assert result.exit_code == 0
 
     return _nativeapp_teardown

--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -14,7 +14,7 @@ def nativeapp_project_directory(project_directory, nativeapp_teardown):
     @contextmanager
     def _nativeapp_project_directory(name):
         with project_directory(name) as d:
-            with nativeapp_teardown(d):
+            with nativeapp_teardown(project_dir=d):
                 yield d
 
     return _nativeapp_project_directory

--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -11,6 +11,15 @@ from tests_integration.conftest import SnowCLIRunner
 
 @pytest.fixture
 def nativeapp_project_directory(project_directory, nativeapp_teardown):
+    """Wrapper around the project_directory fixture specific to Native App testing.
+
+    This fixture provides a context manager that does the following:
+    - Automatically calls `snow app teardown` before exiting
+
+    Parameters for the returned context manager:
+    :param name: The name of the directory in tests_integration/test_data/projects to use.
+    """
+
     @contextmanager
     def _nativeapp_project_directory(name):
         with project_directory(name) as d:
@@ -22,6 +31,17 @@ def nativeapp_project_directory(project_directory, nativeapp_teardown):
 
 @pytest.fixture
 def nativeapp_teardown(runner: SnowCLIRunner):
+    """Runs `snow app teardown` before exiting.
+
+    This fixture provides a context manager that runs
+    `snow app teardown --force --cascade` before exiting,
+    regardless of any exceptions raised.
+
+    Parameters for the returned context manager:
+    :param project_dir: Path to the project directory (optional)
+    :param env: Environment variables to replace os.environ (optional)
+    """
+
     @contextmanager
     def _nativeapp_teardown(
         *,

--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -1,0 +1,31 @@
+from contextlib import contextmanager
+
+import pytest
+
+from tests_integration.conftest import SnowCLIRunner
+
+
+@pytest.fixture
+def nativeapp_project_directory(project_directory, nativeapp_teardown):
+    @contextmanager
+    def _nativeapp_project_directory(name):
+        with project_directory(name) as d:
+            with nativeapp_teardown():
+                yield d
+
+    return _nativeapp_project_directory
+
+
+@pytest.fixture
+def nativeapp_teardown(runner: SnowCLIRunner):
+    @contextmanager
+    def _nativeapp_teardown():
+        try:
+            yield
+        finally:
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown", "--force", "--cascade"]
+            )
+            assert result.exit_code == 0
+
+    return _nativeapp_teardown

--- a/tests_integration/nativeapp/test_bundle.py
+++ b/tests_integration/nativeapp/test_bundle.py
@@ -24,10 +24,10 @@ from tests_integration.testing_utils import (
 
 
 @pytest.fixture(scope="function", params=["napp_init_v1", "napp_init_v2"])
-def template_setup(runner, project_directory, request):
+def template_setup(runner, nativeapp_project_directory, request):
     test_project = request.param
     with enable_definition_v2_feature_flag:
-        with project_directory(test_project) as project_root:
+        with nativeapp_project_directory(test_project) as project_root:
             # Vanilla bundle on the unmodified template
             result = runner.invoke_json(["app", "bundle"])
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_debug_mode.py
+++ b/tests_integration/nativeapp/test_debug_mode.py
@@ -90,6 +90,7 @@ def test_nativeapp_controlled_debug_mode(
     snowflake_session,
     default_username,
     resource_suffix,
+    nativeapp_teardown,
     project_definition_files: List[Path],
 ):
     project_name = "integration"
@@ -110,7 +111,7 @@ def test_nativeapp_controlled_debug_mode(
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # debug mode should be true by default on first app deploy,
             # because snowflake.yml doesn't set it explicitly either way ("uncontrolled")
             assert is_debug_mode(snowflake_session, app_name)
@@ -135,12 +136,3 @@ def test_nativeapp_controlled_debug_mode(
             result = runner.invoke_with_connection_json(["app", "run"])
             assert result.exit_code == 0
             assert is_debug_mode(snowflake_session, app_name)
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_deploy.py
+++ b/tests_integration/nativeapp/test_deploy.py
@@ -49,7 +49,7 @@ def sanitize_deploy_output(default_username, resource_suffix):
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snowflake_session,
     default_username,
@@ -59,52 +59,44 @@ def test_nativeapp_deploy(
     print_paths_as_posix,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         result = runner.invoke_with_connection(["app", "deploy"])
         assert result.exit_code == 0
         assert sanitize_deploy_output(result.output) == snapshot
 
-        try:
-            # package exist
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show application packages like '{package_name}'",
-                    )
-                ),
-                dict(name=package_name),
-            )
+        # package exist
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '{package_name}'",
+                )
+            ),
+            dict(name=package_name),
+        )
 
-            # manifest file exists
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
+        # manifest file exists
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
 
-            # app does not exist
-            assert not_contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show applications like '{app_name}'",
-                    )
-                ),
-                dict(name=app_name),
-            )
+        # app does not exist
+        assert not_contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show applications like '{app_name}'",
+                )
+            ),
+            dict(name=app_name),
+        )
 
-            # re-deploying should be a no-op; make sure we don't issue any PUT commands
-            result = runner.invoke_with_connection_json(["app", "deploy", "--debug"])
-            assert result.exit_code == 0
-            assert "Successfully uploaded chunk 0 of file" not in result.output
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # re-deploying should be a no-op; make sure we don't issue any PUT commands
+        result = runner.invoke_with_connection_json(["app", "deploy", "--debug"])
+        assert result.exit_code == 0
+        assert "Successfully uploaded chunk 0 of file" not in result.output
 
 
 @pytest.mark.integration
@@ -130,7 +122,7 @@ def test_nativeapp_deploy_prune(
     contains,
     not_contains,
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snapshot,
     print_paths_as_posix,
@@ -139,40 +131,28 @@ def test_nativeapp_deploy_prune(
     sanitize_deploy_output,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         result = runner.invoke_with_connection_json(["app", "deploy"])
         assert result.exit_code == 0
 
-        try:
-            # delete a file locally
-            os.remove(os.path.join("app", "README.md"))
+        # delete a file locally
+        os.remove(os.path.join("app", "README.md"))
 
-            # deploy
-            result = runner.invoke_with_connection(command.split())
-            assert result.exit_code == 0
-            assert sanitize_deploy_output(result.output) == snapshot
+        # deploy
+        result = runner.invoke_with_connection(command.split())
+        assert result.exit_code == 0
+        assert sanitize_deploy_output(result.output) == snapshot
 
-            # verify the file does not exist on the stage
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            for name in contains:
-                assert contains_row_with(stage_files.json, {"name": name})
-            for name in not_contains:
-                assert not_contains_row_with(stage_files.json, {"name": name})
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # verify the file does not exist on the stage
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        for name in contains:
+            assert contains_row_with(stage_files.json, {"name": name})
+        for name in not_contains:
+            assert not_contains_row_with(stage_files.json, {"name": name})
 
 
 # Tests a simple flow of executing "snow app deploy [files]", verifying that only the specified files are synced to the stage
@@ -181,7 +161,7 @@ def test_nativeapp_deploy_prune(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_files(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snapshot,
     print_paths_as_posix,
@@ -190,7 +170,7 @@ def test_nativeapp_deploy_files(
     sanitize_deploy_output,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         # sync only two specific files to stage
         result = runner.invoke_with_connection(
             [
@@ -204,29 +184,15 @@ def test_nativeapp_deploy_files(
         assert result.exit_code == 0
         assert sanitize_deploy_output(result.output) == snapshot
 
-        try:
-            # manifest and script files exist, readme doesn't exist
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/setup_script.sql"}
-            )
-            assert not_contains_row_with(stage_files.json, {"name": "stage/README.md"})
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # manifest and script files exist, readme doesn't exist
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
+        assert contains_row_with(stage_files.json, {"name": "stage/setup_script.sql"})
+        assert not_contains_row_with(stage_files.json, {"name": "stage/README.md"})
 
 
 # Tests that files inside of a symlinked directory are deployed
@@ -235,7 +201,7 @@ def test_nativeapp_deploy_files(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_nested_directories(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snapshot,
     print_paths_as_posix,
@@ -244,7 +210,7 @@ def test_nativeapp_deploy_nested_directories(
     sanitize_deploy_output,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         # create nested file under app/
         touch("app/nested/dir/file.txt")
 
@@ -254,26 +220,14 @@ def test_nativeapp_deploy_nested_directories(
         assert result.exit_code == 0
         assert sanitize_deploy_output(result.output) == snapshot
 
-        try:
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/nested/dir/file.txt"}
-            )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/nested/dir/file.txt"}
+        )
 
 
 # Tests that deploying a directory recursively syncs all of its contents
@@ -282,14 +236,14 @@ def test_nativeapp_deploy_nested_directories(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_directory(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     default_username,
     resource_suffix,
     sanitize_deploy_output,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         touch("app/dir/file.txt")
         result = runner.invoke_with_connection(
             ["app", "deploy", "app/dir", "--no-recursive", "--no-validate"]
@@ -303,24 +257,12 @@ def test_nativeapp_deploy_directory(
         )
         assert result.exit_code == 0
 
-        try:
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/dir/file.txt"})
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(stage_files.json, {"name": "stage/dir/file.txt"})
 
 
 # Tests that deploying a directory without specifying -r returns an error
@@ -329,21 +271,15 @@ def test_nativeapp_deploy_directory(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_directory_no_recursive(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
 ):
-    with project_directory(test_project):
-        try:
-            touch("app/nested/dir/file.txt")
-            result = runner.invoke_with_connection_json(
-                ["app", "deploy", "app/nested", "--no-validate"]
-            )
-            assert result.exit_code == 1, result.output
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+    with nativeapp_project_directory(test_project):
+        touch("app/nested/dir/file.txt")
+        result = runner.invoke_with_connection_json(
+            ["app", "deploy", "app/nested", "--no-validate"]
+        )
+        assert result.exit_code == 1, result.output
 
 
 # Tests that specifying an unknown path to deploy results in an error
@@ -352,21 +288,15 @@ def test_nativeapp_deploy_directory_no_recursive(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_unknown_path(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
 ):
-    with project_directory(test_project):
-        try:
-            result = runner.invoke_with_connection_json(
-                ["app", "deploy", "does_not_exist", "--no-validate"]
-            )
-            assert result.exit_code == 1
-            assert "The following path does not exist:" in result.output
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+    with nativeapp_project_directory(test_project):
+        result = runner.invoke_with_connection_json(
+            ["app", "deploy", "does_not_exist", "--no-validate"]
+        )
+        assert result.exit_code == 1
+        assert "The following path does not exist:" in result.output
 
 
 # Tests that specifying a path with no deploy artifact results in an error
@@ -375,21 +305,15 @@ def test_nativeapp_deploy_unknown_path(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_path_with_no_mapping(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
 ):
-    with project_directory(test_project):
-        try:
-            result = runner.invoke_with_connection_json(
-                ["app", "deploy", "snowflake.yml", "--no-validate"]
-            )
-            assert result.exit_code == 1
-            assert "No artifact found for" in result.output
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+    with nativeapp_project_directory(test_project):
+        result = runner.invoke_with_connection_json(
+            ["app", "deploy", "snowflake.yml", "--no-validate"]
+        )
+        assert result.exit_code == 1
+        assert "No artifact found for" in result.output
 
 
 # Tests that specifying a path and pruning result in an error
@@ -398,25 +322,19 @@ def test_nativeapp_deploy_path_with_no_mapping(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_rejects_pruning_when_path_is_specified(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
 ):
-    with project_directory(test_project):
-        try:
-            os.unlink("app/README.md")
-            result = runner.invoke_with_connection_json(
-                ["app", "deploy", "app/README.md", "--prune"]
-            )
+    with nativeapp_project_directory(test_project):
+        os.unlink("app/README.md")
+        result = runner.invoke_with_connection_json(
+            ["app", "deploy", "app/README.md", "--prune"]
+        )
 
-            assert_that_result_is_usage_error(
-                result,
-                "Parameters 'paths' and '--prune' are incompatible and cannot be used simultaneously.",
-            )
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        assert_that_result_is_usage_error(
+            result,
+            "Parameters 'paths' and '--prune' are incompatible and cannot be used simultaneously.",
+        )
 
 
 # Tests that specifying a path with no direct mapping falls back to search for prefix matches
@@ -427,7 +345,7 @@ def test_nativeapp_deploy_rejects_pruning_when_path_is_specified(
 )
 def test_nativeapp_deploy_looks_for_prefix_matches(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snapshot,
     print_paths_as_posix,
@@ -437,83 +355,72 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
 ):
     project_name = "myapp"
 
-    with project_directory(test_project):
-        try:
-            result = runner.invoke_with_connection(["app", "deploy", "-r", "app"])
-            assert result.exit_code == 0
-            assert sanitize_deploy_output(result.output) == snapshot
+    with nativeapp_project_directory(test_project):
+        result = runner.invoke_with_connection(["app", "deploy", "-r", "app"])
+        assert result.exit_code == 0
+        assert sanitize_deploy_output(result.output) == snapshot
 
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/setup_script.sql"}
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/README.md"})
-            assert not_contains_row_with(
-                stage_files.json, {"name": "stage/src/main.py"}
-            )
-            assert not_contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
-            )
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
+        assert contains_row_with(stage_files.json, {"name": "stage/setup_script.sql"})
+        assert contains_row_with(stage_files.json, {"name": "stage/README.md"})
+        assert not_contains_row_with(stage_files.json, {"name": "stage/src/main.py"})
+        assert not_contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
+        )
 
-            result = runner.invoke_with_connection(
-                ["app", "deploy", "-r", "lib/parent/child/c"]
-            )
-            assert result.exit_code == 0
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
-            )
-            assert not_contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/a.py"}
-            )
-            assert not_contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/b.py"}
-            )
+        result = runner.invoke_with_connection(
+            ["app", "deploy", "-r", "lib/parent/child/c"]
+        )
+        assert result.exit_code == 0
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
+        )
+        assert not_contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/a.py"}
+        )
+        assert not_contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/b.py"}
+        )
 
-            result = runner.invoke_with_connection(
-                ["app", "deploy", "lib/parent/child/a.py"]
-            )
-            assert result.exit_code == 0
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/a.py"}
-            )
-            assert not_contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/b.py"}
-            )
+        result = runner.invoke_with_connection(
+            ["app", "deploy", "lib/parent/child/a.py"]
+        )
+        assert result.exit_code == 0
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/a.py"}
+        )
+        assert not_contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/b.py"}
+        )
 
-            result = runner.invoke_with_connection(["app", "deploy", "lib", "-r"])
-            assert result.exit_code == 0
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/a.py"}
-            )
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/parent-lib/child/b.py"}
-            )
-
-        finally:
-            result = runner.invoke_with_connection(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        result = runner.invoke_with_connection(["app", "deploy", "lib", "-r"])
+        assert result.exit_code == 0
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/c/c.py"}
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/a.py"}
+        )
+        assert contains_row_with(
+            stage_files.json, {"name": "stage/parent-lib/child/b.py"}
+        )
 
 
 # Tests that snow app deploy -r . deploys all changes
@@ -522,7 +429,7 @@ def test_nativeapp_deploy_looks_for_prefix_matches(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_deploy_dot(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snapshot,
     print_paths_as_posix,
@@ -531,25 +438,16 @@ def test_nativeapp_deploy_dot(
     sanitize_deploy_output,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
-        try:
-            result = runner.invoke_with_connection(["app", "deploy", "-r", "."])
-            assert result.exit_code == 0
-            assert sanitize_deploy_output(result.output) == snapshot
+    with nativeapp_project_directory(test_project):
+        result = runner.invoke_with_connection(["app", "deploy", "-r", "."])
+        assert result.exit_code == 0
+        assert sanitize_deploy_output(result.output) == snapshot
 
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
-            stage_files = runner.invoke_with_connection_json(
-                ["stage", "list-files", f"{package_name}.{stage_name}"]
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
-            assert contains_row_with(
-                stage_files.json, {"name": "stage/setup_script.sql"}
-            )
-            assert contains_row_with(stage_files.json, {"name": "stage/README.md"})
-
-        finally:
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        stage_name = "app_src.stage"  # as defined in native-apps-templates/basic
+        stage_files = runner.invoke_with_connection_json(
+            ["stage", "list-files", f"{package_name}.{stage_name}"]
+        )
+        assert contains_row_with(stage_files.json, {"name": "stage/manifest.yml"})
+        assert contains_row_with(stage_files.json, {"name": "stage/setup_script.sql"})
+        assert contains_row_with(stage_files.json, {"name": "stage/README.md"})

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -39,9 +39,9 @@ from tests_integration.testing_utils import assert_that_result_is_usage_error
     ],
 )
 def test_app_events_mutually_exclusive_options(
-    test_project, runner, project_directory, flag_names, command
+    test_project, runner, nativeapp_project_directory, flag_names, command
 ):
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
         result = runner.invoke_with_connection(["app", "events", *command])
@@ -69,9 +69,9 @@ def test_app_events_mutually_exclusive_options(
     ],
 )
 def test_app_events_paired_options(
-    test_project, runner, project_directory, flag_names, command
+    test_project, runner, nativeapp_project_directory, flag_names, command
 ):
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
         result = runner.invoke_with_connection(["app", "events", *command])
@@ -84,8 +84,10 @@ def test_app_events_paired_options(
 @pytest.mark.integration
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_app_events_reject_invalid_type(test_project, runner, project_directory):
-    with project_directory(test_project):
+def test_app_events_reject_invalid_type(
+    test_project, runner, nativeapp_project_directory
+):
+    with nativeapp_project_directory(test_project):
         # The integration test account doesn't have an event table set up
         # but this test is still useful to validate the negative case
         result = runner.invoke_with_connection(["app", "events", "--type", "foo"])

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -32,48 +32,36 @@ from tests_integration.test_utils import (
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_init_run_without_modifications(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snowflake_session,
     default_username,
     resource_suffix,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
-        try:
-            # app + package exist
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show application packages like '{package_name}'",
-                    )
-                ),
-                dict(name=package_name),
-            )
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show applications like '{app_name}'",
-                    )
-                ),
-                dict(name=app_name),
-            )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # app + package exist
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '{package_name}'",
+                )
+            ),
+            dict(name=package_name),
+        )
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show applications like '{app_name}'",
+                )
+            ),
+            dict(name=app_name),
+        )
 
 
 # Tests a simple flow of an existing project, but executing snow app run and teardown, all with distribution=internal
@@ -87,6 +75,7 @@ def test_nativeapp_run_existing(
     snowflake_session,
     project_definition_files: List[Path],
     default_username,
+    nativeapp_teardown,
     resource_suffix,
 ):
     project_name = "integration"
@@ -95,7 +84,7 @@ def test_nativeapp_run_existing(
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = (
                 f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
@@ -137,15 +126,6 @@ def test_nativeapp_run_existing(
                 {"ECHO": test_string},
             )
 
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
-
 
 # Tests a simple flow of initiating a project, executing snow app run and teardown, all with distribution=internal
 @pytest.mark.integration
@@ -153,48 +133,36 @@ def test_nativeapp_run_existing(
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_init_run_handles_spaces(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     runner,
     snowflake_session,
     default_username,
     resource_suffix,
 ):
     project_name = "myapp"
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
-        try:
-            # app + package exist
-            package_name = (
-                f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
-            )
-            app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show application packages like '{package_name}'",
-                    )
-                ),
-                dict(name=package_name),
-            )
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show applications like '{app_name}'",
-                    )
-                ),
-                dict(name=app_name),
-            )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # app + package exist
+        package_name = f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
+        app_name = f"{project_name}_{default_username}{resource_suffix}".upper()
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '{package_name}'",
+                )
+            ),
+            dict(name=package_name),
+        )
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show applications like '{app_name}'",
+                )
+            ),
+            dict(name=app_name),
+        )
 
 
 # Tests a simple flow of an existing project, but executing snow app run and teardown, all with distribution=external
@@ -210,6 +178,7 @@ def test_nativeapp_run_existing_w_external(
     snowflake_session,
     project_definition_files: List[Path],
     default_username,
+    nativeapp_teardown,
     resource_suffix,
 ):
     project_name = "integration_external"
@@ -218,7 +187,7 @@ def test_nativeapp_run_existing_w_external(
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = (
                 f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
@@ -273,10 +242,6 @@ def test_nativeapp_run_existing_w_external(
                 {"ECHO": test_string},
             )
 
-            # make sure we always delete the app, --force required for external distribution
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
-
             expect = snowflake_session.execute_string(
                 f"show applications like '{app_name}'"
             )
@@ -291,46 +256,35 @@ def test_nativeapp_run_existing_w_external(
                 row_from_snowflake_session(expect), {"name": package_name}
             )
 
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
-
 
 # Verifies that running "app run" after "app deploy" upgrades the app
 @pytest.mark.integration
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
 def test_nativeapp_run_after_deploy(
-    test_project, project_directory, runner, default_username, resource_suffix
+    test_project, nativeapp_project_directory, runner, default_username, resource_suffix
 ):
     project_name = "myapp"
     app_name = f"{project_name}_{default_username}{resource_suffix}"
     stage_fqn = f"{project_name}_pkg_{default_username}{resource_suffix}.app_src.stage"
 
-    with project_directory(test_project):
-        try:
-            # Run #1
-            result = runner.invoke_with_connection_json(["app", "run"])
-            assert result.exit_code == 0
+    with nativeapp_project_directory(test_project):
+        # Run #1
+        result = runner.invoke_with_connection_json(["app", "run"])
+        assert result.exit_code == 0
 
-            # Make a change & deploy
-            with open("app/README.md", "a") as file:
-                file.write("### Test")
-            result = runner.invoke_with_connection_json(["app", "deploy"])
-            assert result.exit_code == 0
+        # Make a change & deploy
+        with open("app/README.md", "a") as file:
+            file.write("### Test")
+        result = runner.invoke_with_connection_json(["app", "deploy"])
+        assert result.exit_code == 0
 
-            # Run #2
-            result = runner.invoke_with_connection_json(["app", "run", "--debug"])
-            assert result.exit_code == 0
-            assert (
-                f"alter application {app_name} upgrade using @{stage_fqn}"
-                in result.output
-            )
-
-        finally:
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # Run #2
+        result = runner.invoke_with_connection_json(["app", "run", "--debug"])
+        assert result.exit_code == 0
+        assert (
+            f"alter application {app_name} upgrade using @{stage_fqn}" in result.output
+        )
 
 
 # Tests initialization of a project from a repo with a single template
@@ -390,6 +344,7 @@ def test_nativeapp_run_orphan(
     force_flag,
     default_username,
     resource_suffix,
+    nativeapp_teardown,
 ):
     project_name = "integration"
     project_dir = project_definition_files[0].parent
@@ -397,7 +352,7 @@ def test_nativeapp_run_orphan(
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = (
                 f"{project_name}_pkg_{default_username}{resource_suffix}".upper()
@@ -479,21 +434,6 @@ def test_nativeapp_run_orphan(
                 dict(name=app_name, source=package_name),
             )
 
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(["app", "teardown"])
-            assert result.exit_code == 0
-
-        finally:
-            # manually drop the application in case the test failed and it wasn't dropped
-            result = runner.invoke_with_connection(
-                ["sql", "-q", f"drop application if exists {app_name} cascade"]
-            )
-            assert result.exit_code == 0, result.output
-
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
-            assert result.exit_code == 0
-
 
 # Verifies that we can always cross-upgrade between different
 # run configurations as long as we pass the --force flag to "app run"
@@ -517,7 +457,7 @@ def test_nativeapp_run_orphan(
 )
 def test_nativeapp_force_cross_upgrade(
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     run_args_from,
     run_args_to,
     runner,
@@ -528,36 +468,30 @@ def test_nativeapp_force_cross_upgrade(
     app_name = f"{project_name}_{default_username}{resource_suffix}"
     pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
-    with project_directory(test_project):
-        try:
-            # Create version
-            result = runner.invoke_with_connection(["app", "version", "create", "v1"])
-            assert result.exit_code == 0
+    with nativeapp_project_directory(test_project):
+        # Create version
+        result = runner.invoke_with_connection(["app", "version", "create", "v1"])
+        assert result.exit_code == 0
 
-            # Set default release directive
-            result = runner.invoke_with_connection(
-                [
-                    "sql",
-                    "-q",
-                    f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
-                ]
-            )
-            assert result.exit_code == 0
+        # Set default release directive
+        result = runner.invoke_with_connection(
+            [
+                "sql",
+                "-q",
+                f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
+            ]
+        )
+        assert result.exit_code == 0
 
-            # Initial run
-            result = runner.invoke_with_connection(["app", "run"] + run_args_from)
-            assert result.exit_code == 0
+        # Initial run
+        result = runner.invoke_with_connection(["app", "run"] + run_args_from)
+        assert result.exit_code == 0
 
-            # (Cross-)upgrade
-            is_cross_upgrade = run_args_from != run_args_to
-            result = runner.invoke_with_connection(
-                ["app", "run"] + run_args_to + ["--force"]
-            )
-            assert result.exit_code == 0
-            if is_cross_upgrade:
-                assert f"Dropping application object {app_name}." in result.output
-
-        finally:
-            # Drop the package
-            result = runner.invoke_with_connection(["app", "teardown", "--force"])
-            assert result.exit_code == 0
+        # (Cross-)upgrade
+        is_cross_upgrade = run_args_from != run_args_to
+        result = runner.invoke_with_connection(
+            ["app", "run"] + run_args_to + ["--force"]
+        )
+        assert result.exit_code == 0
+        if is_cross_upgrade:
+            assert f"Dropping application object {app_name}." in result.output

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -242,20 +242,6 @@ def test_nativeapp_run_existing_w_external(
                 {"ECHO": test_string},
             )
 
-            expect = snowflake_session.execute_string(
-                f"show applications like '{app_name}'"
-            )
-            assert not_contains_row_with(
-                row_from_snowflake_session(expect), {"name": app_name}
-            )
-
-            expect = snowflake_session.execute_string(
-                f"show application packages like '{package_name}'"
-            )
-            assert not_contains_row_with(
-                row_from_snowflake_session(expect), {"name": package_name}
-            )
-
 
 # Verifies that running "app run" after "app deploy" upgrades the app
 @pytest.mark.integration

--- a/tests_integration/nativeapp/test_large_upload.py
+++ b/tests_integration/nativeapp/test_large_upload.py
@@ -97,6 +97,5 @@ def test_large_upload_skips_reupload(
             # make sure our file has been deleted
             temp_file.unlink(missing_ok=True)
 
-            # teardown is idempotent, so we can execute it again with no ill effects
             result = runner.invoke_with_connection_json(["app", "teardown", "--force"])
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_open.py
+++ b/tests_integration/nativeapp/test_open.py
@@ -26,30 +26,24 @@ def test_nativeapp_open(
     mock_typer_launch,
     runner,
     test_project,
-    project_directory,
+    nativeapp_project_directory,
     default_username,
     resource_suffix,
 ):
     project_name = "myapp"
     app_name = f"{project_name}_{default_username}{resource_suffix}"
 
-    with project_directory(test_project):
+    with nativeapp_project_directory(test_project):
         result = runner.invoke_with_connection_json(["app", "run"])
         assert result.exit_code == 0
-        try:
-            result = runner.invoke_with_connection_json(["app", "open"])
-            assert result.exit_code == 0
-            assert "Snowflake Native App opened in browser." in result.output
 
-            mock_call = mock_typer_launch.call_args_list[0].args[0]
-            assert re.match(
-                rf"https://app.snowflake.com/.*#/apps/application/{app_name}",
-                mock_call,
-                re.IGNORECASE,
-            )
+        result = runner.invoke_with_connection_json(["app", "open"])
+        assert result.exit_code == 0
+        assert "Snowflake Native App opened in browser." in result.output
 
-        finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force", "--cascade"]
-            )
-            assert result.exit_code == 0
+        mock_call = mock_typer_launch.call_args_list[0].args[0]
+        assert re.match(
+            rf"https://app.snowflake.com/.*#/apps/application/{app_name}",
+            mock_call,
+            re.IGNORECASE,
+        )

--- a/tests_integration/nativeapp/test_post_deploy.py
+++ b/tests_integration/nativeapp/test_post_deploy.py
@@ -75,7 +75,7 @@ def test_nativeapp_post_deploy(
     snowflake_session,
     default_username,
     resource_suffix,
-    project_directory,
+    nativeapp_project_directory,
     test_project,
     is_versioned,
     with_project_flag,
@@ -85,7 +85,7 @@ def test_nativeapp_post_deploy(
     app_name = f"{project_name}_{default_username}{resource_suffix}"
     pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
-    with project_directory(test_project) as tmp_dir:
+    with nativeapp_project_directory(test_project) as tmp_dir:
         project_args = ["--project", f"{tmp_dir}"] if with_project_flag else []
         version_run_args = ["--version", version] if is_versioned else []
 

--- a/tests_integration/nativeapp/test_project_templating.py
+++ b/tests_integration/nativeapp/test_project_templating.py
@@ -50,7 +50,7 @@ def test_nativeapp_project_templating_use_env_from_os(
         )
         assert result.exit_code == 0
 
-        with nativeapp_teardown():
+        with nativeapp_teardown(env=local_test_env):
             # app + package exist
             package_name = f"{project_name}_{test_ci_env}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{test_ci_env}_{default_username}{resource_suffix}".upper()
@@ -120,7 +120,7 @@ def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
         )
         assert result.exit_code == 0
 
-        with nativeapp_teardown():
+        with nativeapp_teardown(env=local_test_env):
             # app + package exist
             package_name = f"{project_name}_{test_ci_env}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{test_ci_env}_{default_username}{resource_suffix}".upper()
@@ -190,7 +190,7 @@ def test_nativeapp_project_templating_use_default_env_from_project(
         )
         assert result.exit_code == 0
 
-        with nativeapp_teardown():
+        with nativeapp_teardown(env=local_test_env):
             # app + package exist
             package_name = f"{project_name}_{default_ci_env}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{default_ci_env}_{default_username}{resource_suffix}".upper()
@@ -262,7 +262,7 @@ def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
         )
         assert result.exit_code == 0
 
-        with nativeapp_teardown():
+        with nativeapp_teardown(env=local_test_env):
             # app + package exist
             package_name = f"{project_name}_{expected_value}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{expected_value}_{default_username}{resource_suffix}".upper()
@@ -329,7 +329,7 @@ def test_nativeapp_project_templating_bundle_deploy_successful(
     local_test_env = {"CI_ENV": test_ci_env, "APP_DIR": "app"}
 
     with pushd(project_dir):
-        with nativeapp_teardown():
+        with nativeapp_teardown(env=local_test_env):
             result = runner.invoke_json(
                 ["app", "bundle"],
                 env=local_test_env,

--- a/tests_integration/nativeapp/test_project_templating.py
+++ b/tests_integration/nativeapp/test_project_templating.py
@@ -34,6 +34,7 @@ def test_nativeapp_project_templating_use_env_from_os(
     snowflake_session,
     default_username,
     resource_suffix,
+    nativeapp_teardown,
     project_definition_files: List[Path],
 ):
     project_name = "integration"
@@ -49,7 +50,7 @@ def test_nativeapp_project_templating_use_env_from_os(
         )
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = f"{project_name}_{test_ci_env}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{test_ci_env}_{default_username}{resource_suffix}".upper()
@@ -88,21 +89,6 @@ def test_nativeapp_project_templating_use_env_from_os(
                 ),
                 {"ECHO": test_string},
             )
-
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
 
 
 # Tests a simple flow of native app with template reading env variables from OS through an intermediate var
@@ -118,6 +104,7 @@ def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
     snowflake_session,
     default_username,
     resource_suffix,
+    nativeapp_teardown,
     project_definition_files: List[Path],
 ):
     project_name = "integration"
@@ -133,7 +120,7 @@ def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
         )
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = f"{project_name}_{test_ci_env}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{test_ci_env}_{default_username}{resource_suffix}".upper()
@@ -173,21 +160,6 @@ def test_nativeapp_project_templating_use_env_from_os_through_intermediate_var(
                 {"ECHO": test_string},
             )
 
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-
 
 # Tests a simple flow of native app with template reading default env values from project definition file
 @pytest.mark.integration
@@ -202,6 +174,7 @@ def test_nativeapp_project_templating_use_default_env_from_project(
     snowflake_session,
     default_username,
     resource_suffix,
+    nativeapp_teardown,
     project_definition_files: List[Path],
 ):
     project_name = "integration"
@@ -217,7 +190,7 @@ def test_nativeapp_project_templating_use_default_env_from_project(
         )
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = f"{project_name}_{default_ci_env}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{default_ci_env}_{default_username}{resource_suffix}".upper()
@@ -257,21 +230,6 @@ def test_nativeapp_project_templating_use_default_env_from_project(
                 {"ECHO": test_string},
             )
 
-            # make sure we always delete the app
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-
 
 # Tests a native app with --env parameter through command line overwriting values from os env and project definition filetemplate reading env var
 @pytest.mark.integration
@@ -286,6 +244,7 @@ def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
     snowflake_session,
     default_username,
     resource_suffix,
+    nativeapp_teardown,
     project_definition_files: List[Path],
 ):
     project_name = "integration"
@@ -303,7 +262,7 @@ def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
         )
         assert result.exit_code == 0
 
-        try:
+        with nativeapp_teardown():
             # app + package exist
             package_name = f"{project_name}_{expected_value}_pkg_{default_username}{resource_suffix}".upper()
             app_name = f"{project_name}_{expected_value}_{default_username}{resource_suffix}".upper()
@@ -350,14 +309,6 @@ def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
             )
             assert result.exit_code == 0
 
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--env", f"CI_ENV={expected_value}", "--force"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-
 
 # Tests that other native app commands still succeed with templating
 @pytest.mark.integration
@@ -369,6 +320,7 @@ def test_nativeapp_project_templating_use_env_from_cli_as_highest_priority(
 )
 def test_nativeapp_project_templating_bundle_deploy_successful(
     runner,
+    nativeapp_teardown,
     project_definition_files: List[Path],
 ):
     project_dir = project_definition_files[0].parent
@@ -377,7 +329,7 @@ def test_nativeapp_project_templating_bundle_deploy_successful(
     local_test_env = {"CI_ENV": test_ci_env, "APP_DIR": "app"}
 
     with pushd(project_dir):
-        try:
+        with nativeapp_teardown():
             result = runner.invoke_json(
                 ["app", "bundle"],
                 env=local_test_env,
@@ -386,13 +338,6 @@ def test_nativeapp_project_templating_bundle_deploy_successful(
 
             result = runner.invoke_with_connection_json(
                 ["app", "deploy"],
-                env=local_test_env,
-            )
-            assert result.exit_code == 0
-        finally:
-            # teardown is idempotent, so we can execute it again with no ill effects
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"],
                 env=local_test_env,
             )
             assert result.exit_code == 0

--- a/tests_integration/nativeapp/test_validate.py
+++ b/tests_integration/nativeapp/test_validate.py
@@ -21,35 +21,25 @@ from tests_integration.test_utils import (
 @pytest.mark.integration
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_nativeapp_validate(test_project, project_directory, runner):
-    with project_directory(test_project):
-        try:
-            # validate the app's setup script
-            result = runner.invoke_with_connection(["app", "validate"])
-            assert result.exit_code == 0, result.output
-            assert "Native App validation succeeded." in result.output
-        finally:
-            result = runner.invoke_with_connection(["app", "teardown", "--force"])
-            assert result.exit_code == 0, result.output
+def test_nativeapp_validate(test_project, nativeapp_project_directory, runner):
+    with nativeapp_project_directory(test_project):
+        # validate the app's setup script
+        result = runner.invoke_with_connection(["app", "validate"])
+        assert result.exit_code == 0, result.output
+        assert "Native App validation succeeded." in result.output
 
 
 @pytest.mark.integration
 @enable_definition_v2_feature_flag
 @pytest.mark.parametrize("test_project", ["napp_init_v1", "napp_init_v2"])
-def test_nativeapp_validate_failing(test_project, project_directory, runner):
-    with project_directory(test_project):
+def test_nativeapp_validate_failing(test_project, nativeapp_project_directory, runner):
+    with nativeapp_project_directory(test_project):
         # Create invalid SQL file
         Path("app/setup_script.sql").write_text("Lorem ipsum dolor sit amet")
 
-        try:
-            # validate the app's setup script, this will fail
-            # because we include an empty file
-            result = runner.invoke_with_connection(["app", "validate"])
-            assert result.exit_code == 1, result.output
-            assert (
-                "Snowflake Native App setup script failed validation." in result.output
-            )
-            assert "syntax error" in result.output
-        finally:
-            result = runner.invoke_with_connection(["app", "teardown", "--force"])
-            assert result.exit_code == 0, result.output
+        # validate the app's setup script, this will fail
+        # because we include an empty file
+        result = runner.invoke_with_connection(["app", "validate"])
+        assert result.exit_code == 1, result.output
+        assert "Snowflake Native App setup script failed validation." in result.output
+        assert "syntax error" in result.output

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -74,13 +74,6 @@ def test_nativeapp_version_create_and_drop(
             actual = runner.invoke_with_connection_json(["app", "version", "list"])
             assert len(actual.json) == 0
 
-            expect = snowflake_session.execute_string(
-                f"show application packages like '{package_name}'"
-            )
-            assert not_contains_row_with(
-                row_from_snowflake_session(expect), {"name": package_name}
-            )
-
 
 # Tests upgrading an app from an existing loose files installation to versioned installation.
 @pytest.mark.integration
@@ -180,13 +173,6 @@ def test_nativeapp_version_create_3_patches(
             actual = runner.invoke_with_connection_json(["app", "version", "list"])
             assert len(actual.json) == 0
 
-            expect = snowflake_session.execute_string(
-                f"show application packages like '{package_name}'"
-            )
-            assert not_contains_row_with(
-                row_from_snowflake_session(expect), {"name": package_name}
-            )
-
 
 @pytest.mark.integration
 @enable_definition_v2_feature_flag
@@ -258,13 +244,6 @@ def test_nativeapp_version_create_patch_is_integer(
             # ensure there are no versions now
             actual = runner.invoke_with_connection_json(["app", "version", "list"])
             assert len(actual.json) == 0
-
-            expect = snowflake_session.execute_string(
-                f"show application packages like '{package_name}'"
-            )
-            assert not_contains_row_with(
-                row_from_snowflake_session(expect), {"name": package_name}
-            )
 
 
 # Tests creating a version for a package that was not created by the CLI


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * N/A I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * N/A I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Changes `with project_directory()` to `with nativeapp_project_directory()`, which automatically runs `snow app teardown` before exiting the project. This allows us to remove the `try`/`finally` in most tests. For tests that were using `with pushd(test_project)`, this has been changed to `with nativeapp_teardown()`, which is what `with nativeapp_project_directory()` uses under the hood.
