### PR TITLE
Support backslash for windows path

### DIFF
--- a/src/snowflake/cli/api/project/errors.py
+++ b/src/snowflake/cli/api/project/errors.py
@@ -29,10 +29,25 @@ class SchemaValidationError(ClickException):
     def __init__(self, error: ValidationError):
         errors = error.errors()
         message = f"During evaluation of {error.title} in project definition following errors were encountered:\n"
+
+        def calculate_location(e):
+            if e["loc"] is None:
+                return None
+
+            # show numbers as list indexes and strings as dictionary keys. Example: key1[0].key2
+            result = "".join(
+                f"[{item}]" if isinstance(item, int) else f".{item}"
+                for item in e["loc"]
+            )
+
+            # remove leading dot from the string if any:
+            return result[1:] if result.startswith(".") else result
+
         message += "\n".join(
             [
                 self.message_templates.get(e["type"], self.generic_message).format(
-                    **e, location=".".join(e["loc"]) if e["loc"] is not None else None
+                    **e,
+                    location=calculate_location(e),
                 )
                 for e in errors
             ]

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -621,12 +621,14 @@ class NativeAppManager(SqlExecutionMixin):
             )
 
         env = jinja2.Environment(
-            loader=jinja2.loaders.FileSystemLoader(self.project_root),
+            loader=jinja2.FileSystemLoader(searchpath="/"),
             keep_trailing_newline=True,
             undefined=jinja2.StrictUndefined,
         )
 
-        package_scripts_paths = [Path(script) for script in self.package_scripts]
+        package_scripts_paths = [
+            Path(self.project_root) / script for script in self.package_scripts
+        ]
         queued_queries = self._expand_script_templates(
             env, dict(package_name=self.package_name), package_scripts_paths
         )
@@ -676,14 +678,14 @@ class NativeAppManager(SqlExecutionMixin):
             sql_scripts_paths = []
             for hook in post_deploy_hooks:
                 if hook.sql_script:
-                    sql_scripts_paths.append(Path(hook.sql_script))
+                    sql_scripts_paths.append(self.project_root / hook.sql_script)
                 else:
                     raise ValueError(
                         f"Unsupported {deployed_object_type} post-deploy hook type: {hook}"
                     )
 
             env = get_sql_cli_jinja_env(
-                loader=jinja2.loaders.FileSystemLoader(self.project_root)
+                loader=jinja2.loaders.FileSystemLoader(searchpath="/")
             )
             scripts_content_list = self._expand_script_templates(
                 env, cli_context.template_context, sql_scripts_paths

--- a/tests/nativeapp/test_post_deploy_for_app.py
+++ b/tests/nativeapp/test_post_deploy_for_app.py
@@ -148,7 +148,10 @@ def test_missing_sql_script(
         with pytest.raises(MissingScriptError) as err:
             processor.execute_app_post_deploy_hooks()
 
-        assert err.value.message == 'Script "scripts/missing.sql" does not exist'
+        assert (
+            err.value.message
+            == f'Script "{project_dir}/scripts/missing.sql" does not exist'
+        )
 
 
 @mock.patch(RUN_PROCESSOR_APP_POST_DEPLOY_HOOKS, new_callable=mock.PropertyMock)

--- a/tests/nativeapp/test_post_deploy_for_app.py
+++ b/tests/nativeapp/test_post_deploy_for_app.py
@@ -148,10 +148,7 @@ def test_missing_sql_script(
         with pytest.raises(MissingScriptError) as err:
             processor.execute_app_post_deploy_hooks()
 
-        assert (
-            err.value.message
-            == f'Script "{project_dir}/scripts/missing.sql" does not exist'
-        )
+        assert err.value.message == 'Script "scripts/missing.sql" does not exist'
 
 
 @mock.patch(RUN_PROCESSOR_APP_POST_DEPLOY_HOOKS, new_callable=mock.PropertyMock)
@@ -171,7 +168,7 @@ def test_invalid_hook_type(
 
         with pytest.raises(ValueError) as err:
             processor.execute_app_post_deploy_hooks()
-        assert "Unsupported application post-deploy hook type" in str(err)
+        assert "Unsupported application post_deploy hook type" in str(err)
 
 
 @pytest.mark.parametrize(

--- a/tests/nativeapp/test_post_deploy_for_package.py
+++ b/tests/nativeapp/test_post_deploy_for_package.py
@@ -125,7 +125,7 @@ def test_package_post_deploy_scripts_with_non_existing_scripts(
 
         assert (
             err.value.message
-            == 'Script "scripts/package_missing_script.sql" does not exist'
+            == f'Script "{project_dir}/scripts/package_missing_script.sql" does not exist'
         )
 
 

--- a/tests/nativeapp/test_post_deploy_for_package.py
+++ b/tests/nativeapp/test_post_deploy_for_package.py
@@ -125,7 +125,7 @@ def test_package_post_deploy_scripts_with_non_existing_scripts(
 
         assert (
             err.value.message
-            == f'Script "{project_dir}/scripts/package_missing_script.sql" does not exist'
+            == 'Script "scripts/package_missing_script.sql" does not exist'
         )
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix 1: backslash path in Windows for sql scripts
Before, you can only specify native app sql script to run with forward slashes.
Backward slashes were causing issues with Jinja2. By using as_posix(), we ensure that Jinja2 can parse the paths

Fix 2: fix pydantic reporting which was not working when there is an array in the path:
Example: native_app.application.post_deploy[0].sql_script