### PR TITLE
Fix integer indices in error reporting

### DIFF
--- a/src/snowflake/cli/api/project/errors.py
+++ b/src/snowflake/cli/api/project/errors.py
@@ -29,10 +29,25 @@ class SchemaValidationError(ClickException):
     def __init__(self, error: ValidationError):
         errors = error.errors()
         message = f"During evaluation of {error.title} in project definition following errors were encountered:\n"
+
+        def calculate_location(e):
+            if e["loc"] is None:
+                return None
+
+            # show numbers as list indexes and strings as dictionary keys. Example: key1[0].key2
+            result = "".join(
+                f"[{item}]" if isinstance(item, int) else f".{item}"
+                for item in e["loc"]
+            )
+
+            # remove leading dot from the string if any:
+            return result[1:] if result.startswith(".") else result
+
         message += "\n".join(
             [
                 self.message_templates.get(e["type"], self.generic_message).format(
-                    **e, location=".".join(e["loc"]) if e["loc"] is not None else None
+                    **e,
+                    location=calculate_location(e),
                 )
                 for e in errors
             ]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
When error location in Pydantic contains indices, it crashes with an error that can't be decyphired easily.
It crashes trying to join a mix of string and integers ".".join(e["loc"]).

This fixes it to report integers nicely: e.g. key1[1].key2 

WIll add unit test as a follow up (to unblock the release)