### PR TITLE
Improve error messages on SQL execution

### DIFF
--- a/src/snowflake/cli/api/entities/application_package_entity.py
+++ b/src/snowflake/cli/api/entities/application_package_entity.py
@@ -30,7 +30,7 @@ from snowflake.cli.api.project.schemas.entities.application_package_entity_model
     ApplicationPackageEntityModel,
 )
 from snowflake.cli.api.rendering.jinja import (
-    jinja_render_from_str,
+    get_basic_jinja_env,
 )
 from snowflake.connector import ProgrammingError
 
@@ -178,9 +178,9 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
         queued_queries = render_script_templates(
             project_root,
-            jinja_render_from_str,
             dict(package_name=package_name),
             package_scripts,
+            get_basic_jinja_env(),
         )
 
         # once we're sure all the templates expanded correctly, execute all of them

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, NoReturn, Optional
+from typing import Any, List, NoReturn, Optional
 
 import jinja2
 from click import ClickException
@@ -25,6 +25,7 @@ from snowflake.cli._plugins.stage.diff import (
     to_stage_path,
 )
 from snowflake.cli._plugins.stage.utils import print_diff_to_console
+from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.console.abc import AbstractConsole
 from snowflake.cli.api.entities.common import get_sql_executor
 from snowflake.cli.api.errno import (
@@ -34,7 +35,7 @@ from snowflake.cli.api.errno import (
 from snowflake.cli.api.project.schemas.entities.common import PostDeployHook
 from snowflake.cli.api.project.util import unquote_identifier
 from snowflake.cli.api.rendering.sql_templates import (
-    snowflake_sql_jinja_render,
+    choose_sql_jinja_env_based_on_template_syntax,
 )
 from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
 from snowflake.connector import ProgrammingError
@@ -272,8 +273,7 @@ def execute_post_deploy_hooks(
 
         scripts_content_list = render_script_templates(
             project_root,
-            snowflake_sql_jinja_render,
-            {},
+            get_cli_context().template_context,
             sql_scripts_paths,
         )
 
@@ -287,16 +287,17 @@ def execute_post_deploy_hooks(
 
 def render_script_templates(
     project_root: Path,
-    render_from_str: Callable[[str, Dict[str, Any]], str],
     jinja_context: dict[str, Any],
     scripts: List[str],
+    override_env: Optional[jinja2.Environment] = None,
 ) -> List[str]:
     """
     Input:
     - project_root: path to project root
-    - render_from_str: function which renders a jinja template from a string and jinja context
     - jinja_context: a dictionary with the jinja context
     - scripts: list of script paths relative to the project root
+    - override_env: optional jinja environment to use for rendering,
+      if not provided, the environment will be chosen based on the template syntax
     Returns:
     - List of rendered scripts content
     Size of the return list is the same as the size of the input scripts list.
@@ -306,7 +307,10 @@ def render_script_templates(
         script_full_path = SecurePath(project_root) / relpath
         try:
             template_content = script_full_path.read_text(file_size_limit_mb=UNLIMITED)
-            result = render_from_str(template_content, jinja_context)
+            env = override_env or choose_sql_jinja_env_based_on_template_syntax(
+                template_content, reference_name=relpath
+            )
+            result = env.from_string(template_content).render(jinja_context)
             scripts_contents.append(result)
 
         except FileNotFoundError as e:

--- a/src/snowflake/cli/api/rendering/jinja.py
+++ b/src/snowflake/cli/api/rendering/jinja.py
@@ -82,7 +82,7 @@ class IgnoreAttrEnvironment(Environment):
             return self.undefined(obj=obj, name=argument)
 
 
-def _get_jinja_env(loader: Optional[loaders.BaseLoader] = None) -> Environment:
+def get_basic_jinja_env(loader: Optional[loaders.BaseLoader] = None) -> Environment:
     return env_bootstrap(
         IgnoreAttrEnvironment(
             loader=loader or loaders.BaseLoader(),
@@ -90,20 +90,6 @@ def _get_jinja_env(loader: Optional[loaders.BaseLoader] = None) -> Environment:
             undefined=StrictUndefined,
         )
     )
-
-
-def jinja_render_from_str(template_content: str, data: Dict[str, Any]) -> str:
-    """
-    Renders a jinja template and outputs either the rendered contents as string or writes to a file.
-
-    Args:
-        template_content (str): template contents
-        data (dict): A dictionary of jinja variables and their actual values
-
-    Returns:
-        None if file path is provided, else returns the rendered string.
-    """
-    return _get_jinja_env().from_string(template_content).render(data)
 
 
 def jinja_render_from_file(
@@ -120,7 +106,7 @@ def jinja_render_from_file(
     Returns:
         None if file path is provided, else returns the rendered string.
     """
-    env = _get_jinja_env(
+    env = get_basic_jinja_env(
         loader=loaders.FileSystemLoader(template_path.parent.as_posix())
     )
     loaded_template = env.get_template(template_path.name)

--- a/tests/nativeapp/test_post_deploy_for_package.py
+++ b/tests/nativeapp/test_post_deploy_for_package.py
@@ -20,6 +20,7 @@ from unittest import mock
 import pytest
 from snowflake.cli._plugins.nativeapp.exceptions import MissingScriptError
 from snowflake.cli._plugins.nativeapp.manager import NativeAppManager
+from snowflake.cli.api.exceptions import InvalidTemplate
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli.api.project.errors import SchemaValidationError
 from snowflake.connector import ProgrammingError
@@ -172,4 +173,105 @@ def test_package_scripts_and_post_deploy_found(
         assert (
             "package.scripts and package.post_deploy fields cannot be used together"
             in err.value.message
+        )
+
+
+@pytest.mark.parametrize(
+    "template_syntax", [("<% ctx.env.test %>"), ("&{ ctx.env.test }")]
+)
+@mock.patch(SQL_EXECUTOR_EXECUTE)
+@mock.patch(SQL_EXECUTOR_EXECUTE_QUERIES)
+@mock.patch(CLI_GLOBAL_TEMPLATE_CONTEXT, new_callable=mock.PropertyMock)
+@mock.patch.dict(os.environ, {"USER": "test_user"})
+@mock_connection()
+def test_package_post_deploy_scripts_with_templates(
+    mock_conn,
+    mock_cli_ctx,
+    mock_execute_queries,
+    mock_execute_query,
+    project_directory,
+    template_syntax,
+):
+    mock_conn.return_value = MockConnectionCtx()
+    with project_directory("napp_post_deploy") as project_dir:
+        # edit scripts/package_post_deploy1.sql to include template variables
+        with open(project_dir / "scripts" / "package_post_deploy1.sql", "w") as f:
+            f.write(
+                dedent(
+                    f"""\
+                    -- package post-deploy script (1/2)
+
+                    select '{template_syntax}';
+                    """
+                )
+            )
+
+        dm = DefinitionManager(project_dir, {"ctx": {"env": {"test": "test_value"}}})
+        manager = NativeAppManager(
+            project_definition=dm.project_definition.native_app,
+            project_root=dm.project_root,
+        )
+        mock_cli_ctx.return_value = dm.template_context
+
+        manager.execute_package_post_deploy_hooks()
+
+        assert mock_execute_query.mock_calls == [
+            mock.call("use database myapp_pkg_test_user"),
+            mock.call("use database myapp_pkg_test_user"),
+        ]
+        assert mock_execute_queries.mock_calls == [
+            # Verify template variables were expanded correctly
+            mock.call(
+                dedent(
+                    """\
+                    -- package post-deploy script (1/2)
+
+                    select 'test_value';
+                    """
+                )
+            ),
+            mock.call("-- package post-deploy script (2/2)\n"),
+        ]
+
+
+@mock.patch(SQL_EXECUTOR_EXECUTE)
+@mock.patch(SQL_EXECUTOR_EXECUTE_QUERIES)
+@mock.patch(CLI_GLOBAL_TEMPLATE_CONTEXT, new_callable=mock.PropertyMock)
+@mock.patch.dict(os.environ, {"USER": "test_user"})
+@mock_connection()
+def test_package_post_deploy_scripts_with_mix_syntax_templates(
+    mock_conn,
+    mock_cli_ctx,
+    mock_execute_queries,
+    mock_execute_query,
+    project_directory,
+):
+    mock_conn.return_value = MockConnectionCtx()
+    with project_directory("napp_post_deploy") as project_dir:
+        # edit scripts/package_post_deploy1.sql to include template variables
+        with open(project_dir / "scripts" / "package_post_deploy1.sql", "w") as f:
+            f.write(
+                dedent(
+                    """\
+                    -- package post-deploy script (1/2)
+
+                    select '<% ctx.env.test %>';
+                    select '&{ ctx.env.test }';
+                    """
+                )
+            )
+
+        dm = DefinitionManager(project_dir, {"ctx": {"env": {"test": "test_value"}}})
+        manager = NativeAppManager(
+            project_definition=dm.project_definition.native_app,
+            project_root=dm.project_root,
+        )
+        mock_cli_ctx.return_value = dm.template_context
+
+        with pytest.raises(InvalidTemplate) as err:
+            manager.execute_package_post_deploy_hooks()
+
+        assert (
+            "The SQL query in scripts/package_post_deploy1.sql mixes &{ ... } syntax and <% ... %> syntax."
+            == str(err.value)
         )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
By supporting old and new templating syntax, we warn if both old syntax is used, and we error out if both old and new syntax is used at the same time in the same file.

The error messaging for these does not say which file is coming from.
In this PR I do some small refactor while adding the name of the file in the messaging.

I have already added this messaging to templating arbitrary files - this expands it to post_deploy scripts.
