### PR TITLE
SNOW-1643030 Add Native App support to `snow ws migrate` command

### DIFF
--- a/src/snowflake/cli/_plugins/snowpark/commands.py
+++ b/src/snowflake/cli/_plugins/snowpark/commands.py
@@ -446,5 +446,5 @@ def describe(
 def _get_v2_project_definition(cli_context) -> ProjectDefinitionV2:
     pd = cli_context.project_definition
     if not pd.meets_version_requirement("2"):
-        pd = convert_project_definition_to_v2(pd)
+        pd = convert_project_definition_to_v2(cli_context.project_root, pd)
     return pd

--- a/src/snowflake/cli/_plugins/streamlit/commands.py
+++ b/src/snowflake/cli/_plugins/streamlit/commands.py
@@ -138,7 +138,7 @@ def streamlit_deploy(
             raise NoProjectDefinitionError(
                 project_type="streamlit", project_root=cli_context.project_root
             )
-        pd = convert_project_definition_to_v2(pd)
+        pd = convert_project_definition_to_v2(cli_context.project_root, pd)
 
     streamlits: Dict[str, StreamlitEntityModel] = pd.get_entities_by_type(
         entity_type="streamlit"

--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -53,13 +53,14 @@ def migrate(
     ),
     **options,
 ):
-    """Migrates the Snowpark and Streamlit project definition files from V1 to V2."""
-    pd = DefinitionManager().unrendered_project_definition
+    """Migrates the Snowpark, Streamlit, and Native App project definition files from V1 to V2."""
+    manager = DefinitionManager()
+    pd = manager.unrendered_project_definition
 
     if pd.meets_version_requirement("2"):
         return MessageResult("Project definition is already at version 2.")
 
-    pd_v2 = convert_project_definition_to_v2(pd, accept_templates)
+    pd_v2 = convert_project_definition_to_v2(manager.project_root, pd, accept_templates)
 
     SecurePath("snowflake.yml").rename("snowflake_V1.yml")
     with open("snowflake.yml", "w") as file:

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -181,7 +181,9 @@ def convert_native_app_to_v2_data(
         bundle_map = build_bundle(
             project_root, Path(native_app.deploy_root), native_app.artifacts
         )
-        return str(bundle_map.to_project_path(Path("manifest.yml")))
+        # Use a POSIX path to be consistent with other migrated fields
+        # which use POSIX paths as default values
+        return bundle_map.to_project_path(Path("manifest.yml")).as_posix()
 
     package_entity_name = "pkg"
     package = {

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional
 
 from click import ClickException
+from snowflake.cli._plugins.nativeapp.artifacts import (
+    build_bundle,
+)
 from snowflake.cli._plugins.snowpark.common import is_name_a_templated_one
 from snowflake.cli.api.constants import (
     DEFAULT_ENV_FILE,
@@ -10,6 +15,9 @@ from snowflake.cli.api.constants import (
     PROJECT_TEMPLATE_VARIABLE_OPENING,
     SNOWPARK_SHARED_MIXIN,
 )
+from snowflake.cli.api.project.schemas.native_app.application import Application
+from snowflake.cli.api.project.schemas.native_app.native_app import NativeApp
+from snowflake.cli.api.project.schemas.native_app.package import Package
 from snowflake.cli.api.project.schemas.project_definition import (
     ProjectDefinition,
     ProjectDefinitionV2,
@@ -25,18 +33,25 @@ log = logging.getLogger(__name__)
 
 
 def convert_project_definition_to_v2(
-    pd: ProjectDefinition, accept_templates: bool = False
+    project_root: Path, pd: ProjectDefinition, accept_templates: bool = False
 ) -> ProjectDefinitionV2:
     _check_if_project_definition_meets_requirements(pd, accept_templates)
 
     snowpark_data = convert_snowpark_to_v2_data(pd.snowpark) if pd.snowpark else {}
     streamlit_data = convert_streamlit_to_v2_data(pd.streamlit) if pd.streamlit else {}
+    native_app_data = (
+        convert_native_app_to_v2_data(project_root, pd.native_app)
+        if pd.native_app
+        else {}
+    )
     envs = convert_envs_to_v2(pd)
 
     data = {
         "definition_version": "2",
         "entities": get_list_of_all_entities(
-            snowpark_data.get("entities", {}), streamlit_data.get("entities", {})
+            snowpark_data.get("entities", {}),
+            streamlit_data.get("entities", {}),
+            native_app_data.get("entities", {}),
         ),
         "mixins": snowpark_data.get("mixins", None),
         "env": envs,
@@ -99,7 +114,7 @@ def convert_snowpark_to_v2_data(snowpark: Snowpark) -> Dict[str, Any]:
     return data
 
 
-def convert_streamlit_to_v2_data(streamlit: Streamlit):
+def convert_streamlit_to_v2_data(streamlit: Streamlit) -> Dict[str, Any]:
     # Process env file and pages dir
     environment_file = _process_streamlit_files(streamlit.env_file, "environment")
     pages_dir = _process_streamlit_files(streamlit.pages_dir, "pages")
@@ -144,6 +159,74 @@ def convert_streamlit_to_v2_data(streamlit: Streamlit):
     return data
 
 
+def convert_native_app_to_v2_data(
+    project_root, native_app: NativeApp
+) -> Dict[str, Any]:
+    def _make_meta(obj: Application | Package):
+        meta = {}
+        if obj.role:
+            meta["role"] = obj.role
+        if obj.warehouse:
+            meta["warehouse"] = obj.warehouse
+        if obj.post_deploy:
+            meta["post_deploy"] = obj.post_deploy
+        return meta
+
+    def _find_manifest():
+        # We don't know which file in the project directory is the actual manifest,
+        # and we can't iterate through the artifacts property since the src can contain
+        # glob patterns. The simplest solution is to bundle the app and find the
+        # manifest file from the resultant BundleMap, since the bundle process ensures
+        # that only a single source path can map to the corresponding destination path
+        bundle_map = build_bundle(
+            project_root, Path(native_app.deploy_root), native_app.artifacts
+        )
+        return str(bundle_map.to_project_path(Path("manifest.yml")))
+
+    package_entity_name = "pkg"
+    package = {
+        "type": "application package",
+        "identifier": (
+            native_app.package.name
+            if native_app.package and native_app.package.name
+            else f"{native_app.name}_pkg"
+        ),
+        "manifest": _find_manifest(),
+        "artifacts": native_app.artifacts,
+        "bundle_root": native_app.bundle_root,
+        "generated_root": native_app.generated_root,
+        "deploy_root": native_app.deploy_root,
+        "stage": native_app.source_stage,
+        "scratch_stage": native_app.scratch_stage,
+    }
+    if native_app.package:
+        package["distribution"] = native_app.package.distribution
+        if package_meta := _make_meta(native_app.package):
+            package["meta"] = package_meta
+        # todo migrate package scripts (requires migrating template tags)
+
+    app_entity_name = "app"
+    app = {
+        "type": "application",
+        "identifier": (
+            native_app.application.name
+            if native_app.application and native_app.application.name
+            else native_app.name
+        ),
+        "from": {"target": package_entity_name},
+    }
+    if native_app.application:
+        if app_meta := _make_meta(native_app.application):
+            app["meta"] = app_meta
+
+    return {
+        "entities": {
+            package_entity_name: package,
+            app_entity_name: app,
+        }
+    }
+
+
 def convert_envs_to_v2(pd: ProjectDefinition):
     if hasattr(pd, "env") and pd.env:
         data = {k: v for k, v in pd.env.items()}
@@ -166,9 +249,11 @@ def _check_if_project_definition_meets_requirements(
         log.warning(
             "Your V1 definition contains templates. We cannot guarantee the correctness of the migration."
         )
-    if pd.native_app:
+    if pd.native_app and pd.native_app.package and pd.native_app.package.scripts:
         raise ClickException(
-            "Your project file contains a native app definition. Conversion of Native apps is not yet supported"
+            "Your project file contains a native app definition that uses package scripts. "
+            "Package scripts are not supported in definition version 2 and require manual conversion "
+            "to post-deploy scripts."
         )
 
 
@@ -185,10 +270,19 @@ def _process_streamlit_files(
 
 
 def get_list_of_all_entities(
-    snowpark_entities: Dict[str, Any], streamlit_entities: Dict[str, Any]
+    snowpark_entities: Dict[str, Any],
+    streamlit_entities: Dict[str, Any],
+    native_app_entities: Dict[str, Any],
 ):
-    if snowpark_entities.keys() & streamlit_entities.keys():
-        raise ClickException(
-            "In your project, streamlit and snowpark entities share the same name. Please rename them and try again."
-        )
-    return snowpark_entities | streamlit_entities
+    # Check all combinations of entity types for overlapping names
+    # (No need to use itertools here, PDFv1 only supports these three types)
+    for types, first, second in [
+        ("streamlit and snowpark", streamlit_entities, snowpark_entities),
+        ("streamlit and native app", streamlit_entities, native_app_entities),
+        ("native app and snowpark", native_app_entities, snowpark_entities),
+    ]:
+        if first.keys() & second.keys():
+            raise ClickException(
+                f"In your project, {types} entities share the same name. Please rename them and try again."
+            )
+    return snowpark_entities | streamlit_entities | native_app_entities

--- a/tests/project/test_project_definition_v2.py
+++ b/tests/project/test_project_definition_v2.py
@@ -369,7 +369,7 @@ def test_v1_to_v2_conversion(
 
     with project_directory(project_name) as project_dir:
         definition_v1 = DefinitionManager(project_dir).project_definition
-        definition_v2 = convert_project_definition_to_v2(definition_v1)
+        definition_v2 = convert_project_definition_to_v2(project_dir, definition_v1)
         assert definition_v2.definition_version == "2"
         assert (
             definition_v1.snowpark.project_name

--- a/tests/test_data/projects/migration_multiple_entities/app/README.md
+++ b/tests/test_data/projects/migration_multiple_entities/app/README.md
@@ -1,0 +1,4 @@
+# README
+
+This directory contains an extremely simple application that is used for
+integration testing SnowCLI.

--- a/tests/test_data/projects/migration_multiple_entities/app/manifest.yml
+++ b/tests/test_data/projects/migration_multiple_entities/app/manifest.yml
@@ -1,0 +1,18 @@
+# This is a manifest.yml file, a required component of creating a native application.
+# This file defines properties required by the application package, including the location of the setup script and version definitions.
+# Refer to https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest for a detailed understanding of this file.
+
+manifest_version: 1
+
+version:
+  name: dev
+  label: "Dev Version"
+  comment: "Default version used for development. Override for actual deployment."
+
+artifacts:
+  setup_script: setup.sql
+  readme: README.md
+
+configuration:
+  log_level: INFO
+  trace_level: ALWAYS

--- a/tests/test_data/projects/migration_multiple_entities/app/setup.sql
+++ b/tests/test_data/projects/migration_multiple_entities/app/setup.sql
@@ -1,0 +1,19 @@
+create application role if not exists app_public;
+create or alter versioned schema core;
+
+    create or replace procedure core.echo(inp varchar)
+    returns varchar
+    language sql
+    immutable
+    as
+    $$
+    begin
+        return inp;
+    end;
+    $$;
+
+    grant usage on procedure core.echo(varchar) to application role app_public;
+
+    create or replace view core.shared_view as select * from my_shared_content.shared_table;
+
+    grant select on view core.shared_view to application role app_public;

--- a/tests/test_data/projects/migration_multiple_entities/snowflake.yml
+++ b/tests/test_data/projects/migration_multiple_entities/snowflake.yml
@@ -27,3 +27,24 @@ snowpark:
         - name: "name"
           type: "string"
       returns: string
+native_app:
+  name: myapp
+  source_stage: app_src.stage
+  scratch_stage: app_src.scratch
+  artifacts:
+    - src: app/*
+      dest: ./
+    - src: to_process/*
+      dest: ./
+      processors:
+        - native app setup
+        - name: templates
+          properties:
+            foo: bar
+  package:
+    role: pkg_role
+    distribution: external
+  application:
+    name: myapp_app
+    warehouse: app_wh
+    debug: true

--- a/tests/workspace/__snapshots__/test_manager.ambr
+++ b/tests/workspace/__snapshots__/test_manager.ambr
@@ -181,6 +181,13 @@
   '''
   definition_version: '2'
   entities:
+    app:
+      from:
+        target: pkg
+      identifier: myapp_app
+      meta:
+        warehouse: app_wh
+      type: application
     func1:
       artifacts:
       - dest: my_snowpark_project
@@ -204,6 +211,28 @@
         type: variant
       stage: dev_deployment
       type: function
+    pkg:
+      artifacts:
+      - dest: ./
+        src: app/*
+      - dest: ./
+        processors:
+        - name: native app setup
+        - name: templates
+          properties:
+            foo: bar
+        src: to_process/*
+      bundle_root: output/bundle/
+      deploy_root: output/deploy/
+      distribution: external
+      generated_root: __generated/
+      identifier: myapp_pkg
+      manifest: app/manifest.yml
+      meta:
+        role: pkg_role
+      scratch_stage: app_src.scratch
+      stage: app_src.stage
+      type: application package
     procedureName:
       artifacts:
       - dest: my_snowpark_project
@@ -277,6 +306,26 @@
           - name: "name"
             type: "string"
         returns: string
-  
+  native_app:
+    name: myapp
+    source_stage: app_src.stage
+    scratch_stage: app_src.scratch
+    artifacts:
+      - src: app/*
+        dest: ./
+      - src: to_process/*
+        dest: ./
+        processors:
+          - native app setup
+          - name: templates
+            properties:
+              foo: bar
+    package:
+      role: pkg_role
+      distribution: external
+    application:
+      name: myapp_app
+      warehouse: app_wh
+      debug: true
   '''
 # ---

--- a/tests/workspace/__snapshots__/test_manager.ambr
+++ b/tests/workspace/__snapshots__/test_manager.ambr
@@ -327,5 +327,6 @@
       name: myapp_app
       warehouse: app_wh
       debug: true
+  
   '''
 # ---

--- a/tests/workspace/test_manager.py
+++ b/tests/workspace/test_manager.py
@@ -143,15 +143,6 @@ def test_migration_with_only_envs(project_directory, runner):
     assert result.exit_code == 0
 
 
-def test_migrating_native_app_raises_error(
-    project_directory, runner, os_agnostic_snapshot
-):
-    with project_directory("napp_project_1") as pd:
-        result = runner.invoke(["ws", "migrate"])
-    assert result.exit_code == 1
-    assert result.output == os_agnostic_snapshot
-
-
 @pytest.mark.parametrize(
     "duplicated_entity",
     [


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes (covered by existing note).
   * [x] I've described my changes in the section below.

### Changes description
Enables `snow ws migrate` to migrate a v1 or v1.1 Native App project file to v2. Doesn't support migrating package scripts since they use a different template syntax, we'll tackle those in a followup.
