### PR TITLE
SNOW-1653909 Add options for choosing which entities to convert back to v1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## New additions
 * Added templates expansion of arbitrary files for Native Apps through `templates` processor.
+* Added `--package-entity-id` and `--app-entity-id` options to `snow app` commands to allow targeting specific entities when the `definition_version` in `snowflake.yml` is `2` or higher and it contains multiple `application package` or `application` entities.
 
 ## Fixes and improvements
 * Duplicated keys in `snowflake.yml` are now detected and reported.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,6 @@
 
 ## New additions
 * Added templates expansion of arbitrary files for Native Apps through `templates` processor.
-* Added `--package-entity-id` and `--app-entity-id` options to `snow app` commands to allow targeting specific entities when the `definition_version` in `snowflake.yml` is `2` or higher and it contains multiple `application package` or `application` entities.
 
 ## Fixes and improvements
 * Duplicated keys in `snowflake.yml` are now detected and reported.
@@ -56,6 +55,7 @@
 * Added support for `<% ... %>` syntax in SQL templating.
 * Support multiple Streamlit application in single snowflake.yml project definition file.
 * Added `snow ws migrate` command to migrate `snowflake.yml` file from V1 to V2.
+* Added `--package-entity-id` and `--app-entity-id` options to `snow app` commands to allow targeting specific entities when the `definition_version` in `snowflake.yml` is `2` or higher and it contains multiple `application package` or `application` entities.
 
 ## Fixes and improvements
 * Fixed problem with whitespaces in `snow connection add` command.

--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -62,14 +62,12 @@ def _pdf_v2_to_v1(
     app_definition: Optional[ApplicationEntityModel] = None
 
     # Enumerate all application package and application entities in the project definition
-    packages = {}
-    apps = {}
-    for key, entity in v2_definition.entities.items():
-        entity_type = entity.get_type()
-        if entity_type == ApplicationPackageEntityModel.get_type():
-            packages[key] = entity
-        elif entity_type == ApplicationEntityModel.get_type():
-            apps[key] = entity
+    packages: dict[
+        str, ApplicationPackageEntityModel
+    ] = v2_definition.get_entities_by_type(ApplicationPackageEntityModel.get_type())
+    apps: dict[str, ApplicationEntityModel] = v2_definition.get_entities_by_type(
+        ApplicationEntityModel.get_type()
+    )
 
     # Determine the application entity to convert, there can be zero or one
     if app_entity_id:

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -48,11 +48,18 @@
    Prepares a local folder with configured app artifacts.                         
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
-  |                          current working directory.                          |
-  | --env              TEXT  String in format of key=value. Overrides variables  |
-  |                          from env section used for templates.                |
-  | --help     -h            Show this message and exit.                         |
+  | --package-entity-id          TEXT  The ID of the package entity on which to  |
+  |                                    operate when definition_version is 2 or   |
+  |                                    higher.                                   |
+  | --app-entity-id              TEXT  The ID of the application entity on which |
+  |                                    to operate when definition_version is 2   |
+  |                                    or higher.                                |
+  | --project            -p      TEXT  Path where Snowflake project resides.     |
+  |                                    Defaults to current working directory.    |
+  | --env                        TEXT  String in format of key=value. Overrides  |
+  |                                    variables from env section used for       |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format           [TABLE|JSON]  Specifies the output format.                |
@@ -89,32 +96,47 @@
   |                          syncs all local changes to the stage.               |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --prune          --no-prune              Whether to delete specified files   |
-  |                                          from the stage if they don't exist  |
-  |                                          locally. If set, the command        |
-  |                                          deletes files that exist in the     |
-  |                                          stage, but not in the local         |
-  |                                          filesystem. This option cannot be   |
-  |                                          used when paths are specified.      |
-  |                                          [default: no-prune]                 |
-  | --recursive  -r  --no-recursive          Whether to traverse and deploy      |
-  |                                          files from subdirectories. If set,  |
-  |                                          the command deploys all files and   |
-  |                                          subdirectories; otherwise, only     |
-  |                                          files in the current directory are  |
-  |                                          deployed.                           |
-  |                                          [default: no-recursive]             |
-  | --validate       --no-validate           When enabled, this option triggers  |
-  |                                          validation of a deployed Snowflake  |
-  |                                          Native App's setup script SQL       |
-  |                                          [default: validate]                 |
-  | --project    -p                    TEXT  Path where Snowflake project        |
-  |                                          resides. Defaults to current        |
-  |                                          working directory.                  |
-  | --env                              TEXT  String in format of key=value.      |
-  |                                          Overrides variables from env        |
-  |                                          section used for templates.         |
-  | --help       -h                          Show this message and exit.         |
+  | --prune                  --no-prune              Whether to delete specified |
+  |                                                  files from the stage if     |
+  |                                                  they don't exist locally.   |
+  |                                                  If set, the command deletes |
+  |                                                  files that exist in the     |
+  |                                                  stage, but not in the local |
+  |                                                  filesystem. This option     |
+  |                                                  cannot be used when paths   |
+  |                                                  are specified.              |
+  |                                                  [default: no-prune]         |
+  | --recursive          -r  --no-recursive          Whether to traverse and     |
+  |                                                  deploy files from           |
+  |                                                  subdirectories. If set, the |
+  |                                                  command deploys all files   |
+  |                                                  and subdirectories;         |
+  |                                                  otherwise, only files in    |
+  |                                                  the current directory are   |
+  |                                                  deployed.                   |
+  |                                                  [default: no-recursive]     |
+  | --validate               --no-validate           When enabled, this option   |
+  |                                                  triggers validation of a    |
+  |                                                  deployed Snowflake Native   |
+  |                                                  App's setup script SQL      |
+  |                                                  [default: validate]         |
+  | --package-entity-id                        TEXT  The ID of the package       |
+  |                                                  entity on which to operate  |
+  |                                                  when definition_version is  |
+  |                                                  2 or higher.                |
+  | --app-entity-id                            TEXT  The ID of the application   |
+  |                                                  entity on which to operate  |
+  |                                                  when definition_version is  |
+  |                                                  2 or higher.                |
+  | --project            -p                    TEXT  Path where Snowflake        |
+  |                                                  project resides. Defaults   |
+  |                                                  to current working          |
+  |                                                  directory.                  |
+  | --env                                      TEXT  String in format of         |
+  |                                                  key=value. Overrides        |
+  |                                                  variables from env section  |
+  |                                                  used for templates.         |
+  | --help               -h                          Show this message and exit. |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -185,11 +207,18 @@
    Performs a diff between the app's source stage and the local deploy root.      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
-  |                          current working directory.                          |
-  | --env              TEXT  String in format of key=value. Overrides variables  |
-  |                          from env section used for templates.                |
-  | --help     -h            Show this message and exit.                         |
+  | --package-entity-id          TEXT  The ID of the package entity on which to  |
+  |                                    operate when definition_version is 2 or   |
+  |                                    higher.                                   |
+  | --app-entity-id              TEXT  The ID of the application entity on which |
+  |                                    to operate when definition_version is 2   |
+  |                                    or higher.                                |
+  | --project            -p      TEXT  Path where Snowflake project resides.     |
+  |                                    Defaults to current working directory.    |
+  | --env                        TEXT  String in format of key=value. Overrides  |
+  |                                    variables from env section used for       |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -306,6 +335,16 @@
   |                                                     seconds when using the   |
   |                                                     --follow flag.           |
   |                                                     [default: 10]            |
+  | --package-entity-id          TEXT                   The ID of the package    |
+  |                                                     entity on which to       |
+  |                                                     operate when             |
+  |                                                     definition_version is 2  |
+  |                                                     or higher.               |
+  | --app-entity-id              TEXT                   The ID of the            |
+  |                                                     application entity on    |
+  |                                                     which to operate when    |
+  |                                                     definition_version is 2  |
+  |                                                     or higher.               |
   | --project            -p      TEXT                   Path where Snowflake     |
   |                                                     project resides.         |
   |                                                     Defaults to current      |
@@ -473,11 +512,18 @@
    installed in your account.                                                     
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
-  |                          current working directory.                          |
-  | --env              TEXT  String in format of key=value. Overrides variables  |
-  |                          from env section used for templates.                |
-  | --help     -h            Show this message and exit.                         |
+  | --package-entity-id          TEXT  The ID of the package entity on which to  |
+  |                                    operate when definition_version is 2 or   |
+  |                                    higher.                                   |
+  | --app-entity-id              TEXT  The ID of the application entity on which |
+  |                                    to operate when definition_version is 2   |
+  |                                    or higher.                                |
+  | --project            -p      TEXT  Path where Snowflake project resides.     |
+  |                                    Defaults to current working directory.    |
+  | --env                        TEXT  String in format of key=value. Overrides  |
+  |                                    variables from env section used for       |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -623,6 +669,16 @@
   |                                                        Native App's setup    |
   |                                                        script SQL            |
   |                                                        [default: validate]   |
+  | --package-entity-id                           TEXT     The ID of the package |
+  |                                                        entity on which to    |
+  |                                                        operate when          |
+  |                                                        definition_version is |
+  |                                                        2 or higher.          |
+  | --app-entity-id                               TEXT     The ID of the         |
+  |                                                        application entity on |
+  |                                                        which to operate when |
+  |                                                        definition_version is |
+  |                                                        2 or higher.          |
   | --project             -p                      TEXT     Path where Snowflake  |
   |                                                        project resides.      |
   |                                                        Defaults to current   |
@@ -705,33 +761,50 @@
    defined in the project definition file.                                        
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --force                                      When enabled, this option       |
-  |                                              causes the command to           |
-  |                                              implicitly approve any prompts  |
-  |                                              that arise. You should enable   |
-  |                                              this option if interactive mode |
-  |                                              is not specified and if you     |
-  |                                              want perform potentially        |
-  |                                              destructive actions. Defaults   |
-  |                                              to unset.                       |
-  | --cascade          --no-cascade              Whether to drop all application |
-  |                                              objects owned by the            |
-  |                                              application within the account. |
-  |                                              Default: false.                 |
-  | --interactive      --no-interactive          When enabled, this option       |
-  |                                              displays prompts even if the    |
-  |                                              standard input and output are   |
-  |                                              not terminal devices. Defaults  |
-  |                                              to True in an interactive shell |
-  |                                              environment, and False          |
-  |                                              otherwise.                      |
-  | --project      -p                      TEXT  Path where Snowflake project    |
-  |                                              resides. Defaults to current    |
-  |                                              working directory.              |
-  | --env                                  TEXT  String in format of key=value.  |
-  |                                              Overrides variables from env    |
-  |                                              section used for templates.     |
-  | --help         -h                            Show this message and exit.     |
+  | --force                                            When enabled, this option |
+  |                                                    causes the command to     |
+  |                                                    implicitly approve any    |
+  |                                                    prompts that arise. You   |
+  |                                                    should enable this option |
+  |                                                    if interactive mode is    |
+  |                                                    not specified and if you  |
+  |                                                    want perform potentially  |
+  |                                                    destructive actions.      |
+  |                                                    Defaults to unset.        |
+  | --cascade                --no-cascade              Whether to drop all       |
+  |                                                    application objects owned |
+  |                                                    by the application within |
+  |                                                    the account. Default:     |
+  |                                                    false.                    |
+  | --interactive            --no-interactive          When enabled, this option |
+  |                                                    displays prompts even if  |
+  |                                                    the standard input and    |
+  |                                                    output are not terminal   |
+  |                                                    devices. Defaults to True |
+  |                                                    in an interactive shell   |
+  |                                                    environment, and False    |
+  |                                                    otherwise.                |
+  | --package-entity-id                          TEXT  The ID of the package     |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --app-entity-id                              TEXT  The ID of the application |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --project            -p                      TEXT  Path where Snowflake      |
+  |                                                    project resides. Defaults |
+  |                                                    to current working        |
+  |                                                    directory.                |
+  | --env                                        TEXT  String in format of       |
+  |                                                    key=value. Overrides      |
+  |                                                    variables from env        |
+  |                                                    section used for          |
+  |                                                    templates.                |
+  | --help               -h                            Show this message and     |
+  |                                                    exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -802,11 +875,18 @@
    Validates a deployed Snowflake Native App's setup script.                      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
-  |                          current working directory.                          |
-  | --env              TEXT  String in format of key=value. Overrides variables  |
-  |                          from env section used for templates.                |
-  | --help     -h            Show this message and exit.                         |
+  | --package-entity-id          TEXT  The ID of the package entity on which to  |
+  |                                    operate when definition_version is 2 or   |
+  |                                    higher.                                   |
+  | --app-entity-id              TEXT  The ID of the application entity on which |
+  |                                    to operate when definition_version is 2   |
+  |                                    or higher.                                |
+  | --project            -p      TEXT  Path where Snowflake project resides.     |
+  |                                    Defaults to current working directory.    |
+  | --env                        TEXT  String in format of key=value. Overrides  |
+  |                                    variables from env section used for       |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -885,52 +965,70 @@
   |                           [default: None]                                    |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --patch                                   INTEGER  The patch number you want |
-  |                                                    to create for an existing |
-  |                                                    version. Defaults to      |
-  |                                                    undefined if it is not    |
-  |                                                    set, which means the      |
-  |                                                    Snowflake CLI either uses |
-  |                                                    the patch specified in    |
-  |                                                    the manifest.yml file or  |
-  |                                                    automatically generates a |
-  |                                                    new patch number.         |
-  |                                                    [default: None]           |
-  | --skip-git-check                                   When enabled, the         |
-  |                                                    Snowflake CLI skips       |
-  |                                                    checking if your project  |
-  |                                                    has any untracked or      |
-  |                                                    stages files in git.      |
-  |                                                    Default: unset.           |
-  | --interactive         --no-interactive             When enabled, this option |
-  |                                                    displays prompts even if  |
-  |                                                    the standard input and    |
-  |                                                    output are not terminal   |
-  |                                                    devices. Defaults to True |
-  |                                                    in an interactive shell   |
-  |                                                    environment, and False    |
-  |                                                    otherwise.                |
-  | --force                                            When enabled, this option |
-  |                                                    causes the command to     |
-  |                                                    implicitly approve any    |
-  |                                                    prompts that arise. You   |
-  |                                                    should enable this option |
-  |                                                    if interactive mode is    |
-  |                                                    not specified and if you  |
-  |                                                    want perform potentially  |
-  |                                                    destructive actions.      |
-  |                                                    Defaults to unset.        |
-  | --project         -p                      TEXT     Path where Snowflake      |
-  |                                                    project resides. Defaults |
-  |                                                    to current working        |
-  |                                                    directory.                |
-  | --env                                     TEXT     String in format of       |
-  |                                                    key=value. Overrides      |
-  |                                                    variables from env        |
-  |                                                    section used for          |
-  |                                                    templates.                |
-  | --help            -h                               Show this message and     |
-  |                                                    exit.                     |
+  | --patch                                      INTEGER  The patch number you   |
+  |                                                       want to create for an  |
+  |                                                       existing version.      |
+  |                                                       Defaults to undefined  |
+  |                                                       if it is not set,      |
+  |                                                       which means the        |
+  |                                                       Snowflake CLI either   |
+  |                                                       uses the patch         |
+  |                                                       specified in the       |
+  |                                                       manifest.yml file or   |
+  |                                                       automatically          |
+  |                                                       generates a new patch  |
+  |                                                       number.                |
+  |                                                       [default: None]        |
+  | --skip-git-check                                      When enabled, the      |
+  |                                                       Snowflake CLI skips    |
+  |                                                       checking if your       |
+  |                                                       project has any        |
+  |                                                       untracked or stages    |
+  |                                                       files in git. Default: |
+  |                                                       unset.                 |
+  | --interactive            --no-interactive             When enabled, this     |
+  |                                                       option displays        |
+  |                                                       prompts even if the    |
+  |                                                       standard input and     |
+  |                                                       output are not         |
+  |                                                       terminal devices.      |
+  |                                                       Defaults to True in an |
+  |                                                       interactive shell      |
+  |                                                       environment, and False |
+  |                                                       otherwise.             |
+  | --force                                               When enabled, this     |
+  |                                                       option causes the      |
+  |                                                       command to implicitly  |
+  |                                                       approve any prompts    |
+  |                                                       that arise. You should |
+  |                                                       enable this option if  |
+  |                                                       interactive mode is    |
+  |                                                       not specified and if   |
+  |                                                       you want perform       |
+  |                                                       potentially            |
+  |                                                       destructive actions.   |
+  |                                                       Defaults to unset.     |
+  | --package-entity-id                          TEXT     The ID of the package  |
+  |                                                       entity on which to     |
+  |                                                       operate when           |
+  |                                                       definition_version is  |
+  |                                                       2 or higher.           |
+  | --app-entity-id                              TEXT     The ID of the          |
+  |                                                       application entity on  |
+  |                                                       which to operate when  |
+  |                                                       definition_version is  |
+  |                                                       2 or higher.           |
+  | --project            -p                      TEXT     Path where Snowflake   |
+  |                                                       project resides.       |
+  |                                                       Defaults to current    |
+  |                                                       working directory.     |
+  | --env                                        TEXT     String in format of    |
+  |                                                       key=value. Overrides   |
+  |                                                       variables from env     |
+  |                                                       section used for       |
+  |                                                       templates.             |
+  | --help               -h                               Show this message and  |
+  |                                                       exit.                  |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -1009,29 +1107,45 @@
   |                           [default: None]                                    |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --interactive      --no-interactive          When enabled, this option       |
-  |                                              displays prompts even if the    |
-  |                                              standard input and output are   |
-  |                                              not terminal devices. Defaults  |
-  |                                              to True in an interactive shell |
-  |                                              environment, and False          |
-  |                                              otherwise.                      |
-  | --force                                      When enabled, this option       |
-  |                                              causes the command to           |
-  |                                              implicitly approve any prompts  |
-  |                                              that arise. You should enable   |
-  |                                              this option if interactive mode |
-  |                                              is not specified and if you     |
-  |                                              want perform potentially        |
-  |                                              destructive actions. Defaults   |
-  |                                              to unset.                       |
-  | --project      -p                      TEXT  Path where Snowflake project    |
-  |                                              resides. Defaults to current    |
-  |                                              working directory.              |
-  | --env                                  TEXT  String in format of key=value.  |
-  |                                              Overrides variables from env    |
-  |                                              section used for templates.     |
-  | --help         -h                            Show this message and exit.     |
+  | --interactive            --no-interactive          When enabled, this option |
+  |                                                    displays prompts even if  |
+  |                                                    the standard input and    |
+  |                                                    output are not terminal   |
+  |                                                    devices. Defaults to True |
+  |                                                    in an interactive shell   |
+  |                                                    environment, and False    |
+  |                                                    otherwise.                |
+  | --force                                            When enabled, this option |
+  |                                                    causes the command to     |
+  |                                                    implicitly approve any    |
+  |                                                    prompts that arise. You   |
+  |                                                    should enable this option |
+  |                                                    if interactive mode is    |
+  |                                                    not specified and if you  |
+  |                                                    want perform potentially  |
+  |                                                    destructive actions.      |
+  |                                                    Defaults to unset.        |
+  | --package-entity-id                          TEXT  The ID of the package     |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --app-entity-id                              TEXT  The ID of the application |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --project            -p                      TEXT  Path where Snowflake      |
+  |                                                    project resides. Defaults |
+  |                                                    to current working        |
+  |                                                    directory.                |
+  | --env                                        TEXT  String in format of       |
+  |                                                    key=value. Overrides      |
+  |                                                    variables from env        |
+  |                                                    section used for          |
+  |                                                    templates.                |
+  | --help               -h                            Show this message and     |
+  |                                                    exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |
@@ -1102,11 +1216,18 @@
    Lists all versions defined in an application package.                          
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --project  -p      TEXT  Path where Snowflake project resides. Defaults to   |
-  |                          current working directory.                          |
-  | --env              TEXT  String in format of key=value. Overrides variables  |
-  |                          from env section used for templates.                |
-  | --help     -h            Show this message and exit.                         |
+  | --package-entity-id          TEXT  The ID of the package entity on which to  |
+  |                                    operate when definition_version is 2 or   |
+  |                                    higher.                                   |
+  | --app-entity-id              TEXT  The ID of the application entity on which |
+  |                                    to operate when definition_version is 2   |
+  |                                    or higher.                                |
+  | --project            -p      TEXT  Path where Snowflake project resides.     |
+  |                                    Defaults to current working directory.    |
+  | --env                        TEXT  String in format of key=value. Overrides  |
+  |                                    variables from env section used for       |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |

--- a/tests/nativeapp/test_v2_to_v1.py
+++ b/tests/nativeapp/test_v2_to_v1.py
@@ -168,6 +168,258 @@ def test_v2_to_v1_conversions(pdfv2_input, expected_pdfv1, expected_error):
         assert {**pdfv1_actual, **pdfv1_expected} == pdfv1_actual
 
 
+@pytest.mark.parametrize(
+    "pdfv2_input, expected_pdfv1, expected_error",
+    [
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    "pkg": {
+                        "type": "application package",
+                        "identifier": "pkg_name",
+                        "artifacts": [{"src": "app/*", "dest": "./"}],
+                        "manifest": "",
+                        "stage": "app.stage",
+                        "bundle_root": "bundle_root_path",
+                        "generated_root": "generated_root_path",
+                        "deploy_root": "deploy_root_path",
+                        "scratch_stage": "scratch_stage_path",
+                        "meta": {
+                            "role": "pkg_role",
+                            "warehouse": "pkg_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script1.sql"},
+                                {"sql_script": "scripts/script2.sql"},
+                            ],
+                        },
+                        "distribution": "external",
+                    },
+                    "pkg2": {
+                        "type": "application package",
+                        "identifier": "pkg_name2",
+                        "artifacts": [{"src": "app/*", "dest": "./"}],
+                        "manifest": "",
+                        "stage": "app.stage",
+                        "bundle_root": "bundle_root_path",
+                        "generated_root": "generated_root_path",
+                        "deploy_root": "deploy_root_path",
+                        "scratch_stage": "scratch_stage_path",
+                        "meta": {
+                            "role": "pkg_role",
+                            "warehouse": "pkg_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script1.sql"},
+                                {"sql_script": "scripts/script2.sql"},
+                            ],
+                        },
+                        "distribution": "external",
+                    },
+                    "app": {
+                        "type": "application",
+                        "identifier": "app_name",
+                        "from": {"target": "pkg"},
+                        "debug": True,
+                        "meta": {
+                            "role": "app_role",
+                            "warehouse": "app_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script3.sql"},
+                                {"sql_script": "scripts/script4.sql"},
+                            ],
+                        },
+                    },
+                },
+            },
+            None,
+            "More than one application package entity exists in the project definition file, "
+            "specify --package-entity-id to choose which one to operate on.",
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    "pkg": {
+                        "type": "application package",
+                        "identifier": "pkg_name",
+                        "artifacts": [{"src": "app/*", "dest": "./"}],
+                        "manifest": "",
+                        "stage": "app.stage",
+                        "bundle_root": "bundle_root_path",
+                        "generated_root": "generated_root_path",
+                        "deploy_root": "deploy_root_path",
+                        "scratch_stage": "scratch_stage_path",
+                        "meta": {
+                            "role": "pkg_role",
+                            "warehouse": "pkg_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script1.sql"},
+                                {"sql_script": "scripts/script2.sql"},
+                            ],
+                        },
+                        "distribution": "external",
+                    },
+                    "app": {
+                        "type": "application",
+                        "identifier": "app_name",
+                        "from": {"target": "pkg"},
+                        "debug": True,
+                        "meta": {
+                            "role": "app_role",
+                            "warehouse": "app_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script3.sql"},
+                                {"sql_script": "scripts/script4.sql"},
+                            ],
+                        },
+                    },
+                    "app2": {
+                        "type": "application",
+                        "identifier": "app_name2",
+                        "from": {"target": "pkg"},
+                        "debug": True,
+                        "meta": {
+                            "role": "app_role",
+                            "warehouse": "app_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script3.sql"},
+                                {"sql_script": "scripts/script4.sql"},
+                            ],
+                        },
+                    },
+                },
+            },
+            None,
+            "More than one application entity exists in the project definition file, "
+            "specify --app-entity-id to choose which one to operate on.",
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    "pkg": {
+                        "type": "application package",
+                        "identifier": "pkg_name",
+                        "artifacts": [{"src": "app/*", "dest": "./"}],
+                        "manifest": "",
+                        "stage": "app.stage",
+                        "bundle_root": "bundle_root_path",
+                        "generated_root": "generated_root_path",
+                        "deploy_root": "deploy_root_path",
+                        "scratch_stage": "scratch_stage_path",
+                        "meta": {
+                            "role": "pkg_role",
+                            "warehouse": "pkg_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script1.sql"},
+                                {"sql_script": "scripts/script2.sql"},
+                            ],
+                        },
+                        "distribution": "external",
+                    },
+                    "pkg2": {
+                        "type": "application package",
+                        "identifier": "pkg_name2",
+                        "artifacts": [{"src": "app/*", "dest": "./"}],
+                        "manifest": "",
+                        "stage": "app.stage",
+                        "bundle_root": "bundle_root_path",
+                        "generated_root": "generated_root_path",
+                        "deploy_root": "deploy_root_path",
+                        "scratch_stage": "scratch_stage_path",
+                        "meta": {
+                            "role": "pkg_role",
+                            "warehouse": "pkg_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script1.sql"},
+                                {"sql_script": "scripts/script2.sql"},
+                            ],
+                        },
+                        "distribution": "external",
+                    },
+                    "app": {
+                        "type": "application",
+                        "identifier": "app_name",
+                        "from": {"target": "pkg"},
+                        "debug": True,
+                        "meta": {
+                            "role": "app_role",
+                            "warehouse": "app_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script3.sql"},
+                                {"sql_script": "scripts/script4.sql"},
+                            ],
+                        },
+                    },
+                    "app2": {
+                        "type": "application",
+                        "identifier": "app_name2",
+                        "from": {"target": "pkg2"},
+                        "debug": True,
+                        "meta": {
+                            "role": "app_role",
+                            "warehouse": "app_wh",
+                            "post_deploy": [
+                                {"sql_script": "scripts/script3.sql"},
+                                {"sql_script": "scripts/script4.sql"},
+                            ],
+                        },
+                    },
+                },
+            },
+            {
+                "definition_version": "1.1",
+                "native_app": {
+                    "name": "app_name2",
+                    "artifacts": [{"src": "app/*", "dest": "./"}],
+                    "source_stage": "app.stage",
+                    "bundle_root": "bundle_root_path",
+                    "generated_root": "generated_root_path",
+                    "deploy_root": "deploy_root_path",
+                    "scratch_stage": "scratch_stage_path",
+                    "package": {
+                        "name": "pkg_name2",
+                        "distribution": "external",
+                        "role": "pkg_role",
+                        "warehouse": "pkg_wh",
+                        "post_deploy": [
+                            {"sql_script": "scripts/script1.sql"},
+                            {"sql_script": "scripts/script2.sql"},
+                        ],
+                    },
+                    "application": {
+                        "name": "app_name2",
+                        "role": "app_role",
+                        "debug": True,
+                        "warehouse": "app_wh",
+                        "post_deploy": [
+                            {"sql_script": "scripts/script3.sql"},
+                            {"sql_script": "scripts/script4.sql"},
+                        ],
+                    },
+                },
+            },
+            None,
+        ],
+    ],
+)
+def test_v2_to_v1_conversions_with_multiple_entities(
+    pdfv2_input, expected_pdfv1, expected_error
+):
+    pdfv2 = DefinitionV20(**pdfv2_input)
+    if expected_error:
+        with pytest.raises(ClickException, match=expected_error) as err:
+            _pdf_v2_to_v1(pdfv2)
+    else:
+        pdfv1_actual = vars(
+            _pdf_v2_to_v1(pdfv2, package_entity_id="pkg2", app_entity_id="app2")
+        )
+        pdfv1_expected = vars(DefinitionV11(**expected_pdfv1))
+
+        # Assert that the expected dict is a subset of the actual dict
+        assert {**pdfv1_actual, **pdfv1_expected} == pdfv1_actual
+
+
 def test_decorator_error_when_no_project_exists():
     with pytest.raises(ValueError, match="Project definition could not be found"):
         nativeapp_definition_v2_to_v1(lambda *args: None)()

--- a/tests/nativeapp/test_v2_to_v1.py
+++ b/tests/nativeapp/test_v2_to_v1.py
@@ -30,6 +30,82 @@ from snowflake.cli.api.project.schemas.project_definition import (
 )
 
 
+def package_v2(entity_id: str):
+    return {
+        entity_id: {
+            "type": "application package",
+            "identifier": entity_id,
+            "artifacts": [{"src": "app/*", "dest": "./"}],
+            "manifest": "app/manifest.yml",
+            "stage": "app.stage",
+            "bundle_root": "bundle_root_path",
+            "generated_root": "generated_root_path",
+            "deploy_root": "deploy_root_path",
+            "scratch_stage": "scratch_stage_path",
+            "meta": {
+                "role": "pkg_role",
+                "warehouse": "pkg_wh",
+                "post_deploy": [
+                    {"sql_script": "scripts/script1.sql"},
+                    {"sql_script": "scripts/script2.sql"},
+                ],
+            },
+            "distribution": "external",
+        }
+    }
+
+
+def app_v2(entity_id: str, from_pkg: str):
+    return {
+        entity_id: {
+            "type": "application",
+            "identifier": entity_id,
+            "from": {"target": from_pkg},
+            "debug": True,
+            "meta": {
+                "role": "app_role",
+                "warehouse": "app_wh",
+                "post_deploy": [
+                    {"sql_script": "scripts/script3.sql"},
+                    {"sql_script": "scripts/script4.sql"},
+                ],
+            },
+        }
+    }
+
+
+def native_app_v1(name: str, pkg: str, app: str):
+    return {
+        "name": name,
+        "artifacts": [{"src": "app/*", "dest": "./"}],
+        "source_stage": "app.stage",
+        "bundle_root": "bundle_root_path",
+        "generated_root": "generated_root_path",
+        "deploy_root": "deploy_root_path",
+        "scratch_stage": "scratch_stage_path",
+        "package": {
+            "name": pkg,
+            "distribution": "external",
+            "role": "pkg_role",
+            "warehouse": "pkg_wh",
+            "post_deploy": [
+                {"sql_script": "scripts/script1.sql"},
+                {"sql_script": "scripts/script2.sql"},
+            ],
+        },
+        "application": {
+            "name": app,
+            "role": "app_role",
+            "debug": True,
+            "warehouse": "app_wh",
+            "post_deploy": [
+                {"sql_script": "scripts/script3.sql"},
+                {"sql_script": "scripts/script4.sql"},
+            ],
+        },
+    }
+
+
 @pytest.mark.parametrize(
     "pdfv2_input, expected_pdfv1, expected_error",
     [
@@ -37,18 +113,8 @@ from snowflake.cli.api.project.schemas.project_definition import (
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg1": {
-                        "type": "application package",
-                        "identifier": "pkg",
-                        "artifacts": [],
-                        "manifest": "",
-                    },
-                    "pkg2": {
-                        "type": "application package",
-                        "identifier": "pkg",
-                        "artifacts": [],
-                        "manifest": "",
-                    },
+                    **package_v2("pkg1"),
+                    **package_v2("pkg2"),
                 },
             },
             None,
@@ -58,22 +124,9 @@ from snowflake.cli.api.project.schemas.project_definition import (
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "pkg",
-                        "artifacts": [],
-                        "manifest": "",
-                    },
-                    "app1": {
-                        "type": "application",
-                        "identifier": "pkg",
-                        "from": {"target": "pkg"},
-                    },
-                    "app2": {
-                        "type": "application",
-                        "identifier": "pkg",
-                        "from": {"target": "pkg"},
-                    },
+                    **package_v2("pkg"),
+                    **app_v2("app1", "pkg"),
+                    **app_v2("app2", "pkg"),
                 },
             },
             None,
@@ -83,73 +136,28 @@ from snowflake.cli.api.project.schemas.project_definition import (
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "pkg_name",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                        "bundle_root": "bundle_root_path",
-                        "generated_root": "generated_root_path",
-                        "deploy_root": "deploy_root_path",
-                        "scratch_stage": "scratch_stage_path",
-                        "meta": {
-                            "role": "pkg_role",
-                            "warehouse": "pkg_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script1.sql"},
-                                {"sql_script": "scripts/script2.sql"},
-                            ],
-                        },
-                        "distribution": "external",
-                    },
-                    "app": {
-                        "type": "application",
-                        "identifier": "app_name",
-                        "from": {"target": "pkg"},
-                        "debug": True,
-                        "meta": {
-                            "role": "app_role",
-                            "warehouse": "app_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
+                    **package_v2("pkg"),
+                    **app_v2("app", "pkg"),
                 },
             },
             {
                 "definition_version": "1.1",
-                "native_app": {
-                    "name": "app_name",
-                    "artifacts": [{"src": "app/*", "dest": "./"}],
-                    "source_stage": "app.stage",
-                    "bundle_root": "bundle_root_path",
-                    "generated_root": "generated_root_path",
-                    "deploy_root": "deploy_root_path",
-                    "scratch_stage": "scratch_stage_path",
-                    "package": {
-                        "name": "pkg_name",
-                        "distribution": "external",
-                        "role": "pkg_role",
-                        "warehouse": "pkg_wh",
-                        "post_deploy": [
-                            {"sql_script": "scripts/script1.sql"},
-                            {"sql_script": "scripts/script2.sql"},
-                        ],
-                    },
-                    "application": {
-                        "name": "app_name",
-                        "role": "app_role",
-                        "debug": True,
-                        "warehouse": "app_wh",
-                        "post_deploy": [
-                            {"sql_script": "scripts/script3.sql"},
-                            {"sql_script": "scripts/script4.sql"},
-                        ],
-                    },
+                "native_app": native_app_v1("app", "pkg", "app"),
+            },
+            None,
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    **package_v2("pkg1"),
+                    **package_v2("pkg2"),
+                    **app_v2("app1", "pkg1"),
                 },
+            },
+            {
+                "definition_version": "1.1",
+                "native_app": native_app_v1("app1", "pkg1", "app1"),
             },
             None,
         ],
@@ -169,126 +177,19 @@ def test_v2_to_v1_conversions(pdfv2_input, expected_pdfv1, expected_error):
 
 
 @pytest.mark.parametrize(
-    "pdfv2_input, expected_pdfv1, expected_error",
+    "pdfv2_input, target_pkg, target_app, expected_pdfv1, expected_error",
     [
         [
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "pkg_name",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                        "bundle_root": "bundle_root_path",
-                        "generated_root": "generated_root_path",
-                        "deploy_root": "deploy_root_path",
-                        "scratch_stage": "scratch_stage_path",
-                        "meta": {
-                            "role": "pkg_role",
-                            "warehouse": "pkg_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script1.sql"},
-                                {"sql_script": "scripts/script2.sql"},
-                            ],
-                        },
-                        "distribution": "external",
-                    },
-                    "pkg2": {
-                        "type": "application package",
-                        "identifier": "pkg_name2",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                        "bundle_root": "bundle_root_path",
-                        "generated_root": "generated_root_path",
-                        "deploy_root": "deploy_root_path",
-                        "scratch_stage": "scratch_stage_path",
-                        "meta": {
-                            "role": "pkg_role",
-                            "warehouse": "pkg_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script1.sql"},
-                                {"sql_script": "scripts/script2.sql"},
-                            ],
-                        },
-                        "distribution": "external",
-                    },
-                    "app": {
-                        "type": "application",
-                        "identifier": "app_name",
-                        "from": {"target": "pkg"},
-                        "debug": True,
-                        "meta": {
-                            "role": "app_role",
-                            "warehouse": "app_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
+                    **package_v2("pkg1"),
+                    **app_v2("app1", "pkg1"),
+                    **app_v2("app2", "pkg1"),
                 },
             },
-            None,
-            "More than one application package entity exists in the project definition file, "
-            "specify --package-entity-id to choose which one to operate on.",
-        ],
-        [
-            {
-                "definition_version": "2",
-                "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "pkg_name",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                        "bundle_root": "bundle_root_path",
-                        "generated_root": "generated_root_path",
-                        "deploy_root": "deploy_root_path",
-                        "scratch_stage": "scratch_stage_path",
-                        "meta": {
-                            "role": "pkg_role",
-                            "warehouse": "pkg_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script1.sql"},
-                                {"sql_script": "scripts/script2.sql"},
-                            ],
-                        },
-                        "distribution": "external",
-                    },
-                    "app": {
-                        "type": "application",
-                        "identifier": "app_name",
-                        "from": {"target": "pkg"},
-                        "debug": True,
-                        "meta": {
-                            "role": "app_role",
-                            "warehouse": "app_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
-                    "app2": {
-                        "type": "application",
-                        "identifier": "app_name2",
-                        "from": {"target": "pkg"},
-                        "debug": True,
-                        "meta": {
-                            "role": "app_role",
-                            "warehouse": "app_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
-                },
-            },
+            "",
+            "",
             None,
             "More than one application entity exists in the project definition file, "
             "specify --app-entity-id to choose which one to operate on.",
@@ -297,122 +198,74 @@ def test_v2_to_v1_conversions(pdfv2_input, expected_pdfv1, expected_error):
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "pkg_name",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                        "bundle_root": "bundle_root_path",
-                        "generated_root": "generated_root_path",
-                        "deploy_root": "deploy_root_path",
-                        "scratch_stage": "scratch_stage_path",
-                        "meta": {
-                            "role": "pkg_role",
-                            "warehouse": "pkg_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script1.sql"},
-                                {"sql_script": "scripts/script2.sql"},
-                            ],
-                        },
-                        "distribution": "external",
-                    },
-                    "pkg2": {
-                        "type": "application package",
-                        "identifier": "pkg_name2",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                        "bundle_root": "bundle_root_path",
-                        "generated_root": "generated_root_path",
-                        "deploy_root": "deploy_root_path",
-                        "scratch_stage": "scratch_stage_path",
-                        "meta": {
-                            "role": "pkg_role",
-                            "warehouse": "pkg_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script1.sql"},
-                                {"sql_script": "scripts/script2.sql"},
-                            ],
-                        },
-                        "distribution": "external",
-                    },
-                    "app": {
-                        "type": "application",
-                        "identifier": "app_name",
-                        "from": {"target": "pkg"},
-                        "debug": True,
-                        "meta": {
-                            "role": "app_role",
-                            "warehouse": "app_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
-                    "app2": {
-                        "type": "application",
-                        "identifier": "app_name2",
-                        "from": {"target": "pkg2"},
-                        "debug": True,
-                        "meta": {
-                            "role": "app_role",
-                            "warehouse": "app_wh",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
+                    **package_v2("pkg1"),
+                    **package_v2("pkg2"),
+                    **app_v2("app2", "pkg1"),
                 },
             },
+            "pkg2",
+            "app2",
+            None,
+            "The application entity app2 does not "
+            "target the application package entity pkg2.",
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    **package_v2("pkg1"),
+                    **package_v2("pkg2"),
+                },
+            },
+            "",
+            "",
+            None,
+            "More than one application package entity exists in the project definition file, "
+            "specify --package-entity-id to choose which one to operate on.",
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    **package_v2("pkg1"),
+                    **package_v2("pkg2"),
+                },
+            },
+            "pkg3",
+            "",
+            None,
+            f'Could not find an application package entity with ID "pkg3" in the project definition file.',
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    **package_v2("pkg1"),
+                    **app_v2("app1", "pkg1"),
+                    **package_v2("pkg2"),
+                    **app_v2("app2", "pkg2"),
+                },
+            },
+            "pkg2",
+            "app2",
             {
                 "definition_version": "1.1",
-                "native_app": {
-                    "name": "app_name2",
-                    "artifacts": [{"src": "app/*", "dest": "./"}],
-                    "source_stage": "app.stage",
-                    "bundle_root": "bundle_root_path",
-                    "generated_root": "generated_root_path",
-                    "deploy_root": "deploy_root_path",
-                    "scratch_stage": "scratch_stage_path",
-                    "package": {
-                        "name": "pkg_name2",
-                        "distribution": "external",
-                        "role": "pkg_role",
-                        "warehouse": "pkg_wh",
-                        "post_deploy": [
-                            {"sql_script": "scripts/script1.sql"},
-                            {"sql_script": "scripts/script2.sql"},
-                        ],
-                    },
-                    "application": {
-                        "name": "app_name2",
-                        "role": "app_role",
-                        "debug": True,
-                        "warehouse": "app_wh",
-                        "post_deploy": [
-                            {"sql_script": "scripts/script3.sql"},
-                            {"sql_script": "scripts/script4.sql"},
-                        ],
-                    },
-                },
+                "native_app": native_app_v1("app2", "pkg2", "app2"),
             },
             None,
         ],
     ],
 )
 def test_v2_to_v1_conversions_with_multiple_entities(
-    pdfv2_input, expected_pdfv1, expected_error
+    pdfv2_input, target_pkg, target_app, expected_pdfv1, expected_error
 ):
     pdfv2 = DefinitionV20(**pdfv2_input)
     if expected_error:
         with pytest.raises(ClickException, match=expected_error) as err:
-            _pdf_v2_to_v1(pdfv2)
+            _pdf_v2_to_v1(pdfv2, package_entity_id=target_pkg, app_entity_id=target_app)
     else:
         pdfv1_actual = vars(
-            _pdf_v2_to_v1(pdfv2, package_entity_id="pkg2", app_entity_id="app2")
+            _pdf_v2_to_v1(pdfv2, package_entity_id=target_pkg, app_entity_id=target_app)
         )
         pdfv1_expected = vars(DefinitionV11(**expected_pdfv1))
 
@@ -433,25 +286,8 @@ def test_decorator_error_when_no_project_exists():
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "package_name",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                    },
-                    "app": {
-                        "type": "application",
-                        "identifier": "application_name",
-                        "from": {"target": "pkg"},
-                        "meta": {
-                            "role": "app_role",
-                            "post_deploy": [
-                                {"sql_script": "scripts/script3.sql"},
-                                {"sql_script": "scripts/script4.sql"},
-                            ],
-                        },
-                    },
+                    **package_v2("pkg"),
+                    **app_v2("application_name", "pkg"),
                 },
             },
             "application_name",
@@ -461,13 +297,7 @@ def test_decorator_error_when_no_project_exists():
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "package_name",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                    },
+                    **package_v2("package_name"),
                 },
             },
             "package_name",
@@ -477,13 +307,7 @@ def test_decorator_error_when_no_project_exists():
             {
                 "definition_version": "2",
                 "entities": {
-                    "pkg": {
-                        "type": "application package",
-                        "identifier": "appname_pkg_username",
-                        "artifacts": [{"src": "app/*", "dest": "./"}],
-                        "manifest": "",
-                        "stage": "app.stage",
-                    },
+                    **package_v2("appname_pkg_username"),
                 },
             },
             "appname",

--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -21,9 +21,9 @@ def nativeapp_project_directory(project_directory, nativeapp_teardown):
     """
 
     @contextmanager
-    def _nativeapp_project_directory(name):
+    def _nativeapp_project_directory(name, teardown_args: list[str] | None = None):
         with project_directory(name) as d:
-            with nativeapp_teardown(project_dir=d):
+            with nativeapp_teardown(project_dir=d, extra_args=teardown_args):
                 yield d
 
     return _nativeapp_project_directory
@@ -47,6 +47,7 @@ def nativeapp_teardown(runner: SnowCLIRunner):
         *,
         project_dir: Path | None = None,
         env: dict | None = None,
+        extra_args: list[str] | None = None,
     ):
         try:
             yield
@@ -54,6 +55,8 @@ def nativeapp_teardown(runner: SnowCLIRunner):
             args = ["--force", "--cascade"]
             if project_dir:
                 args += ["--project", str(project_dir)]
+            if extra_args:
+                args += extra_args
             kwargs: dict[str, Any] = {}
             if env:
                 kwargs["env"] = env

--- a/tests_integration/test_data/projects/napp_init_v2_multiple_entities/app/README.md
+++ b/tests_integration/test_data/projects/napp_init_v2_multiple_entities/app/README.md
@@ -1,0 +1,3 @@
+# README
+
+This is the v2 version of the napp_init_v1 project with multiple PDFv2 entities of the same type

--- a/tests_integration/test_data/projects/napp_init_v2_multiple_entities/app/manifest.yml
+++ b/tests_integration/test_data/projects/napp_init_v2_multiple_entities/app/manifest.yml
@@ -1,0 +1,7 @@
+# This is the v2 version of the napp_init_v1 project
+
+manifest_version: 1
+
+artifacts:
+  setup_script: setup_script.sql
+  readme: README.md

--- a/tests_integration/test_data/projects/napp_init_v2_multiple_entities/app/setup_script.sql
+++ b/tests_integration/test_data/projects/napp_init_v2_multiple_entities/app/setup_script.sql
@@ -1,0 +1,3 @@
+-- This is the v2 version of the napp_init_v1 project
+
+CREATE OR ALTER VERSIONED SCHEMA core;

--- a/tests_integration/test_data/projects/napp_init_v2_multiple_entities/snowflake.yml
+++ b/tests_integration/test_data/projects/napp_init_v2_multiple_entities/snowflake.yml
@@ -1,0 +1,28 @@
+# This is the v2 version of the napp_init_v1 project definition
+
+definition_version: 2
+entities:
+  pkg:
+    type: application package
+    identifier: myapp_pkg_<% ctx.env.USER %>
+    artifacts:
+      - src: app/*
+        dest: ./
+    manifest: app/manifest.yml
+  app:
+    type: application
+    identifier: myapp_<% ctx.env.USER %>
+    from:
+      target: pkg
+  pkg2:
+    type: application package
+    identifier: myapp_pkg_<% ctx.env.USER %>_2
+    artifacts:
+      - src: app/*
+        dest: ./
+    manifest: app/manifest.yml
+  app2:
+    type: application
+    identifier: myapp_<% ctx.env.USER %>_2
+    from:
+      target: pkg2


### PR DESCRIPTION
Use the [no-whitespace diff](https://github.com/snowflakedb/snowflake-cli/pull/1546/files?w=1) for a more pleasant diff-viewing experience

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds `--package-entity-id` and `--app-entity-id` options to all commands that use `@nativeapp_definition_v2_to_v1` to allow us to handle v2 definitions that have multiple apps or packages in the old v1 commands.

The new logic will also attempt to determine which app or package to convert if it's non-ambiguous (i.e. there's only one entity of that type) and will infer the package to convert from the application entity's `target` field.