### PR TITLE
SNOW-1653909 If we can't find an app entity to convert, only fail if it's required, update `snow app teardown` to tear down multiple apps

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -306,7 +306,7 @@ def app_open(
 
 @app.command("teardown", requires_connection=True)
 @with_project_definition()
-# This command doesn't use @nativeapp_definition_v2_to_v1() because it needs to
+# This command doesn't use @nativeapp_definition_v2_to_v1 because it needs to
 # be aware of PDFv2 definitions that have multiple apps created from the same package,
 # which all need to be torn down.
 def app_teardown(
@@ -317,7 +317,7 @@ def app_teardown(
         show_default=False,
     ),
     interactive: bool = InteractiveOption,
-    # From nativeapp_definition_v2_to_v1
+    # Same as the param auto-added by @nativeapp_definition_v2_to_v1
     package_entity_id: Optional[str] = typer.Option(
         default="",
         help="The ID of the package entity on which to operate when definition_version is 2 or higher.",
@@ -347,7 +347,7 @@ def app_teardown(
             # Make sure the package entity exists in the project definition
             ws.get_entity(package_entity_id)
         except ValueError:
-            # Same as _pdf_v2_to_v1
+            # Same as what @nativeapp_definition_v2_to_v1 does
             raise ClickException(
                 f'Could not find an application package entity with ID "{package_entity_id}" '
                 f"in the project definition file."

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -343,25 +343,27 @@ def app_teardown(
         # New behaviour, multi-app aware so teardown all the apps created from the package
 
         # Determine the package entity to drop, there must be one
-        app_package_definition = find_entity(
+        app_package_entity = find_entity(
             project,
             ApplicationPackageEntityModel,
             package_entity_id,
             disambiguation_option="--package-entity-id",
             required=True,
         )
-        assert app_package_definition is not None  # satisfy mypy
+        assert app_package_entity is not None  # satisfy mypy
 
         # Same implementation as `snow ws drop`
         ws = WorkspaceManager(
             project_definition=cli_context.project_definition,
             project_root=cli_context.project_root,
         )
-        for app_id in project.get_entities_by_type(ApplicationEntityModel.get_type()):
+        for app_entity in project.get_entities_by_type(
+            ApplicationEntityModel.get_type()
+        ).values():
             # Drop each app
-            if app_id.from_.target == app_package_definition.entity_id:
+            if app_entity.from_.target == app_package_entity.entity_id:
                 ws.perform_action(
-                    app_id,
+                    app_entity.entity_id,
                     EntityActions.DROP,
                     force_drop=force,
                     interactive=interactive,
@@ -369,7 +371,7 @@ def app_teardown(
                 )
         # Then drop the package
         ws.perform_action(
-            app_package_definition.entity_id,
+            app_package_entity.entity_id,
             EntityActions.DROP,
             force_drop=force,
             interactive=interactive,

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -299,7 +299,7 @@ def app_open(
 
 @app.command("teardown", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1(app_required=True)
+@nativeapp_definition_v2_to_v1(app_required=False)
 def app_teardown(
     force: Optional[bool] = ForceOption,
     cascade: Optional[bool] = typer.Option(

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -350,7 +350,7 @@ def app_teardown(
             disambiguation_option="--package-entity-id",
             required=True,
         )
-        assert app_package_definition is not None, "package entity is required"
+        assert app_package_definition is not None  # satisfy mypy
 
         # Same implementation as `snow ws drop`
         ws = WorkspaceManager(

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -160,7 +160,7 @@ def app_list_templates(**options) -> CommandResult:
 
 @app.command("bundle")
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def app_bundle(
     **options,
 ) -> CommandResult:
@@ -181,7 +181,7 @@ def app_bundle(
 
 @app.command("diff", requires_connection=True, hidden=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def app_diff(
     **options,
 ) -> CommandResult:
@@ -208,7 +208,7 @@ def app_diff(
 
 @app.command("run", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1(app_required=True)
 def app_run(
     version: Optional[str] = typer.Option(
         None,
@@ -272,7 +272,7 @@ def app_run(
 
 @app.command("open", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1(app_required=True)
 def app_open(
     **options,
 ) -> CommandResult:
@@ -299,7 +299,7 @@ def app_open(
 
 @app.command("teardown", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1(app_required=True)
 def app_teardown(
     force: Optional[bool] = ForceOption,
     cascade: Optional[bool] = typer.Option(
@@ -327,7 +327,7 @@ def app_teardown(
 
 @app.command("deploy", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def app_deploy(
     prune: Optional[bool] = typer.Option(
         default=None,
@@ -395,7 +395,7 @@ def app_deploy(
 
 @app.command("validate", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def app_validate(**options):
     """
     Validates a deployed Snowflake Native App's setup script.
@@ -428,7 +428,7 @@ DEFAULT_EVENT_FOLLOW_LAST = 20
 
 @app.command("events", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1(app_required=True)
 def app_events(
     since: str = typer.Option(
         default="",

--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -97,7 +97,7 @@ def _pdf_v2_to_v1(
         disambiguation_option="--package-entity-id",
         required=True,
     )
-    assert app_package_definition is not None, "package entity is required"
+    assert app_package_definition is not None  # satisfy mypy
 
     # NativeApp
     if app_definition and app_definition.fqn.identifier:

--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -167,6 +167,20 @@ def find_entity(
     disambiguation_option: str,
     required: bool,
 ) -> T | None:
+    """
+    Find an entity of the specified type in the project definition file.
+
+    If an ID is passed, only that entity will be considered,
+    otherwise look for a single entity of the specified type.
+
+    If there are multiple entities of the specified type,
+    the user must specify which one to use using the CLI option
+    named in the disambiguation_option parameter.
+
+    If no entity is found, an error is raised if required is True,
+    otherwise None is returned.
+    """
+
     entity_type = entity_class.get_type()
     entities = project_definition.get_entities_by_type(entity_type)
 

--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -75,7 +75,8 @@ def _pdf_v2_to_v1(
         if package_entity_id:
             # If the user specified a package entity ID,
             # check that the app entity targets the user-specified package entity
-            if target_package != package_entity_id:
+            # if the app entity is used by the command being run
+            if target_package != package_entity_id and app_required:
                 raise ClickException(
                     f"The application entity {app_definition.entity_id} does not "
                     f"target the application package entity {package_entity_id}. Either"

--- a/src/snowflake/cli/_plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/commands.py
@@ -51,7 +51,7 @@ log = logging.getLogger(__name__)
 
 @app.command(requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def create(
     version: Optional[str] = typer.Argument(
         None,
@@ -117,7 +117,7 @@ def create(
 
 @app.command("list", requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def version_list(
     **options,
 ) -> CommandResult:
@@ -138,7 +138,7 @@ def version_list(
 
 @app.command(requires_connection=True)
 @with_project_definition()
-@nativeapp_definition_v2_to_v1
+@nativeapp_definition_v2_to_v1()
 def drop(
     version: Optional[str] = typer.Argument(
         None,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -789,11 +789,6 @@
   |                                                    operate when              |
   |                                                    definition_version is 2   |
   |                                                    or higher.                |
-  | --app-entity-id                              TEXT  The ID of the application |
-  |                                                    entity on which to        |
-  |                                                    operate when              |
-  |                                                    definition_version is 2   |
-  |                                                    or higher.                |
   | --project            -p                      TEXT  Path where Snowflake      |
   |                                                    project resides. Defaults |
   |                                                    to current working        |

--- a/tests/nativeapp/test_v2_to_v1.py
+++ b/tests/nativeapp/test_v2_to_v1.py
@@ -272,22 +272,6 @@ def test_v2_to_v1_conversions(pdfv2_input, expected_pdfv1, expected_error):
                 "entities": {
                     **package_v2("pkg1"),
                     **package_v2("pkg2"),
-                    **app_v2("app2", "pkg1"),
-                },
-            },
-            "pkg2",
-            "app2",
-            False,
-            None,
-            "The application entity app2 does not "
-            "target the application package entity pkg2.",
-        ],
-        [
-            {
-                "definition_version": "2",
-                "entities": {
-                    **package_v2("pkg1"),
-                    **package_v2("pkg2"),
                 },
             },
             "",

--- a/tests/test_data/projects/integration_templated_v2/snowflake.yml
+++ b/tests/test_data/projects/integration_templated_v2/snowflake.yml
@@ -12,6 +12,11 @@ entities:
       post_deploy:
         - sql_script: package/001-shared.sql
         - sql_script: package/002-shared.sql
+  app:
+    type: application
+    identifier: integration_<% ctx.env.INTERMEDIATE_CI_ENV %>_<% ctx.env.USER %>
+    from:
+      target: pkg
 env:
   INTERMEDIATE_CI_ENV: '<% ctx.env.CI_ENV %>'
   CI_ENV: 'dev'

--- a/tests/test_data/projects/integration_v2/snowflake.yml
+++ b/tests/test_data/projects/integration_v2/snowflake.yml
@@ -12,3 +12,8 @@ entities:
       post_deploy:
         - sql_script: package/001-shared.sql
         - sql_script: package/002-shared.sql
+  app:
+    type: application
+    identifier: integration_<% ctx.env.USER %>
+    from:
+      target: pkg

--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -70,12 +70,19 @@ def nativeapp_teardown(runner: SnowCLIRunner):
                 project_yml = yaml.safe_load(f)
             packages = [
                 entity_id
-                for entity_id, entity in project_yml["entities"].items()
+                for entity_id, entity in project_yml.get("entities", {}).items()
                 if entity["type"] == "application package"
             ]
-            for package in packages:
+            if packages:
+                for package in packages:
+                    result = runner.invoke_with_connection(
+                        ["app", "teardown", *args, "--package-entity-id", package],
+                        **kwargs,
+                    )
+                    assert result.exit_code == 0
+            else:
                 result = runner.invoke_with_connection(
-                    ["app", "teardown", *args, "--package-entity-id", package], **kwargs
+                    ["app", "teardown", *args], **kwargs
                 )
                 assert result.exit_code == 0
 

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -81,9 +81,12 @@ def test_nativeapp_init_run_multiple_pdf_entities(
     resource_suffix,
 ):
     project_name = "myapp"
-    entity_id_selector = ["--package-entity-id", "pkg2", "--app-entity-id", "app2"]
-    with nativeapp_project_directory(test_project, teardown_args=entity_id_selector):
-        result = runner.invoke_with_connection_json(["app", "run"] + entity_id_selector)
+    with nativeapp_project_directory(
+        test_project, teardown_args=["--package-entity-id", "pkg2"]
+    ):
+        result = runner.invoke_with_connection_json(
+            ["app", "run", "--package-entity-id", "pkg2", "--app-entity-id", "app2"]
+        )
         assert result.exit_code == 0
 
         # app + package exist

--- a/tests_integration/nativeapp/test_teardown.py
+++ b/tests_integration/nativeapp/test_teardown.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from shlex import split
 
+import yaml
+
 from tests.project.fixtures import *
 from tests_integration.test_utils import (
     contains_row_with,
@@ -261,3 +263,122 @@ def test_nativeapp_teardown_pkg_versions(
         # either way, we can now tear down the application package
         result = runner.invoke_with_connection(split(command) + teardown_args)
         assert result.exit_code == 0
+
+
+def test_nativeapp_teardown_multiple_apps_using_snow_app(
+    runner,
+    nativeapp_project_directory,
+    snowflake_session,
+    default_username,
+    resource_suffix,
+):
+    test_project = "napp_init_v2"
+    project_name = "myapp"
+    pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
+    app_name_1 = f"{project_name}_{default_username}{resource_suffix}".upper()
+    app_name_2 = f"{project_name}2_{default_username}{resource_suffix}".upper()
+
+    with nativeapp_project_directory(test_project) as project_dir:
+        # Add a second app to the project
+        snowflake_yml = project_dir / "snowflake.yml"
+        with open(snowflake_yml, "r") as file:
+            project_yml = yaml.safe_load(file)
+        project_yml["entities"]["app2"] = project_yml["entities"]["app"] | dict(
+            identifier="myapp2_<% ctx.env.USER %>"
+        )
+        with open(snowflake_yml, "w") as file:
+            yaml.dump(project_yml, file)
+
+        # Create the package and both apps
+        result = runner.invoke_with_connection_json(
+            ["app", "run", "--app-entity-id", "app"]
+        )
+        assert result.exit_code == 0, result.output
+
+        result = runner.invoke_with_connection_json(
+            ["app", "run", "--app-entity-id", "app2"]
+        )
+        assert result.exit_code == 0, result.output
+
+        # Run the teardown command
+        result = runner.invoke_with_connection_json(["app", "teardown"])
+        assert result.exit_code == 0, result.output
+
+        # Verify the package is dropped
+        assert not_contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '{pkg_name}'",
+                )
+            ),
+            dict(name=pkg_name),
+        )
+
+        # Verify the apps are dropped
+        for app_name in [app_name_1, app_name_2]:
+            assert not_contains_row_with(
+                row_from_snowflake_session(
+                    snowflake_session.execute_string(
+                        f"show applications like '{app_name}'",
+                    )
+                ),
+                dict(name=app_name),
+            )
+
+
+def test_nativeapp_teardown_multiple_packages_using_snow_app_must_choose(
+    runner,
+    nativeapp_project_directory,
+    snowflake_session,
+    default_username,
+    resource_suffix,
+):
+    test_project = "napp_init_v2"
+    project_name = "myapp"
+    pkgs = {
+        "pkg": f"{project_name}_pkg_{default_username}{resource_suffix}",
+        "pkg2": f"{project_name}_pkg2_{default_username}{resource_suffix}",
+    }
+
+    with nativeapp_project_directory(test_project) as project_dir:
+        # Add a second package to the project
+        snowflake_yml = project_dir / "snowflake.yml"
+        with open(snowflake_yml, "r") as file:
+            project_yml = yaml.safe_load(file)
+        project_yml["entities"]["pkg2"] = project_yml["entities"]["pkg"] | dict(
+            identifier="myapp_pkg2_<% ctx.env.USER %>"
+        )
+        with open(snowflake_yml, "w") as file:
+            yaml.dump(project_yml, file)
+
+        # Create both packages
+        for entity_id in pkgs:
+            result = runner.invoke_with_connection_json(
+                ["app", "deploy", "--package-entity-id", entity_id]
+            )
+            assert result.exit_code == 0, result.output
+
+        # Run the teardown command without specifying a package, it should fail
+        result = runner.invoke_with_connection_json(["app", "teardown"])
+        assert result.exit_code == 1, result.output
+        assert (
+            "More than one application package entity exists in the project definition"
+            in result.output
+        )
+
+        # Run the teardown command on each package
+        for entity_id, pkg_name in pkgs.items():
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown", "--package-entity-id", entity_id]
+            )
+            assert result.exit_code == 0, result.output
+
+            # Verify the package is dropped
+            assert not_contains_row_with(
+                row_from_snowflake_session(
+                    snowflake_session.execute_string(
+                        f"show application packages like '{pkg_name}'",
+                    )
+                ),
+                dict(name=pkg_name),
+            )


### PR DESCRIPTION
Use the [no-whitespace diff](https://github.com/snowflakedb/snowflake-cli/pull/1557/files?w=1) for a more pleasant diff-viewing experience

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Followup to #1546 to fix a bug where it would complain if we had a PDv2 with multiple app entities for commands that didn't care about the app at all.

Also updates `snow app teardown` to me PDFv2-aware so we can teardown all the apps created from one package.