### PR TITLE
Catch error on deploy for package with special comment

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -57,7 +57,7 @@
 * `snow streamlit deploy` will check for existing streamlit instance before deploying anything.
 * Fixed `snow git execute` with `/` in name of the branch.
 * `snow app` commands don't enforce ownership of the objects they manage, and rely on RBAC instead.
-* `snow app deploy` and `snow ws deploy` for package entity now allows operating on application packages created outside the CLI
+* `snow app deploy` for package entity now allows operating on application packages created outside the CLI
 
 # v2.8.1
 ## Backward incompatibility

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -57,6 +57,7 @@
 * `snow streamlit deploy` will check for existing streamlit instance before deploying anything.
 * Fixed `snow git execute` with `/` in name of the branch.
 * `snow app` commands don't enforce ownership of the objects they manage, and rely on RBAC instead.
+* `snow app deploy` and `snow ws deploy` for package entity now allows operating on application packages created outside the CLI
 
 # v2.8.1
 ## Backward incompatibility

--- a/src/snowflake/cli/_plugins/nativeapp/application_entity.py
+++ b/src/snowflake/cli/_plugins/nativeapp/application_entity.py
@@ -146,6 +146,8 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                 paths=[],
                 validate=validate,
                 stage_fqn=stage_fqn,
+                interactive=interactive,
+                force=force,
             )
 
         self.deploy(

--- a/src/snowflake/cli/_plugins/nativeapp/application_package_entity.py
+++ b/src/snowflake/cli/_plugins/nativeapp/application_package_entity.py
@@ -142,7 +142,9 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             force_drop=force_drop,
         )
 
-    def action_validate(self, ctx: ActionContext, *args, **kwargs):
+    def action_validate(
+        self, ctx: ActionContext, interactive: bool, force: bool, *args, **kwargs
+    ):
         model = self._entity_model
         package_name = model.fqn.identifier
         stage_fqn = f"{package_name}.{model.stage}"
@@ -159,6 +161,8 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 paths=[],
                 validate=False,
                 stage_fqn=model.scratch_stage,
+                interactive=interactive,
+                force=force,
             )
 
         self.validate_setup_script(

--- a/src/snowflake/cli/_plugins/nativeapp/application_package_entity.py
+++ b/src/snowflake/cli/_plugins/nativeapp/application_package_entity.py
@@ -27,12 +27,19 @@ from snowflake.cli._plugins.nativeapp.exceptions import (
     CouldNotDropApplicationPackageWithVersions,
     SetupScriptFailedValidation,
 )
+from snowflake.cli._plugins.nativeapp.policy import (
+    AllowAlwaysPolicy,
+    AskAlwaysPolicy,
+    DenyAlwaysPolicy,
+    PolicyBase,
+)
 from snowflake.cli._plugins.nativeapp.utils import (
     needs_confirmation,
 )
 from snowflake.cli._plugins.stage.diff import DiffResult
 from snowflake.cli._plugins.stage.manager import StageManager
 from snowflake.cli._plugins.workspace.action_context import ActionContext
+from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.console.abc import AbstractConsole
 from snowflake.cli.api.entities.common import EntityBase, get_sql_executor
 from snowflake.cli.api.entities.utils import (
@@ -80,12 +87,22 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         recursive: bool,
         paths: List[Path],
         validate: bool,
+        interactive: bool,
+        force: bool,
         stage_fqn: Optional[str] = None,
         *args,
         **kwargs,
     ):
         model = self._entity_model
         package_name = model.fqn.identifier
+
+        if force:
+            policy = AllowAlwaysPolicy()
+        elif interactive:
+            policy = AskAlwaysPolicy()
+        else:
+            policy = DenyAlwaysPolicy()
+
         return self.deploy(
             console=ctx.console,
             project_root=ctx.project_root,
@@ -107,6 +124,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             ),
             post_deploy_hooks=model.meta and model.meta.post_deploy,
             package_scripts=[],  # Package scripts are not supported in PDFv2
+            policy=policy,
         )
 
     def action_drop(self, ctx: ActionContext, force_drop: bool, *args, **kwargs):
@@ -206,6 +224,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         stage_fqn: str,
         post_deploy_hooks: list[PostDeployHook] | None,
         package_scripts: List[str],
+        policy: PolicyBase,
     ) -> DiffResult:
         # 1. Create a bundle
         bundle_map = cls.bundle(
@@ -218,13 +237,17 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         )
 
         # 2. Create an empty application package, if none exists
-        cls.create_app_package(
-            console=console,
-            package_name=package_name,
-            package_role=package_role,
-            package_distribution=package_distribution,
-        )
-
+        try:
+            cls.create_app_package(
+                console=console,
+                package_name=package_name,
+                package_role=package_role,
+                package_distribution=package_distribution,
+            )
+        except ApplicationPackageAlreadyExistsError as e:
+            cc.warning(e.message)
+            if not policy.should_proceed("Proceed with using this package?"):
+                raise typer.Abort() from e
         with get_sql_executor().use_role(package_role):
             if package_scripts:
                 cls.apply_package_scripts(

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -463,8 +463,6 @@ def app_deploy(
 @with_project_definition()
 @nativeapp_definition_v2_to_v1()
 def app_validate(
-    interactive: bool = InteractiveOption,
-    force: Optional[bool] = ForceOption,
     **options,
 ):
     """
@@ -472,13 +470,6 @@ def app_validate(
     """
 
     assert_project_type("native_app")
-
-    if force:
-        policy = AllowAlwaysPolicy()
-    elif interactive:
-        policy = AskAlwaysPolicy()
-    else:
-        policy = DenyAlwaysPolicy()
 
     cli_context = get_cli_context()
     manager = NativeAppManager(

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -486,11 +486,9 @@ def app_validate(
         project_root=cli_context.project_root,
     )
     if cli_context.output_format == OutputFormat.JSON:
-        return ObjectResult(
-            manager.get_validation_result(policy=policy, use_scratch_stage=True)
-        )
+        return ObjectResult(manager.get_validation_result(use_scratch_stage=True))
 
-    manager.validate(policy=policy, use_scratch_stage=True)
+    manager.validate(use_scratch_stage=True)
     return MessageResult("Snowflake Native App validation succeeded.")
 
 

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -350,6 +350,8 @@ def app_deploy(
             unspecified, the command syncs all local changes to the stage."""
         ).strip(),
     ),
+    interactive: bool = InteractiveOption,
+    force: Optional[bool] = ForceOption,
     validate: bool = ValidateOption,
     **options,
 ) -> CommandResult:
@@ -359,6 +361,13 @@ def app_deploy(
     """
 
     assert_project_type("native_app")
+
+    if force:
+        policy = AllowAlwaysPolicy()
+    elif interactive:
+        policy = AskAlwaysPolicy()
+    else:
+        policy = DenyAlwaysPolicy()
 
     has_paths = paths is not None and len(paths) > 0
     if prune is None and recursive is None and not has_paths:
@@ -386,6 +395,7 @@ def app_deploy(
         recursive=recursive,
         local_paths_to_sync=paths,
         validate=validate,
+        policy=policy,
     )
 
     return MessageResult(

--- a/src/snowflake/cli/_plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/_plugins/nativeapp/manager.py
@@ -36,7 +36,7 @@ from snowflake.cli._plugins.nativeapp.artifacts import (
 from snowflake.cli._plugins.nativeapp.exceptions import (
     NoEventTableForAccount,
 )
-from snowflake.cli._plugins.nativeapp.policy import PolicyBase
+from snowflake.cli._plugins.nativeapp.policy import AllowAlwaysPolicy, PolicyBase
 from snowflake.cli._plugins.nativeapp.project_model import (
     NativeAppProjectModel,
 )
@@ -335,7 +335,7 @@ class NativeAppManager(SqlExecutionMixin):
             policy=policy,
         )
 
-    def deploy_to_scratch_stage_fn(self, policy):
+    def deploy_to_scratch_stage_fn(self):
         bundle_map = self.build_bundle()
         self.deploy(
             bundle_map=bundle_map,
@@ -344,10 +344,10 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn=self.scratch_stage_fqn,
             validate=False,
             print_diff=False,
-            policy=policy,
+            policy=AllowAlwaysPolicy(),
         )
 
-    def validate(self, policy, use_scratch_stage: bool = False):
+    def validate(self, use_scratch_stage: bool = False):
         return ApplicationPackageEntity.validate_setup_script(
             console=cc,
             package_name=self.package_name,
@@ -355,12 +355,10 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn=self.stage_fqn,
             use_scratch_stage=use_scratch_stage,
             scratch_stage_fqn=self.scratch_stage_fqn,
-            deploy_to_scratch_stage_fn=lambda *args: self.deploy_to_scratch_stage_fn(
-                policy, *args
-            ),
+            deploy_to_scratch_stage_fn=self.deploy_to_scratch_stage_fn,
         )
 
-    def get_validation_result(self, policy, use_scratch_stage: bool):
+    def get_validation_result(self, use_scratch_stage: bool):
         return ApplicationPackageEntity.get_validation_result(
             console=cc,
             package_name=self.package_name,
@@ -368,9 +366,7 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn=self.stage_fqn,
             use_scratch_stage=use_scratch_stage,
             scratch_stage_fqn=self.scratch_stage_fqn,
-            deploy_to_scratch_stage_fn=lambda *args: self.deploy_to_scratch_stage_fn(
-                policy, *args
-            ),
+            deploy_to_scratch_stage_fn=self.deploy_to_scratch_stage_fn,
         )
 
     def get_events(  # type: ignore [return]

--- a/src/snowflake/cli/_plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/_plugins/nativeapp/manager.py
@@ -335,7 +335,7 @@ class NativeAppManager(SqlExecutionMixin):
             policy=policy,
         )
 
-    def deploy_to_scratch_stage_fn(self):
+    def deploy_to_scratch_stage_fn(self, policy):
         bundle_map = self.build_bundle()
         self.deploy(
             bundle_map=bundle_map,
@@ -344,9 +344,10 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn=self.scratch_stage_fqn,
             validate=False,
             print_diff=False,
+            policy=policy,
         )
 
-    def validate(self, use_scratch_stage: bool = False):
+    def validate(self, policy, use_scratch_stage: bool = False):
         return ApplicationPackageEntity.validate_setup_script(
             console=cc,
             package_name=self.package_name,
@@ -354,10 +355,12 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn=self.stage_fqn,
             use_scratch_stage=use_scratch_stage,
             scratch_stage_fqn=self.scratch_stage_fqn,
-            deploy_to_scratch_stage_fn=self.deploy_to_scratch_stage_fn,
+            deploy_to_scratch_stage_fn=lambda *args: self.deploy_to_scratch_stage_fn(
+                policy, *args
+            ),
         )
 
-    def get_validation_result(self, use_scratch_stage: bool):
+    def get_validation_result(self, policy, use_scratch_stage: bool):
         return ApplicationPackageEntity.get_validation_result(
             console=cc,
             package_name=self.package_name,
@@ -365,7 +368,9 @@ class NativeAppManager(SqlExecutionMixin):
             stage_fqn=self.stage_fqn,
             use_scratch_stage=use_scratch_stage,
             scratch_stage_fqn=self.scratch_stage_fqn,
-            deploy_to_scratch_stage_fn=self.deploy_to_scratch_stage_fn,
+            deploy_to_scratch_stage_fn=lambda *args: self.deploy_to_scratch_stage_fn(
+                policy, *args
+            ),
         )
 
     def get_events(  # type: ignore [return]

--- a/src/snowflake/cli/_plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/_plugins/nativeapp/manager.py
@@ -36,6 +36,7 @@ from snowflake.cli._plugins.nativeapp.artifacts import (
 from snowflake.cli._plugins.nativeapp.exceptions import (
     NoEventTableForAccount,
 )
+from snowflake.cli._plugins.nativeapp.policy import PolicyBase
 from snowflake.cli._plugins.nativeapp.project_model import (
     NativeAppProjectModel,
 )
@@ -306,6 +307,7 @@ class NativeAppManager(SqlExecutionMixin):
         bundle_map: BundleMap,
         prune: bool,
         recursive: bool,
+        policy: PolicyBase,
         stage_fqn: Optional[str] = None,
         local_paths_to_sync: List[Path] | None = None,
         validate: bool = True,
@@ -330,6 +332,7 @@ class NativeAppManager(SqlExecutionMixin):
             package_warehouse=self.package_warehouse,
             post_deploy_hooks=self.package_post_deploy_hooks,
             package_scripts=self.package_scripts,
+            policy=policy,
         )
 
     def deploy_to_scratch_stage_fn(self):

--- a/src/snowflake/cli/_plugins/nativeapp/policy.py
+++ b/src/snowflake/cli/_plugins/nativeapp/policy.py
@@ -27,6 +27,9 @@ class PolicyBase(ABC):
     def should_proceed(self, user_prompt: Optional[str]) -> bool:
         pass
 
+    def __eq__(self, value: object) -> bool:
+        return self.__class__ == value.__class__
+
 
 class AllowAlwaysPolicy(PolicyBase):
     """Always allow a Snowflake CLI command to continue execution."""

--- a/src/snowflake/cli/_plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/run_processor.py
@@ -151,7 +151,11 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
     ):
         def deploy_package():
             self.deploy(
-                bundle_map=bundle_map, prune=True, recursive=True, validate=validate
+                bundle_map=bundle_map,
+                prune=True,
+                recursive=True,
+                validate=validate,
+                policy=policy,
             )
 
         def drop_app():

--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -211,6 +211,8 @@ def validate(
     entity_id: str = typer.Option(
         help=f"""The ID of the entity you want to validate.""",
     ),
+    interactive: bool = InteractiveOption,
+    force: Optional[bool] = ForceOption,
     **options,
 ):
     """Validates the specified entity."""
@@ -223,6 +225,8 @@ def validate(
     ws.perform_action(
         entity_id,
         EntityActions.VALIDATE,
+        interactive=interactive,
+        force=force,
     )
 
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -96,47 +96,70 @@
   |                          syncs all local changes to the stage.               |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --prune                  --no-prune              Whether to delete specified |
-  |                                                  files from the stage if     |
-  |                                                  they don't exist locally.   |
-  |                                                  If set, the command deletes |
-  |                                                  files that exist in the     |
-  |                                                  stage, but not in the local |
-  |                                                  filesystem. This option     |
-  |                                                  cannot be used when paths   |
-  |                                                  are specified.              |
-  |                                                  [default: no-prune]         |
-  | --recursive          -r  --no-recursive          Whether to traverse and     |
-  |                                                  deploy files from           |
-  |                                                  subdirectories. If set, the |
-  |                                                  command deploys all files   |
-  |                                                  and subdirectories;         |
-  |                                                  otherwise, only files in    |
-  |                                                  the current directory are   |
-  |                                                  deployed.                   |
-  |                                                  [default: no-recursive]     |
-  | --validate               --no-validate           When enabled, this option   |
-  |                                                  triggers validation of a    |
-  |                                                  deployed Snowflake Native   |
-  |                                                  App's setup script SQL      |
-  |                                                  [default: validate]         |
-  | --package-entity-id                        TEXT  The ID of the package       |
-  |                                                  entity on which to operate  |
-  |                                                  when definition_version is  |
-  |                                                  2 or higher.                |
-  | --app-entity-id                            TEXT  The ID of the application   |
-  |                                                  entity on which to operate  |
-  |                                                  when definition_version is  |
-  |                                                  2 or higher.                |
-  | --project            -p                    TEXT  Path where Snowflake        |
-  |                                                  project resides. Defaults   |
-  |                                                  to current working          |
-  |                                                  directory.                  |
-  | --env                                      TEXT  String in format of         |
-  |                                                  key=value. Overrides        |
-  |                                                  variables from env section  |
-  |                                                  used for templates.         |
-  | --help               -h                          Show this message and exit. |
+  | --prune                  --no-prune                Whether to delete         |
+  |                                                    specified files from the  |
+  |                                                    stage if they don't exist |
+  |                                                    locally. If set, the      |
+  |                                                    command deletes files     |
+  |                                                    that exist in the stage,  |
+  |                                                    but not in the local      |
+  |                                                    filesystem. This option   |
+  |                                                    cannot be used when paths |
+  |                                                    are specified.            |
+  |                                                    [default: no-prune]       |
+  | --recursive          -r  --no-recursive            Whether to traverse and   |
+  |                                                    deploy files from         |
+  |                                                    subdirectories. If set,   |
+  |                                                    the command deploys all   |
+  |                                                    files and subdirectories; |
+  |                                                    otherwise, only files in  |
+  |                                                    the current directory are |
+  |                                                    deployed.                 |
+  |                                                    [default: no-recursive]   |
+  | --interactive            --no-interactive          When enabled, this option |
+  |                                                    displays prompts even if  |
+  |                                                    the standard input and    |
+  |                                                    output are not terminal   |
+  |                                                    devices. Defaults to True |
+  |                                                    in an interactive shell   |
+  |                                                    environment, and False    |
+  |                                                    otherwise.                |
+  | --force                                            When enabled, this option |
+  |                                                    causes the command to     |
+  |                                                    implicitly approve any    |
+  |                                                    prompts that arise. You   |
+  |                                                    should enable this option |
+  |                                                    if interactive mode is    |
+  |                                                    not specified and if you  |
+  |                                                    want perform potentially  |
+  |                                                    destructive actions.      |
+  |                                                    Defaults to unset.        |
+  | --validate               --no-validate             When enabled, this option |
+  |                                                    triggers validation of a  |
+  |                                                    deployed Snowflake Native |
+  |                                                    App's setup script SQL    |
+  |                                                    [default: validate]       |
+  | --package-entity-id                          TEXT  The ID of the package     |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --app-entity-id                              TEXT  The ID of the application |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --project            -p                      TEXT  Path where Snowflake      |
+  |                                                    project resides. Defaults |
+  |                                                    to current working        |
+  |                                                    directory.                |
+  | --env                                        TEXT  String in format of       |
+  |                                                    key=value. Overrides      |
+  |                                                    variables from env        |
+  |                                                    section used for          |
+  |                                                    templates.                |
+  | --help               -h                            Show this message and     |
+  |                                                    exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -898,18 +898,45 @@
    Validates a deployed Snowflake Native App's setup script.                      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --package-entity-id          TEXT  The ID of the package entity on which to  |
-  |                                    operate when definition_version is 2 or   |
-  |                                    higher.                                   |
-  | --app-entity-id              TEXT  The ID of the application entity on which |
-  |                                    to operate when definition_version is 2   |
-  |                                    or higher.                                |
-  | --project            -p      TEXT  Path where Snowflake project resides.     |
-  |                                    Defaults to current working directory.    |
-  | --env                        TEXT  String in format of key=value. Overrides  |
-  |                                    variables from env section used for       |
-  |                                    templates.                                |
-  | --help               -h            Show this message and exit.               |
+  | --interactive            --no-interactive          When enabled, this option |
+  |                                                    displays prompts even if  |
+  |                                                    the standard input and    |
+  |                                                    output are not terminal   |
+  |                                                    devices. Defaults to True |
+  |                                                    in an interactive shell   |
+  |                                                    environment, and False    |
+  |                                                    otherwise.                |
+  | --force                                            When enabled, this option |
+  |                                                    causes the command to     |
+  |                                                    implicitly approve any    |
+  |                                                    prompts that arise. You   |
+  |                                                    should enable this option |
+  |                                                    if interactive mode is    |
+  |                                                    not specified and if you  |
+  |                                                    want perform potentially  |
+  |                                                    destructive actions.      |
+  |                                                    Defaults to unset.        |
+  | --package-entity-id                          TEXT  The ID of the package     |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --app-entity-id                              TEXT  The ID of the application |
+  |                                                    entity on which to        |
+  |                                                    operate when              |
+  |                                                    definition_version is 2   |
+  |                                                    or higher.                |
+  | --project            -p                      TEXT  Path where Snowflake      |
+  |                                                    project resides. Defaults |
+  |                                                    to current working        |
+  |                                                    directory.                |
+  | --env                                        TEXT  String in format of       |
+  |                                                    key=value. Overrides      |
+  |                                                    variables from env        |
+  |                                                    section used for          |
+  |                                                    templates.                |
+  | --help               -h                            Show this message and     |
+  |                                                    exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -893,45 +893,18 @@
    Validates a deployed Snowflake Native App's setup script.                      
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --interactive            --no-interactive          When enabled, this option |
-  |                                                    displays prompts even if  |
-  |                                                    the standard input and    |
-  |                                                    output are not terminal   |
-  |                                                    devices. Defaults to True |
-  |                                                    in an interactive shell   |
-  |                                                    environment, and False    |
-  |                                                    otherwise.                |
-  | --force                                            When enabled, this option |
-  |                                                    causes the command to     |
-  |                                                    implicitly approve any    |
-  |                                                    prompts that arise. You   |
-  |                                                    should enable this option |
-  |                                                    if interactive mode is    |
-  |                                                    not specified and if you  |
-  |                                                    want perform potentially  |
-  |                                                    destructive actions.      |
-  |                                                    Defaults to unset.        |
-  | --package-entity-id                          TEXT  The ID of the package     |
-  |                                                    entity on which to        |
-  |                                                    operate when              |
-  |                                                    definition_version is 2   |
-  |                                                    or higher.                |
-  | --app-entity-id                              TEXT  The ID of the application |
-  |                                                    entity on which to        |
-  |                                                    operate when              |
-  |                                                    definition_version is 2   |
-  |                                                    or higher.                |
-  | --project            -p                      TEXT  Path where Snowflake      |
-  |                                                    project resides. Defaults |
-  |                                                    to current working        |
-  |                                                    directory.                |
-  | --env                                        TEXT  String in format of       |
-  |                                                    key=value. Overrides      |
-  |                                                    variables from env        |
-  |                                                    section used for          |
-  |                                                    templates.                |
-  | --help               -h                            Show this message and     |
-  |                                                    exit.                     |
+  | --package-entity-id          TEXT  The ID of the package entity on which to  |
+  |                                    operate when definition_version is 2 or   |
+  |                                    higher.                                   |
+  | --app-entity-id              TEXT  The ID of the application entity on which |
+  |                                    to operate when definition_version is 2   |
+  |                                    or higher.                                |
+  | --project            -p      TEXT  Path where Snowflake project resides.     |
+  |                                    Defaults to current working directory.    |
+  | --env                        TEXT  String in format of key=value. Overrides  |
+  |                                    variables from env section used for       |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment      -c      TEXT  Name of the connection, as     |

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -932,6 +932,40 @@ def test_create_app_pkg_internal_distribution_no_special_comment(
         )
 
 
+# Test create_app_package() with existing package without special comment
+@mock.patch(APP_PACKAGE_ENTITY_IS_DISTRIBUTION_SAME)
+@mock_get_app_pkg_distribution_in_sf()
+@mock.patch(APP_PACKAGE_ENTITY_GET_EXISTING_APP_PKG_INFO)
+@mock.patch(SQL_EXECUTOR_EXECUTE)
+def test_existing_app_pkg_without_special_comment(
+    mock_execute,
+    mock_get_existing_app_pkg_info,
+    mock_get_distribution,
+    mock_is_distribution_same,
+    temp_dir,
+    mock_cursor,
+):
+    mock_get_existing_app_pkg_info.return_value = {
+        "name": "APP_PKG",
+        "comment": "NOT_SPECIAL_COMMENT",
+        "version": LOOSE_FILES_MAGIC_VERSION,
+        "owner": "package_role",
+    }
+    mock_get_distribution.return_value = "internal"
+    mock_is_distribution_same.return_value = True
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir_name=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = _get_na_manager()
+    with pytest.raises(ApplicationPackageAlreadyExistsError):
+        native_app_manager.create_app_package()
+
+
 @pytest.mark.parametrize(
     "paths_to_sync,expected_result",
     [

--- a/tests/workspace/test_application_package_entity.py
+++ b/tests/workspace/test_application_package_entity.py
@@ -135,7 +135,13 @@ def test_deploy(
     app_pkg, bundle_ctx, mock_console = _get_app_pkg_entity(project_directory)
 
     app_pkg.action_deploy(
-        bundle_ctx, prune=False, recursive=False, paths=["a/b", "c"], validate=True
+        bundle_ctx,
+        prune=False,
+        recursive=False,
+        paths=["a/b", "c"],
+        validate=True,
+        interactive=False,
+        force=False,
     )
 
     mock_sync.assert_called_once_with(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
...
Adds a prompt for when running `app deploy` or `ws deploy` (for a package entity) that was not created by the CLI.  
This behavior already exists for version commands. 
