### PR TITLE
Fix app role None with ws commands

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/application_entity.py
+++ b/src/snowflake/cli/_plugins/nativeapp/application_entity.py
@@ -107,9 +107,9 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         app_name = model.fqn.identifier
         debug_mode = model.debug
         if model.meta:
-            app_role = getattr(model.meta, "role", ctx.default_role)
-            app_warehouse = getattr(model.meta, "warehouse", ctx.default_warehouse)
-            post_deploy_hooks = getattr(model.meta, "post_deploy", None)
+            app_role = model.meta.role or ctx.default_role
+            app_warehouse = model.meta.warehouse or ctx.default_warehouse
+            post_deploy_hooks = model.meta.post_deploy
         else:
             app_role = ctx.default_role
             app_warehouse = ctx.default_warehouse

--- a/tests_integration/nativeapp/test_post_deploy.py
+++ b/tests_integration/nativeapp/test_post_deploy.py
@@ -14,8 +14,13 @@ from tests_integration.testing_utils.working_directory_utils import (
 
 
 def run(runner, base_command, args):
-    # TODO Run "ws deploy --entity-id=app" once ApplicationEntity deploy is implemented
-    result = runner.invoke_with_connection_json(["app", "run"] + args)
+    if base_command == "ws":
+        result = runner.invoke_with_connection_json(
+            ["ws", "deploy", "--entity-id", "app"] + args
+        )
+    else:
+        result = runner.invoke_with_connection_json(["app", "run"] + args)
+
     assert result.exit_code == 0
 
 

--- a/tests_integration/nativeapp/test_post_deploy.py
+++ b/tests_integration/nativeapp/test_post_deploy.py
@@ -97,6 +97,12 @@ def test_nativeapp_post_deploy(
     is_versioned,
     with_project_flag,
 ):
+
+    if base_command == "ws" and is_versioned:
+        pytest.skip(
+            "TODO: ws commands do not support deploying applications from versions yet"
+        )
+
     version = "v1"
     project_name = "myapp"
     app_name = f"{project_name}_{default_username}{resource_suffix}"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix app role None with ws commands
- previously, it was resetting to None in getattr() command because getattr only defaults when the attribute doesn't exist, not when the attribute is None.
