### PR TITLE
Fix numerical version when reading from manifest file

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -23,6 +23,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tupl
 from click.exceptions import ClickException
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
 from snowflake.cli.api.project.schemas.v1.native_app.path_mapping import PathMapping
+from snowflake.cli.api.project.util import to_identifier
 from snowflake.cli.api.secure_path import SecurePath
 from yaml import safe_load
 
@@ -738,7 +739,6 @@ def find_version_info_in_manifest_file(
     """
     Find version and patch, if available, in the manifest.yml file.
     """
-    version_field = "version"
     name_field = "name"
     patch_field = "patch"
 
@@ -747,10 +747,11 @@ def find_version_info_in_manifest_file(
     version_name: Optional[str] = None
     patch_name: Optional[str] = None
 
-    if version_field in manifest_content:
-        version_info = manifest_content[version_field]
-        version_name = version_info[name_field]
+    version_info = manifest_content.get("version", None)
+    if version_info:
+        if name_field in version_info:
+            version_name = to_identifier(str(version_info[name_field]))
         if patch_field in version_info:
-            patch_name = version_info[patch_field]
+            patch_name = to_identifier(str(version_info[patch_field]))
 
     return version_name, patch_name

--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -735,7 +735,7 @@ def find_setup_script_file(deploy_root: Path) -> Path:
 
 def find_version_info_in_manifest_file(
     deploy_root: Path,
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Tuple[Optional[str], Optional[int]]:
     """
     Find version and patch, if available, in the manifest.yml file.
     """
@@ -745,13 +745,13 @@ def find_version_info_in_manifest_file(
     manifest_content = find_and_read_manifest_file(deploy_root=deploy_root)
 
     version_name: Optional[str] = None
-    patch_name: Optional[str] = None
+    patch_number: Optional[int] = None
 
     version_info = manifest_content.get("version", None)
     if version_info:
         if name_field in version_info:
             version_name = to_identifier(str(version_info[name_field]))
         if patch_field in version_info:
-            patch_name = to_identifier(str(version_info[patch_field]))
+            patch_number = int(version_info[patch_field])
 
-    return version_name, patch_name
+    return version_name, patch_number

--- a/src/snowflake/cli/_plugins/nativeapp/version/version_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/version_processor.py
@@ -193,7 +193,7 @@ class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
                 )
 
         # Check if --patch needs to throw a bad option error, either if application package does not exist or if version does not exist
-        if patch:
+        if patch is not None:
             try:
                 if not self.get_existing_version_info(version):
                     raise BadOptionUsage(

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -1365,9 +1365,9 @@ def test_symlink_or_copy_with_symlinks_in_project_root(os_agnostic_snapshot):
             assert_dir_snapshot(Path("./output/deploy"), os_agnostic_snapshot)
 
 
-@pytest.mark.parametrize("patch_name", [None, "1", "42", "foo"])
+@pytest.mark.parametrize("patch_name", [None, "1", 42])
 @pytest.mark.parametrize(
-    "version_name", [None, "v1", "1", "1.2", "1.2.3", "0.x", "foo", "abc def"]
+    "version_name", [None, "v1", "1", 2, "1.2", 1.3, "1.2.3", "0.x", "foo", "abc def"]
 )
 def test_find_version_info_in_manifest_file(version_name, patch_name):
     manifest_contents = {"manifest_version": 1, "version": {}}
@@ -1386,9 +1386,9 @@ def test_find_version_info_in_manifest_file(version_name, patch_name):
         if version_name is None:
             assert v is None
         else:
-            assert v == to_identifier(version_name)
+            assert v == to_identifier(str(version_name))
 
         if patch_name is None:
             assert p is None
         else:
-            assert p == to_identifier(patch_name)
+            assert p == int(patch_name)

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -28,11 +28,14 @@ from snowflake.cli._plugins.nativeapp.artifacts import (
     SourceNotFoundError,
     TooManyFilesError,
     build_bundle,
+    find_version_info_in_manifest_file,
     resolve_without_follow,
     symlink_or_copy,
 )
 from snowflake.cli.api.project.definition import load_project
 from snowflake.cli.api.project.schemas.v1.native_app.path_mapping import PathMapping
+from snowflake.cli.api.project.util import to_identifier
+from yaml import safe_dump
 
 from tests.nativeapp.utils import (
     assert_dir_snapshot,
@@ -1360,3 +1363,32 @@ def test_symlink_or_copy_with_symlinks_in_project_root(os_agnostic_snapshot):
             )
 
             assert_dir_snapshot(Path("./output/deploy"), os_agnostic_snapshot)
+
+
+@pytest.mark.parametrize("patch_name", [None, "1", "42", "foo"])
+@pytest.mark.parametrize(
+    "version_name", [None, "v1", "1", "1.2", "1.2.3", "0.x", "foo", "abc def"]
+)
+def test_find_version_info_in_manifest_file(version_name, patch_name):
+    manifest_contents = {"manifest_version": 1, "version": {}}
+
+    if version_name is None and patch_name is None:
+        manifest_contents.pop("version")
+    if version_name is not None:
+        manifest_contents["version"]["name"] = version_name
+    if patch_name is not None:
+        manifest_contents["version"]["patch"] = patch_name
+
+    deploy_root_structure = {"manifest.yml": safe_dump(manifest_contents)}
+    with temp_local_dir(deploy_root_structure) as deploy_root:
+        v, p = find_version_info_in_manifest_file(deploy_root=deploy_root)
+
+        if version_name is None:
+            assert v is None
+        else:
+            assert v == to_identifier(version_name)
+
+        if patch_name is None:
+            assert p is None
+        else:
+            assert p == to_identifier(patch_name)

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -396,7 +396,7 @@ def test_nativeapp_version_create_and_drop_from_manifest(
             )
             assert result_create.exit_code == 0
 
-            # app package contains version v1
+            # app package contains correct version
             actual = runner.invoke_with_connection_json(["app", "version", "list"])
             assert contains_row_with(
                 actual.json, {"version": normalize_identifier(version_name), "patch": 0}

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from shlex import split
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from yaml import safe_dump, safe_load
 
@@ -40,7 +40,7 @@ def set_version_in_app_manifest(manifest_path: Path, version: Any, patch: Any = 
         f.write(safe_dump(manifest))
 
 
-def normalize_identifier(identifier: str) -> str:
+def normalize_identifier(identifier: Union[str, int]) -> str:
     id_str = str(identifier)
     if is_valid_unquoted_identifier(str(id_str)):
         return id_str.upper()

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -419,7 +419,7 @@ def test_nativeapp_version_create_and_drop_from_manifest(
             )
             assert result_create.exit_code == 0
 
-            # app package contains version v1
+            # app package contains version V2
             actual = runner.invoke_with_connection_json(["app", "version", "list"])
             assert contains_row_with(
                 actual.json,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

Fixed a bug where versions read from a manifest file in `snow app create` could lead to a crash due to being parsed as numbers. Fixes SNOW-1653838.
