### PR TITLE
Bring back glob support in streamlit

### DIFF
--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity_model.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity_model.py
@@ -51,17 +51,6 @@ class StreamlitEntityModel(EntityModelBase, ExternalAccessBaseModel, ImportsBase
     )
 
     @model_validator(mode="after")
-    def main_file_must_be_in_artifacts(self):
-        if not self.artifacts:
-            return self
-
-        if Path(self.main_file) not in self.artifacts:
-            raise ValueError(
-                f"Specified main file {self.main_file} is not included in artifacts."
-            )
-        return self
-
-    @model_validator(mode="after")
     def artifacts_must_exists(self):
         if not self.artifacts:
             return self

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity_model.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity_model.py
@@ -67,6 +67,8 @@ class StreamlitEntityModel(EntityModelBase, ExternalAccessBaseModel, ImportsBase
             return self
 
         for artifact in self.artifacts:
+            if "*" in artifact.name:
+                continue
             if not artifact.exists():
                 raise ValueError(
                     f"Specified artifact {artifact} does not exist locally."

--- a/tests/streamlit/__snapshots__/test_commands.ambr
+++ b/tests/streamlit/__snapshots__/test_commands.ambr
@@ -14,21 +14,6 @@
   
   '''
 # ---
-# name: test_main_file_must_be_in_artifacts
-  '''
-  +- Error ----------------------------------------------------------------------+
-  | During evaluation of DefinitionV20 in project definition following errors    |
-  | were encountered:                                                            |
-  | For field entities.my_streamlit.streamlit you provided '{'artifacts':        |
-  | ['streamlit_app.py', 'utils/utils.py', 'pages/', 'environment.yml'],         |
-  | 'identifier': 'test_streamlit_deploy_snowcli', 'main_file': 'foo_bar.py',    |
-  | 'query_warehouse': 'xsmall', 'stage': 'streamlit', 'title': 'My Fancy        |
-  | Streamlit', 'type': 'streamlit'}'. This caused: Value error, Specified main  |
-  | file foo_bar.py is not included in artifacts.                                |
-  +------------------------------------------------------------------------------+
-  
-  '''
-# ---
 # name: test_multiple_streamlit_raise_error_if_multiple_entities
   '''
   Usage: default streamlit deploy [OPTIONS] [ENTITY_ID]

--- a/tests/streamlit/test_commands.py
+++ b/tests/streamlit/test_commands.py
@@ -266,23 +266,6 @@ def test_deploy_only_streamlit_file_replace(
     mock_typer.launch.assert_not_called()
 
 
-def test_main_file_must_be_in_artifacts(
-    runner, mock_ctx, project_directory, alter_snowflake_yml, snapshot
-):
-    with project_directory("example_streamlit_v2") as pdir:
-        alter_snowflake_yml(
-            pdir / "snowflake.yml",
-            parameter_path="entities.my_streamlit.main_file",
-            value="foo_bar.py",
-        )
-
-        result = runner.invoke(
-            ["streamlit", "deploy"],
-        )
-        assert result.exit_code == 1
-        assert result.output == snapshot
-
-
 def test_artifacts_must_exists(
     runner, mock_ctx, project_directory, alter_snowflake_yml, snapshot
 ):

--- a/tests_integration/test_streamlit.py
+++ b/tests_integration/test_streamlit.py
@@ -136,6 +136,27 @@ def test_streamlit_deploy_with_imports(
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("pattern", ["*.py", "*"])
+def test_streamlit_deploy_with_glob_patterns(
+    pattern,
+    runner,
+    snowflake_session,
+    test_database,
+    _new_streamlit_role,
+    project_directory,
+    alter_snowflake_yml,
+):
+    with project_directory(f"streamlit_v2"):
+        alter_snowflake_yml(
+            "snowflake.yml", "entities.my_streamlit.artifacts", [pattern]
+        )
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "deploy", "--replace"]
+        )
+        assert result.exit_code == 0
+
+
+@pytest.mark.integration
 @pytest.mark.skip(
     reason="only works in accounts with experimental checkout behavior enabled"
 )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds back 2.8 support for glob in streamlit. The support was limited to PUT behavior.  The 3.0 added pre-check for srtifacts which caused validation errors.
