### PR TITLE
Don't error on a PDFv2 with multiple entities if it's not required

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/v2_to_v1_decorator.py
@@ -187,21 +187,21 @@ def find_entity(
 
     entity: Optional[T] = None
 
-    # Determine the package entity to convert, there must be one
     if entity_id:
-        # If the user specified a package entity ID (or we inferred one from the app entity), use that one directly
+        # If we're looking for a specific entity, use that one directly
         entity = entities.get(entity_id)
     elif len(entities) == 1:
-        # Otherwise, if there is only one package entity, fall back to that one
+        # Otherwise, if there is only one entity, fall back to that one
         entity = next(iter(entities.values()))
-    elif len(entities) > 1:
-        # If there are multiple package entities, the user must specify which one to use
+    elif len(entities) > 1 and required:
+        # If there are multiple entities and it's required,
+        # the user must specify which one to use
         raise ClickException(
             f"More than one {entity_type} entity exists in the project definition file, "
             f"specify {disambiguation_option} to choose which one to operate on."
         )
 
-    # If we don't have a package entity to convert, error out since it's not optional
+    # If we don't have a package entity to convert, error out if it's required
     if not entity and required:
         with_id = f'with ID "{entity_id}" ' if entity_id else ""
         raise ClickException(

--- a/tests/nativeapp/test_v2_to_v1.py
+++ b/tests/nativeapp/test_v2_to_v1.py
@@ -206,6 +206,24 @@ def test_v2_to_v1_conversions(pdfv2_input, expected_pdfv1, expected_error):
                 "definition_version": "2",
                 "entities": {
                     **package_v2("pkg1"),
+                    **app_v2("app1", "pkg1"),
+                    **app_v2("app2", "pkg1"),
+                },
+            },
+            "",
+            "",
+            False,
+            {
+                "definition_version": "1.1",
+                "native_app": native_app_v1("pkg1", "pkg1", ""),
+            },
+            None,
+        ],
+        [
+            {
+                "definition_version": "2",
+                "entities": {
+                    **package_v2("pkg1"),
                     **package_v2("pkg2"),
                     **app_v2("app2", "pkg1"),
                 },


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes a bug where a command that doesn't use the app entity would show
```
More than one application entity exists in the project definition file, specify --app-entity-id to choose which one to operate on.
```
when there was more than one app entity in `snowflake.yml`. The new logic just ignores all the app entities since the command doesn't use it anyways.