### PR TITLE
Fix DeprecationWarning in tests

### DIFF
--- a/tests_integration/testing_utils/assertions/test_result_assertions.py
+++ b/tests_integration/testing_utils/assertions/test_result_assertions.py
@@ -64,7 +64,7 @@ def assert_that_result_is_usage_error(
     result: CommandResult, expected_error_message: str
 ) -> None:
     assert result.output is not None
-    result_output = re.sub("\s*││\s*", " ", result.output.replace("\n", ""))  # type: ignore
+    result_output = re.sub(r"\s*││\s*", " ", result.output.replace("\n", ""))  # type: ignore
     assert result.exit_code == 2, result.output
     assert expected_error_message in result_output, result.output
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Regexes should use raw strings since `\s` isn't a valid Python escape sequence.
