### PR TITLE
Don't break long lines when converting v1 to v2

### DIFF
--- a/src/snowflake/cli/_plugins/helpers/commands.py
+++ b/src/snowflake/cli/_plugins/helpers/commands.py
@@ -53,5 +53,6 @@ def v1_to_v2(
                 exclude_unset=True, exclude_none=True, mode="json", by_alias=True
             ),
             file,
+            width=float("inf"),  # Don't break lines
         )
     return MessageResult("Project definition migrated to version 2.")

--- a/tests/helpers/__snapshots__/test_v1_to_v2.ambr
+++ b/tests/helpers/__snapshots__/test_v1_to_v2.ambr
@@ -217,8 +217,7 @@
       deploy_root: output/deploy/
       distribution: external
       generated_root: __generated/
-      identifier: <% fn.concat_ids('myapp', '_pkg_', fn.sanitize_id(fn.get_username('unknown_user'))
-        | lower) %>
+      identifier: <% fn.concat_ids('myapp', '_pkg_', fn.sanitize_id(fn.get_username('unknown_user')) | lower) %>
       manifest: app/manifest.yml
       meta:
         role: pkg_role


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes unwanted linebreak for long templated identifiers:
![image](https://github.com/user-attachments/assets/200ed53b-fb1d-4f62-9bfb-1effab946560)
