### PR TITLE
Make NativeAppManager no longer inherit from SqlExecutionMixin

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -10,6 +10,7 @@ from typing import Callable, Generator, List, Literal, Optional, TypedDict
 import typer
 from click import ClickException, UsageError
 from pydantic import Field, field_validator
+from snowflake.cli._plugins.connection.util import make_snowsight_url
 from snowflake.cli._plugins.nativeapp.common_flags import (
     ForceOption,
     InteractiveOption,
@@ -66,6 +67,7 @@ from snowflake.cli.api.project.schemas.updatable_model import DiscriminatorField
 from snowflake.cli.api.project.util import (
     append_test_resource_suffix,
     extract_schema,
+    identifier_for_url,
     unquote_identifier,
 )
 from snowflake.connector import DictCursor, ProgrammingError
@@ -839,6 +841,16 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         sql_executor = get_sql_executor()
         results = sql_executor.execute_query(query, cursor_class=DictCursor)
         return next((r["value"] for r in results if r["key"] == "EVENT_TABLE"), "")
+
+    @classmethod
+    def get_snowsight_url(cls, app_name: str, app_warehouse: str | None) -> str:
+        """Returns the URL that can be used to visit this app via Snowsight."""
+        name = identifier_for_url(app_name)
+        with cls.use_application_warehouse(app_warehouse):
+            sql_executor = get_sql_executor()
+            return make_snowsight_url(
+                sql_executor._conn, f"/#/apps/application/{name}"  # noqa: SLF001
+            )
 
 
 def _new_events_only(previous_events: list[dict], new_events: list[dict]) -> list[dict]:

--- a/src/snowflake/cli/_plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/_plugins/nativeapp/manager.py
@@ -20,7 +20,6 @@ from functools import cached_property
 from pathlib import Path
 from typing import Generator, List, Optional
 
-from snowflake.cli._plugins.connection.util import make_snowsight_url
 from snowflake.cli._plugins.nativeapp.artifacts import (
     BundleMap,
 )
@@ -46,10 +45,6 @@ from snowflake.cli.api.entities.utils import (
 from snowflake.cli.api.project.schemas.entities.common import PostDeployHook
 from snowflake.cli.api.project.schemas.v1.native_app.native_app import NativeApp
 from snowflake.cli.api.project.schemas.v1.native_app.path_mapping import PathMapping
-from snowflake.cli.api.project.util import (
-    identifier_for_url,
-)
-from snowflake.cli.api.sql_execution import SqlExecutionMixin
 
 
 class NativeAppCommandProcessor(ABC):
@@ -58,7 +53,7 @@ class NativeAppCommandProcessor(ABC):
         pass
 
 
-class NativeAppManager(SqlExecutionMixin):
+class NativeAppManager:
     """
     Base class with frequently used functionality already implemented and ready to be used by related subclasses.
     """
@@ -126,9 +121,6 @@ class NativeAppManager(SqlExecutionMixin):
     @property
     def application_warehouse(self) -> Optional[str]:
         return self.na_project.application_warehouse
-
-    def use_application_warehouse(self):
-        return ApplicationEntity.use_application_warehouse(self.application_warehouse)
 
     @property
     def project_identifier(self) -> str:
@@ -252,9 +244,9 @@ class NativeAppManager(SqlExecutionMixin):
 
     def get_snowsight_url(self) -> str:
         """Returns the URL that can be used to visit this app via Snowsight."""
-        name = identifier_for_url(self.app_name)
-        with self.use_application_warehouse():
-            return make_snowsight_url(self._conn, f"/#/apps/application/{name}")
+        return ApplicationEntity.get_snowsight_url(
+            self.app_name, self.application_warehouse
+        )
 
     def create_app_package(self) -> None:
         return ApplicationPackageEntity.create_app_package(

--- a/src/snowflake/cli/_plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/run_processor.py
@@ -32,6 +32,7 @@ from snowflake.cli._plugins.nativeapp.same_account_install_method import (
     SameAccountInstallMethod,
 )
 from snowflake.cli.api.console import cli_console as cc
+from snowflake.cli.api.entities.common import get_sql_executor
 from snowflake.cli.api.entities.utils import (
     generic_sql_error_handler,
 )
@@ -98,7 +99,8 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
             cascade_msg = " (cascade)" if cascade else ""
             cc.step(f"Dropping application object {self.app_name}{cascade_msg}.")
             cascade_sql = " cascade" if cascade else ""
-            self._execute_query(f"drop application {self.app_name}{cascade_sql}")
+            sql_executor = get_sql_executor()
+            sql_executor.execute_query(f"drop application {self.app_name}{cascade_sql}")
         except ProgrammingError as err:
             if err.errno == APPLICATION_OWNS_EXTERNAL_OBJECTS and not cascade:
                 # We need to cascade the deletion, let's try again (only if we didn't try with cascade already)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Since `SqlExecutor` is now instantiated on-demand in the relevant entity methods, we no longer need to make `NativeAppManager` inherit from it. The only external change required was to move `get_snowsight_host` into `ApplicationEntity`.
