### PR TITLE
SNOW-1653357 Remove deploy_to_scratch_stage_fn() and call deploy() directly

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/_plugins/nativeapp/manager.py
@@ -318,38 +318,50 @@ class NativeAppManager:
             policy=policy,
         )
 
-    def deploy_to_scratch_stage_fn(self):
-        bundle_map = self.build_bundle()
-        self.deploy(
-            bundle_map=bundle_map,
-            prune=True,
-            recursive=True,
-            stage_fqn=self.scratch_stage_fqn,
-            validate=False,
-            print_diff=False,
-            policy=AllowAlwaysPolicy(),
-        )
-
     def validate(self, use_scratch_stage: bool = False):
         return ApplicationPackageEntity.validate_setup_script(
             console=cc,
+            project_root=self.project_root,
+            deploy_root=self.deploy_root,
+            bundle_root=self.bundle_root,
+            generated_root=self.generated_root,
+            artifacts=self.artifacts,
             package_name=self.package_name,
             package_role=self.package_role,
+            package_distribution=self.package_distribution,
+            prune=True,
+            recursive=True,
+            paths=[],
             stage_fqn=self.stage_fqn,
+            package_warehouse=self.package_warehouse,
+            post_deploy_hooks=self.package_post_deploy_hooks,
+            package_scripts=self.package_scripts,
+            policy=AllowAlwaysPolicy(),
             use_scratch_stage=use_scratch_stage,
             scratch_stage_fqn=self.scratch_stage_fqn,
-            deploy_to_scratch_stage_fn=self.deploy_to_scratch_stage_fn,
         )
 
-    def get_validation_result(self, use_scratch_stage: bool):
+    def get_validation_result(self, use_scratch_stage: bool = False):
         return ApplicationPackageEntity.get_validation_result(
             console=cc,
+            project_root=self.project_root,
+            deploy_root=self.deploy_root,
+            bundle_root=self.bundle_root,
+            generated_root=self.generated_root,
+            artifacts=self.artifacts,
             package_name=self.package_name,
             package_role=self.package_role,
+            package_distribution=self.package_distribution,
+            prune=True,
+            recursive=True,
+            paths=[],
             stage_fqn=self.stage_fqn,
+            package_warehouse=self.package_warehouse,
+            post_deploy_hooks=self.package_post_deploy_hooks,
+            package_scripts=self.package_scripts,
+            policy=AllowAlwaysPolicy(),
             use_scratch_stage=use_scratch_stage,
             scratch_stage_fqn=self.scratch_stage_fqn,
-            deploy_to_scratch_stage_fn=self.deploy_to_scratch_stage_fn,
         )
 
     def get_events(  # type: ignore

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -45,6 +45,7 @@ from snowflake.cli._plugins.stage.diff import (
     DiffResult,
     StagePath,
 )
+from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.entities.utils import _get_stage_paths_to_sync
 from snowflake.cli.api.errno import (
     DOES_NOT_EXIST_OR_NOT_AUTHORIZED,
@@ -60,11 +61,10 @@ from tests.nativeapp.patch_utils import (
 )
 from tests.nativeapp.utils import (
     APP_ENTITY_GET_ACCOUNT_EVENT_TABLE,
+    APP_PACKAGE_ENTITY_DEPLOY,
     APP_PACKAGE_ENTITY_GET_EXISTING_APP_PKG_INFO,
     APP_PACKAGE_ENTITY_IS_DISTRIBUTION_SAME,
     ENTITIES_UTILS_MODULE,
-    NATIVEAPP_MANAGER_BUILD_BUNDLE,
-    NATIVEAPP_MANAGER_DEPLOY,
     NATIVEAPP_MODULE,
     SQL_EXECUTOR_EXECUTE,
     mock_execute_helper,
@@ -1173,12 +1173,9 @@ def test_validate_not_deployed(mock_execute, temp_dir, mock_cursor):
     assert mock_execute.mock_calls == expected
 
 
-@mock.patch(NATIVEAPP_MANAGER_BUILD_BUNDLE)
-@mock.patch(NATIVEAPP_MANAGER_DEPLOY)
+@mock.patch(APP_PACKAGE_ENTITY_DEPLOY)
 @mock.patch(SQL_EXECUTOR_EXECUTE)
-def test_validate_use_scratch_stage(
-    mock_execute, mock_deploy, mock_build_bundle, temp_dir, mock_cursor
-):
+def test_validate_use_scratch_stage(mock_execute, mock_deploy, temp_dir, mock_cursor):
     create_named_file(
         file_name="snowflake.yml",
         dir_name=temp_dir,
@@ -1213,24 +1210,35 @@ def test_validate_use_scratch_stage(
     native_app_manager = _get_na_manager()
     native_app_manager.validate(use_scratch_stage=True)
 
-    mock_build_bundle.assert_called_once()
     mock_deploy.assert_called_with(
-        bundle_map=mock_build_bundle.return_value,
+        console=cc,
+        project_root=native_app_manager.project_root,
+        deploy_root=native_app_manager.deploy_root,
+        bundle_root=native_app_manager.bundle_root,
+        generated_root=native_app_manager.generated_root,
+        artifacts=native_app_manager.artifacts,
+        bundle_map=None,
+        package_name=native_app_manager.package_name,
+        package_role=native_app_manager.package_role,
+        package_distribution=native_app_manager.package_distribution,
         prune=True,
         recursive=True,
-        stage_fqn=native_app_manager.scratch_stage_fqn,
-        validate=False,
+        paths=[],
         print_diff=False,
+        validate=False,
+        stage_fqn=native_app_manager.scratch_stage_fqn,
+        package_warehouse=native_app_manager.package_warehouse,
+        post_deploy_hooks=native_app_manager.package_post_deploy_hooks,
+        package_scripts=native_app_manager.package_scripts,
         policy=AllowAlwaysPolicy(),
     )
     assert mock_execute.mock_calls == expected
 
 
-@mock.patch(NATIVEAPP_MANAGER_BUILD_BUNDLE)
-@mock.patch(NATIVEAPP_MANAGER_DEPLOY)
+@mock.patch(APP_PACKAGE_ENTITY_DEPLOY)
 @mock.patch(SQL_EXECUTOR_EXECUTE)
 def test_validate_failing_drops_scratch_stage(
-    mock_execute, mock_deploy, mock_build_bundle, temp_dir, mock_cursor
+    mock_execute, mock_deploy, temp_dir, mock_cursor
 ):
     create_named_file(
         file_name="snowflake.yml",
@@ -1280,14 +1288,26 @@ def test_validate_failing_drops_scratch_stage(
     ):
         native_app_manager.validate(use_scratch_stage=True)
 
-    mock_build_bundle.assert_called_once()
     mock_deploy.assert_called_with(
-        bundle_map=mock_build_bundle.return_value,
+        console=cc,
+        project_root=native_app_manager.project_root,
+        deploy_root=native_app_manager.deploy_root,
+        bundle_root=native_app_manager.bundle_root,
+        generated_root=native_app_manager.generated_root,
+        artifacts=native_app_manager.artifacts,
+        bundle_map=None,
+        package_name=native_app_manager.package_name,
+        package_role=native_app_manager.package_role,
+        package_distribution=native_app_manager.package_distribution,
         prune=True,
         recursive=True,
-        stage_fqn=native_app_manager.scratch_stage_fqn,
-        validate=False,
+        paths=[],
         print_diff=False,
+        validate=False,
+        stage_fqn=native_app_manager.scratch_stage_fqn,
+        package_warehouse=native_app_manager.package_warehouse,
+        post_deploy_hooks=native_app_manager.package_post_deploy_hooks,
+        package_scripts=native_app_manager.package_scripts,
         policy=AllowAlwaysPolicy(),
     )
     assert mock_execute.mock_calls == expected

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -80,6 +80,7 @@ APP_ENTITY_GET_OBJECTS_OWNED_BY_APPLICATION = (
 APP_ENTITY_GET_ACCOUNT_EVENT_TABLE = f"{APP_ENTITY}.get_account_event_table"
 
 APP_PACKAGE_ENTITY = "snowflake.cli._plugins.nativeapp.entities.application_package.ApplicationPackageEntity"
+APP_PACKAGE_ENTITY_DEPLOY = f"{APP_PACKAGE_ENTITY}.deploy"
 APP_PACKAGE_ENTITY_DISTRIBUTION_IN_SF = (
     f"{APP_PACKAGE_ENTITY}.get_app_pkg_distribution_in_snowflake"
 )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Now that `ApplicationPackageEntity` has a static `deploy()` method, we can just call that instead of having to pass a callback from the `NativeAppManager` to deploy the app files to the scratch stage when doing setup script validation. There's a bit of a an explosion in required params, but it's temporary and it'll be cleaned up when the v1 commands are made to operate on v2 entities directly.
