### PR TITLE
Defer fetching role and warehouse until they're needed

### DIFF
--- a/src/snowflake/cli/_plugins/workspace/action_context.py
+++ b/src/snowflake/cli/_plugins/workspace/action_context.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from snowflake.cli.api.console.abc import AbstractConsole
 
@@ -13,6 +14,14 @@ class ActionContext:
 
     console: AbstractConsole
     project_root: Path
-    default_role: str
-    default_warehouse: Optional[str]
+    get_default_role: Callable[[], str]
+    get_default_warehouse: Callable[[], str | None]
     get_entity: Callable
+
+    @cached_property
+    def default_role(self) -> str:
+        return self.get_default_role()
+
+    @cached_property
+    def default_warehouse(self) -> str | None:
+        return self.get_default_warehouse()

--- a/src/snowflake/cli/_plugins/workspace/manager.py
+++ b/src/snowflake/cli/_plugins/workspace/manager.py
@@ -31,13 +31,6 @@ class WorkspaceManager:
         self._entities_cache: Dict[str, Entity] = {}
         self._project_definition: DefinitionV20 = project_definition
         self._project_root = project_root
-        self._default_role = default_role()
-        if self._default_role is None:
-            self._default_role = get_sql_executor().current_role()
-        self.default_warehouse = None
-        cli_context = get_cli_context()
-        if cli_context.connection.warehouse:
-            self.default_warehouse = to_identifier(cli_context.connection.warehouse)
 
     def get_entity(self, entity_id: str):
         """
@@ -62,8 +55,8 @@ class WorkspaceManager:
             action_ctx = ActionContext(
                 console=cc,
                 project_root=self.project_root(),
-                default_role=self._default_role,
-                default_warehouse=self.default_warehouse,
+                get_default_role=_get_default_role,
+                get_default_warehouse=_get_default_warehouse,
                 get_entity=self.get_entity,
             )
             return entity.perform(action, action_ctx, *args, **kwargs)
@@ -72,3 +65,17 @@ class WorkspaceManager:
 
     def project_root(self) -> Path:
         return self._project_root
+
+
+def _get_default_role() -> str:
+    role = default_role()
+    if role is None:
+        role = get_sql_executor().current_role()
+    return role
+
+
+def _get_default_warehouse() -> str | None:
+    warehouse = get_cli_context().connection.warehouse
+    if warehouse:
+        warehouse = to_identifier(warehouse)
+    return warehouse

--- a/tests/workspace/test_application_package_entity.py
+++ b/tests/workspace/test_application_package_entity.py
@@ -48,8 +48,8 @@ def _get_app_pkg_entity(project_directory):
             action_ctx = ActionContext(
                 console=mock_console,
                 project_root=project_root,
-                default_role="app_role",
-                default_warehouse="wh",
+                get_default_role=lambda: "app_role",
+                get_default_warehouse=lambda: "wh",
                 get_entity=lambda *args: None,
             )
             return ApplicationPackageEntity(model), action_ctx, mock_console


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
We have some commands, like `snow app bundle`/`snow ws bundle` that don't even need a connection, so let's defer connecting to Snowflake until it's actually needed by the particular action being run.

For now, all `snow ws` commands are still marked as requiring a connection, that will be fixed separately.