### PR TITLE
Disable snowflake.local.yml migration by default, add flag to enable it

### DIFF
--- a/src/snowflake/cli/api/project/definition_manager.py
+++ b/src/snowflake/cli/api/project/definition_manager.py
@@ -41,7 +41,7 @@ class DefinitionManager:
     USER_DEFINITION_FILENAME = "snowflake.local.yml"
 
     project_root: Path
-    _project_config_paths: List[Path]
+    project_config_paths: List[Path]
 
     def __init__(
         self,
@@ -53,12 +53,12 @@ class DefinitionManager:
         )
 
         self.project_root = project_root
-        self._project_config_paths = self._find_definition_files(self.project_root)
+        self.project_config_paths = self._find_definition_files(self.project_root)
         self._context_overrides = context_overrides
 
     @functools.cached_property
     def has_definition_file(self):
-        return len(self._project_config_paths) > 0
+        return len(self.project_config_paths) > 0
 
     @staticmethod
     def _find_definition_files(project_root: Path) -> List[Path]:
@@ -126,11 +126,11 @@ class DefinitionManager:
 
     @functools.cached_property
     def _project_properties(self) -> ProjectProperties:
-        return load_project(self._project_config_paths, self._context_overrides)
+        return load_project(self.project_config_paths, self._context_overrides)
 
     @functools.cached_property
     def _raw_project_data(self) -> ProjectProperties:
-        return load_project(self._project_config_paths, {}, False)
+        return load_project(self.project_config_paths, {}, False)
 
     @functools.cached_property
     def project_definition(self) -> ProjectDefinitionV1:

--- a/tests/helpers/test_v1_to_v2.py
+++ b/tests/helpers/test_v1_to_v2.py
@@ -151,3 +151,19 @@ def test_migrating_a_file_with_duplicated_keys_raises_an_error(
         result = runner.invoke(["helpers", "v1-to-v2"])
     assert result.exit_code == 1, result.output
     assert result.output == os_agnostic_snapshot
+
+
+@pytest.mark.parametrize("migrate_local_yml", [True, False])
+def test_migrating_with_local_yml(
+    runner, project_directory, os_agnostic_snapshot, migrate_local_yml
+):
+    with project_directory("migration_local_yml") as pd:
+        cmd = ["helpers", "v1-to-v2"]
+        if migrate_local_yml:
+            cmd.append("--migrate-local-override")
+        result = runner.invoke(cmd)
+        assert result.exit_code == 0
+        assert Path("snowflake_V1.local.yml").exists()
+        with Path("snowflake.yml").open() as f:
+            pdf = yaml.safe_load(f)
+            assert pdf["env"]["foo"] == "bar_local" if migrate_local_yml else "bar"

--- a/tests/project/test_definition_manager.py
+++ b/tests/project/test_definition_manager.py
@@ -38,7 +38,7 @@ class DefinitionManagerTest(TestCase):
     def test_no_project_parameter_provided(self, mock_getcwd):
         with mock_is_file_for("/hello/world/snowflake.yml") as mock_is_file:
             definition_manager = DefinitionManager()
-            assert definition_manager._project_config_paths == [  # noqa: SLF001
+            assert definition_manager.project_config_paths == [
                 Path("/hello/world/snowflake.yml")
             ]
 
@@ -48,7 +48,7 @@ class DefinitionManagerTest(TestCase):
             "/hello/world/snowflake.yml", "/hello/world/snowflake.local.yml"
         ) as mock_is_file:
             definition_manager = DefinitionManager()
-            assert definition_manager._project_config_paths == [  # noqa: SLF001
+            assert definition_manager.project_config_paths == [
                 Path("/hello/world/snowflake.yml"),
                 Path("/hello/world/snowflake.local.yml"),
             ]

--- a/tests/test_data/projects/migration_local_yml/snowflake.local.yml
+++ b/tests/test_data/projects/migration_local_yml/snowflake.local.yml
@@ -1,0 +1,3 @@
+definition_version: 1.1
+env:
+  foo: bar_local

--- a/tests/test_data/projects/migration_local_yml/snowflake.yml
+++ b/tests/test_data/projects/migration_local_yml/snowflake.yml
@@ -1,0 +1,3 @@
+definition_version: 1.1
+env:
+  foo: bar


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes bug with `snow helpers v1-to-v2` if a `snowflake.local.yml` is present. Currently, the local file isn't renamed, so a v1 local can be overlaid onto a v2 main definition file after migration, which breaks subsequent commands. Since local overrides are no longer a desired feature in PDFv2, we don't convert them unless `--migrate-local-overrides` is used.
