### PR TITLE
Add simple ws dump command to show final PDF model

### DIFF
--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -15,11 +15,13 @@
 from __future__ import annotations
 
 import logging
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent
 from typing import List, Optional
 
 import typer
+import yaml
 from click import MissingParameter
 from snowflake.cli._plugins.nativeapp.artifacts import BundleMap
 from snowflake.cli._plugins.nativeapp.common_flags import (
@@ -41,6 +43,24 @@ ws = SnowTyperFactory(
     is_hidden=lambda: True,
 )
 log = logging.getLogger(__name__)
+
+
+@ws.command(requires_connection=False, hidden=True)
+@with_project_definition()
+def dump(**options):
+    """
+    Dumps the project definition.
+    """
+    cli_context = get_cli_context()
+    pd = cli_context.project_definition
+    io = StringIO()
+    yaml.safe_dump(
+        pd.model_dump(mode="json", by_alias=True),
+        io,
+        sort_keys=False,
+        width=float("inf"),  # Don't break lines
+    )
+    return MessageResult(io.getvalue())
 
 
 @ws.command(requires_connection=True, hidden=True)

--- a/tests/workspace/test_ws_dump.py
+++ b/tests/workspace/test_ws_dump.py
@@ -1,0 +1,57 @@
+import pytest
+import yaml
+from snowflake.cli._plugins.nativeapp.entities.application_package import (
+    ApplicationPackageEntityModel,
+)
+
+
+@pytest.fixture
+def make_project(temp_dir):
+    def _make_project(entities=None, env=None, mixins=None):
+        env = env or {}
+        mixins = mixins or {}
+        project = dict(
+            definition_version=2,
+            entities=entities,
+            env=env,
+            mixins=mixins,
+        )
+        with open("snowflake.yml", "w") as f:
+            yaml.safe_dump(project, f)
+
+    return _make_project
+
+
+def test_ws_dump_includes_defaults(make_project, runner):
+    pkg = dict(
+        type="application package",
+        manifest="app/manifest.yml",
+        artifacts=[dict(src="app/*", dest="./")],
+    )
+    make_project(entities=dict(pkg=pkg))
+
+    result = runner.invoke(["ws", "dump"])
+
+    assert result.exit_code == 0, result.output
+    dumped = yaml.safe_load(result.output)
+    assert (
+        dumped["entities"]["pkg"]["stage"]
+        == ApplicationPackageEntityModel.model_fields["stage"].default
+    )
+
+
+def test_ws_dump_renders_templates(make_project, runner):
+    env_foo = "bar"
+    pkg = dict(
+        type="application package",
+        manifest="app/manifest.yml",
+        artifacts=[dict(src="app/*", dest="./")],
+        stage="my_stage_<% ctx.env.FOO %>",
+    )
+    make_project(entities=dict(pkg=pkg))
+
+    result = runner.invoke(["ws", "dump"], env={"FOO": env_foo})
+
+    assert result.exit_code == 0, result.output
+    dumped = yaml.safe_load(result.output)
+    assert dumped["entities"]["pkg"]["stage"] == f"my_stage_{env_foo}"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Quick `snow ws dump` internal command to show what a snowflake.yml file will render to after defaults, templates, and mixins.

### Examples
v1:
```yml
definition_version: 1
native_app:
  name: test
  source_stage: app_src.stage
  artifacts:
    - src: app/*
      dest: ./
```
```yml
definition_version: '1'
native_app:
  name: test
  artifacts:
  - src: app/*
    dest: ./
    processors: []
  bundle_root: output/bundle/
  deploy_root: output/deploy/
  generated_root: __generated/
  source_stage: app_src.stage
  scratch_stage: app_src.stage_snowflake_cli_scratch
  package: null
  application: null
snowpark: null
streamlit: null
```

v1.1:
```yml
definition_version: 1.1
native_app:
  name: test
  source_stage: app_src.stage
  artifacts:
    - src: app/*
      dest: ./
```
```yml
definition_version: '1.1'
native_app:
  name: test
  artifacts:
  - src: app/*
    dest: ./
    processors: []
  bundle_root: output/bundle/
  deploy_root: output/deploy/
  generated_root: __generated/
  source_stage: app_src.stage
  scratch_stage: app_src.stage_snowflake_cli_scratch
  package:
    scripts: null
    role: null
    name: test_pkg_fcampbell
    warehouse: null
    distribution: internal
    post_deploy: null
  application:
    role: null
    name: test_fcampbell
    warehouse: null
    debug: null
    post_deploy: null
snowpark: null
streamlit: null
env: null
```

v2:
```yml
definition_version: 2
entities:
  pkg_free:
    type: application package
    identifier: my_app_<% ctx.env.USER %>
    meta:
      use_mixins:
        - base-app-package
  pkg_paid:
    type: application package
    identifier: my_app_free
    meta:
      use_mixins:
        - base-app-package
mixins:
  base-app-package:
    manifest: app/manifest.yml
    artifacts:
      - src: app/*
        dest: ./
```
```yml
definition_version: '2'
entities:
  pkg_free:
    meta:
      warehouse: null
      role: null
      post_deploy: null
      use_mixins:
      - base-app-package
    identifier: my_app_fcampbell
    type: application package
    artifacts:
    - src: app/*
      dest: ./
      processors: []
    - src: app/*
      dest: ./
      processors: []
    bundle_root: output/bundle/
    deploy_root: output/deploy/
    generated_root: __generated/
    stage: app_src.stage
    scratch_stage: app_src.stage_snowflake_cli_scratch
    distribution: internal
    manifest: app/manifest.yml
  pkg_paid:
    meta:
      warehouse: null
      role: null
      post_deploy: null
      use_mixins:
      - base-app-package
    identifier: my_app_free
    type: application package
    artifacts:
    - src: app/*
      dest: ./
      processors: []
    - src: app/*
      dest: ./
      processors: []
    bundle_root: output/bundle/
    deploy_root: output/deploy/
    generated_root: __generated/
    stage: app_src.stage
    scratch_stage: app_src.stage_snowflake_cli_scratch
    distribution: internal
    manifest: app/manifest.yml
env: null
mixins:
  base-app-package:
    manifest: app/manifest.yml
    artifacts:
    - src: app/*
      dest: ./
```
