### PR TITLE
Fix snow git execute for Python files

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 
 ## Fixes and improvements
 * Fixed a bug that would cause the `deploy_root`, `bundle_root`, and `generated_root` directories to be created in the current working directory instead of the project root when invoking commands with the `--project` flag from a different directory.
+* Align variables for `snow stage|git execute`. For Python files variables are stripped of leading and trailing quotes.
 
 # v3.0.2
 
@@ -35,7 +36,7 @@
 ## Fixes and improvements
 
 * Fixed the handling empty default values for strings by `snow snowpark deploy`.
-* Added log error details if the `pip` command fails.
+* Added log error details if the `pip` command fails.* Fix `snow git execute` support for Python files.
 
 # v3.0.1
 

--- a/src/snowflake/cli/_plugins/git/commands.py
+++ b/src/snowflake/cli/_plugins/git/commands.py
@@ -338,7 +338,10 @@ def execute(
     extension will be executed.
     """
     results = GitManager().execute(
-        stage_path=repository_path, on_error=on_error, variables=variables
+        stage_path=repository_path,
+        on_error=on_error,
+        variables=variables,
+        requires_temporary_stage=True,
     )
     return CollectionResult(results)
 

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -96,7 +96,7 @@ class StagePathParts:
         return path
 
     def get_standard_stage_path(self) -> str:
-        path = self.path
+        path = self.get_full_stage_path(self.path)
         return f"@{path}{'/'if self.is_directory and not path.endswith('/') else ''}"
 
     def get_standard_stage_directory_path(self) -> str:

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -322,8 +322,8 @@ class StageManager(SqlExecutionMixin):
                 "Destination path cannot be a user stage. Please provide a named stage."
             )
 
-        source = source_path_parts.full_path
-        destination = destination_path_parts.full_path
+        source = source_path_parts.get_standard_stage_path()
+        destination = destination_path_parts.get_standard_stage_path()
         log.info("Copying files from %s to %s", source, destination)
         query = f"copy files into {destination} from {source}"
         return self._execute_query(query)

--- a/src/snowflake/cli/api/identifiers.py
+++ b/src/snowflake/cli/api/identifiers.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from click import ClickException
 from snowflake.cli.api.exceptions import FQNInconsistencyError, FQNNameError
@@ -122,6 +123,11 @@ class FQN:
         if stage.startswith("@"):
             name = stage[1:]
         return cls.from_string(name)
+
+    @classmethod
+    def from_stage_path(cls, stage_path: str) -> "FQN":
+        stage = Path(stage_path).parts[0]
+        return cls.from_stage(stage)
 
     @classmethod
     def from_identifier_model_v1(cls, model: ObjectIdentifierBaseModel) -> "FQN":

--- a/tests/api/test_fqn.py
+++ b/tests/api/test_fqn.py
@@ -192,3 +192,8 @@ def test_using_context(mock_ctx):
     mock_ctx().connection = MagicMock(database="database_test", schema="test_schema")
     fqn = FQN.from_string("name").using_context()
     assert fqn.identifier == "database_test.test_schema.name"
+
+
+def test_git_fqn():
+    fqn = FQN.from_stage_path("@git_repo/branches/main/devops/")
+    assert fqn.name == "git_repo"

--- a/tests/git/test_git_commands.py
+++ b/tests/git/test_git_commands.py
@@ -543,39 +543,41 @@ def test_api_integration_and_secrets_get_unique_names(
         (
             "@repo/branches/main/",
             "@repo/branches/main/",
-            ["@repo/branches/main/s1.sql", "@repo/branches/main/a/S3.sql"],
+            ["/s1.sql", "/a/S3.sql"],
         ),
         (
             "@repo/branches/main/a",
             "@repo/branches/main/",
-            ["@repo/branches/main/a/S3.sql"],
+            ["/a/S3.sql"],
         ),
         (
             "@db.schema.repo/branches/main/",
             "@db.schema.repo/branches/main/",
             [
-                "@db.schema.repo/branches/main/s1.sql",
-                "@db.schema.repo/branches/main/a/S3.sql",
+                "/s1.sql",
+                "/a/S3.sql",
             ],
         ),
         (
             "@db.schema.repo/branches/main/s1.sql",
             "@db.schema.repo/branches/main/",
-            ["@db.schema.repo/branches/main/s1.sql"],
+            ["/s1.sql"],
         ),
         (
             "@DB.SCHEMA.REPO/branches/main/s1.sql",
             "@DB.SCHEMA.REPO/branches/main/",
-            ["@DB.SCHEMA.REPO/branches/main/s1.sql"],
+            ["/s1.sql"],
         ),
         (
             "@DB.schema.REPO/branches/main/a/S3.sql",
             "@DB.schema.REPO/branches/main/",
-            ["@DB.schema.REPO/branches/main/a/S3.sql"],
+            ["/a/S3.sql"],
         ),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
+@mock.patch(f"{STAGE_MANAGER}._conn", new=mock.MagicMock(database="FOO", schema="BAR"))
+@mock.patch(f"snowflake.cli._plugins.stage.manager.time.time", lambda: 123)
 def test_execute(
     mock_execute,
     mock_cursor,
@@ -587,9 +589,9 @@ def test_execute(
 ):
     mock_execute.return_value = mock_cursor(
         [
-            {"name": "repo/branches/main/a/S3.sql"},
-            {"name": "repo/branches/main/s1.sql"},
-            {"name": "repo/branches/main/s2"},
+            {"name": "/a/S3.sql"},
+            {"name": "/s1.sql"},
+            {"name": "/s2"},
         ],
         [],
     )
@@ -597,10 +599,19 @@ def test_execute(
     result = runner.invoke(["git", "execute", repository_path])
 
     assert result.exit_code == 0, result.output
-    ls_call, *execute_calls = mock_execute.mock_calls
-    assert ls_call == mock.call(f"ls {expected_stage}", cursor_class=DictCursor)
+    create_call, copy_call, ls_call, *execute_calls = mock_execute.mock_calls
+    assert create_call == mock.call(
+        "create temporary stage if not exists IDENTIFIER('FOO.BAR.snowflake_cli_tmp_stage_123')"
+    )
+    assert copy_call == mock.call(
+        f"copy files into @FOO.BAR.snowflake_cli_tmp_stage_123/ from {expected_stage}"
+    )
+    assert ls_call == mock.call(
+        f"ls @FOO.BAR.snowflake_cli_tmp_stage_123", cursor_class=DictCursor
+    )
     assert execute_calls == [
-        mock.call(f"execute immediate from {p}") for p in expected_files
+        mock.call(f"execute immediate from @FOO.BAR.snowflake_cli_tmp_stage_123{p}")
+        for p in expected_files
     ]
     assert result.output == os_agnostic_snapshot
 
@@ -612,29 +623,31 @@ def test_execute(
             "@repo/branches/main/",
             "@repo/branches/main/",
             [
-                "@repo/branches/main/S2.sql",
-                "@repo/branches/main/s1.sql",
-                "@repo/branches/main/a/s3.sql",
+                "/S2.sql",
+                "/s1.sql",
+                "/a/s3.sql",
             ],
         ),
         (
             "@repo/branches/main/s1.sql",
             "@repo/branches/main/",
-            ["@repo/branches/main/s1.sql"],
+            ["/s1.sql"],
         ),
         (
             "@repo/branches/main/S2.sql",
             "@repo/branches/main/",
-            ["@repo/branches/main/S2.sql"],
+            ["/S2.sql"],
         ),
         (
             "@repo/branches/main/a/s3.sql",
             "@repo/branches/main/",
-            ["@repo/branches/main/a/s3.sql"],
+            ["/a/s3.sql"],
         ),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
+@mock.patch(f"{STAGE_MANAGER}._conn", new=mock.MagicMock(database="FOO", schema="BAR"))
+@mock.patch(f"snowflake.cli._plugins.stage.manager.time.time", lambda: 123)
 def test_execute_new_git_repository_list_files(
     mock_execute,
     mock_cursor,
@@ -646,9 +659,9 @@ def test_execute_new_git_repository_list_files(
 ):
     mock_execute.return_value = mock_cursor(
         [
-            {"name": "/branches/main/s1.sql"},
-            {"name": "/branches/main/S2.sql"},
-            {"name": "/branches/main/a/s3.sql"},
+            {"name": "/s1.sql"},
+            {"name": "/S2.sql"},
+            {"name": "/a/s3.sql"},
         ],
         [],
     )
@@ -656,10 +669,19 @@ def test_execute_new_git_repository_list_files(
     result = runner.invoke(["git", "execute", repository_path])
 
     assert result.exit_code == 0, result.output
-    ls_call, *execute_calls = mock_execute.mock_calls
-    assert ls_call == mock.call(f"ls {expected_stage}", cursor_class=DictCursor)
+    create_call, copy_call, ls_call, *execute_calls = mock_execute.mock_calls
+    assert create_call == mock.call(
+        "create temporary stage if not exists IDENTIFIER('FOO.BAR.snowflake_cli_tmp_stage_123')"
+    )
+    assert copy_call == mock.call(
+        f"copy files into @FOO.BAR.snowflake_cli_tmp_stage_123/ from {expected_stage}"
+    )
+    assert ls_call == mock.call(
+        f"ls @FOO.BAR.snowflake_cli_tmp_stage_123", cursor_class=DictCursor
+    )
     assert execute_calls == [
-        mock.call(f"execute immediate from {p}") for p in expected_files
+        mock.call(f"execute immediate from @FOO.BAR.snowflake_cli_tmp_stage_123{p}")
+        for p in expected_files
     ]
     assert result.output == os_agnostic_snapshot
 
@@ -671,35 +693,37 @@ def test_execute_new_git_repository_list_files(
             '@repo/branches/"feature/commit"/',
             '@repo/branches/"feature/commit"/',
             [
-                '@repo/branches/"feature/commit"/s1.sql',
-                '@repo/branches/"feature/commit"/a/S3.sql',
+                "/s1.sql",
+                "/a/S3.sql",
             ],
         ),
         (
             '@repo/branches/"feature/commit"/s1.sql',
             '@repo/branches/"feature/commit"/',
             [
-                '@repo/branches/"feature/commit"/s1.sql',
+                "/s1.sql",
             ],
         ),
         (
             '@repo/branches/"feature/commit"/a/',
             '@repo/branches/"feature/commit"/',
             [
-                '@repo/branches/"feature/commit"/a/S3.sql',
+                "/a/S3.sql",
             ],
         ),
         (
             '@db.schema.repo/branches/"feature/commit"/',
             '@db.schema.repo/branches/"feature/commit"/',
             [
-                '@db.schema.repo/branches/"feature/commit"/s1.sql',
-                '@db.schema.repo/branches/"feature/commit"/a/S3.sql',
+                "/s1.sql",
+                "/a/S3.sql",
             ],
         ),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
+@mock.patch(f"{STAGE_MANAGER}._conn", new=mock.MagicMock(database="FOO", schema="BAR"))
+@mock.patch(f"snowflake.cli._plugins.stage.manager.time.time", lambda: 123)
 def test_execute_slash_in_repository_name(
     mock_execute,
     mock_cursor,
@@ -711,9 +735,9 @@ def test_execute_slash_in_repository_name(
 ):
     mock_execute.return_value = mock_cursor(
         [
-            {"name": '/branches/"feature/commit"/a/S3.sql'},
-            {"name": '/branches/"feature/commit"/s1.sql'},
-            {"name": '/branches/"feature/commit"/s2'},
+            {"name": "/a/S3.sql"},
+            {"name": "/s1.sql"},
+            {"name": "/s2"},
         ],
         [],
     )
@@ -721,17 +745,28 @@ def test_execute_slash_in_repository_name(
     result = runner.invoke(["git", "execute", repository_path])
 
     assert result.exit_code == 0, result.output
-    ls_call, *execute_calls = mock_execute.mock_calls
-    assert ls_call == mock.call(f"ls '{expected_stage}'", cursor_class=DictCursor)
+    create_call, copy_call, ls_call, *execute_calls = mock_execute.mock_calls
+    assert create_call == mock.call(
+        "create temporary stage if not exists IDENTIFIER('FOO.BAR.snowflake_cli_tmp_stage_123')"
+    )
+    assert copy_call == mock.call(
+        f"copy files into @FOO.BAR.snowflake_cli_tmp_stage_123/ from {expected_stage}"
+    )
+    assert ls_call == mock.call(
+        f"ls @FOO.BAR.snowflake_cli_tmp_stage_123", cursor_class=DictCursor
+    )
     assert execute_calls == [
-        mock.call(f"execute immediate from '{p}'") for p in expected_files
+        mock.call(f"execute immediate from @FOO.BAR.snowflake_cli_tmp_stage_123{p}")
+        for p in expected_files
     ]
     assert result.output == os_agnostic_snapshot
 
 
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
+@mock.patch(f"{STAGE_MANAGER}._conn", new=mock.MagicMock(database="FOO", schema="BAR"))
+@mock.patch(f"snowflake.cli._plugins.stage.manager.time.time", lambda: 123)
 def test_execute_with_variables(mock_execute, mock_cursor, runner):
-    mock_execute.return_value = mock_cursor([{"name": "repo/branches/main/s1.sql"}], [])
+    mock_execute.return_value = mock_cursor([{"name": "/s1.sql"}], [])
 
     result = runner.invoke(
         [
@@ -752,19 +787,28 @@ def test_execute_with_variables(mock_execute, mock_cursor, runner):
     )
 
     assert result.exit_code == 0
-    assert mock_execute.mock_calls == [
-        mock.call("ls @repo/branches/main/", cursor_class=DictCursor),
+    create_call, copy_call, ls_call, *execute_calls = mock_execute.mock_calls
+    assert create_call == mock.call(
+        "create temporary stage if not exists IDENTIFIER('FOO.BAR.snowflake_cli_tmp_stage_123')"
+    )
+    assert copy_call == mock.call(
+        "copy files into @FOO.BAR.snowflake_cli_tmp_stage_123/ from @repo/branches/main/"
+    )
+    assert ls_call == mock.call(
+        f"ls @FOO.BAR.snowflake_cli_tmp_stage_123", cursor_class=DictCursor
+    )
+    assert execute_calls == [
         mock.call(
-            f"execute immediate from @repo/branches/main/s1.sql using (key1=>'string value', key2=>1, key3=>TRUE, key4=>NULL, key5=>'var=value')"
-        ),
+            f"execute immediate from @FOO.BAR.snowflake_cli_tmp_stage_123/s1.sql using (key1=>'string value', key2=>1, key3=>TRUE, key4=>NULL, key5=>'var=value')"
+        )
     ]
 
 
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
+@mock.patch(f"{STAGE_MANAGER}._conn", new=mock.MagicMock(database="FOO", schema="BAR"))
+@mock.patch(f"snowflake.cli._plugins.stage.manager.time.time", lambda: 123)
 def test_execute_file_with_space_in_name(mock_execute, mock_cursor, runner):
-    mock_execute.return_value = mock_cursor(
-        [{"name": "repo/branches/main/Script 1.sql"}], []
-    )
+    mock_execute.return_value = mock_cursor([{"name": "/Script 1.sql"}], [])
 
     result = runner.invoke(
         [
@@ -775,9 +819,12 @@ def test_execute_file_with_space_in_name(mock_execute, mock_cursor, runner):
     )
 
     assert result.exit_code == 0
-    assert mock_execute.mock_calls == [
-        mock.call("ls @repo/branches/main/", cursor_class=DictCursor),
-        mock.call(f"execute immediate from '@repo/branches/main/Script 1.sql'"),
+    _, __, *calls = mock_execute.mock_calls
+    assert calls == [
+        mock.call("ls @FOO.BAR.snowflake_cli_tmp_stage_123", cursor_class=DictCursor),
+        mock.call(
+            f"execute immediate from '@FOO.BAR.snowflake_cli_tmp_stage_123/Script 1.sql'"
+        ),
     ]
 
 
@@ -789,7 +836,7 @@ def test_raise_error_for_invalid_quotes_number_in_path(runner):
             '@repo/branches"/"ma"in/',
         ]
     )
-    assert result.exit_code == 2
+    assert result.exit_code == 2, result.output
     assert (
         'Invalid string @repo/branches"/"ma"in/, too much " in path, expected 2.'
         in result.output

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -900,11 +900,11 @@ def test_execute_with_variables(mock_bootstrap, mock_execute, mock_cursor, runne
     mock_bootstrap.return_value.assert_called_once_with(
         "@exe/s2.py",
         {
-            "key1": "'string value'",
+            "key1": "string value",
             "key2": "1",
             "KEY3": "TRUE",
             "key4": "NULL",
-            "key5": "'var=value'",
+            "key5": "var=value",
         },
     )
 

--- a/tests_integration/__snapshots__/test_git.ambr
+++ b/tests_integration/__snapshots__/test_git.ambr
@@ -18,6 +18,15 @@
     }),
   ])
 # ---
+# name: test_execute_python
+  list([
+    dict({
+      'Error': None,
+      'File': '@snowflake_cli_tmp_stage_1727969525/tests_integration/test_data/projects/stage_execute/script1.py',
+      'Status': 'SUCCESS',
+    }),
+  ])
+# ---
 # name: test_execute_with_name_in_pascal_case
   list([
     dict({

--- a/tests_integration/__snapshots__/test_git.ambr
+++ b/tests_integration/__snapshots__/test_git.ambr
@@ -1,14 +1,4 @@
 # serializer version: 1
-# name: test_copy_error
-  '''
-  093554 (22023): 01b6ce5e-090b-6508-0001-c1be067d48f6: The specified tag 'no-such-tag' cannot be found in the Git Repository.
-  ╭─ Error ──────────────────────────────────────────────────────────────────────╮
-  │ 093554 (22023): 01b6ce5e-090b-6508-0001-c1be067d48f6: The specified tag      │
-  │ 'no-such-tag' cannot be found in the Git Repository.                         │
-  ╰──────────────────────────────────────────────────────────────────────────────╯
-  
-  '''
-# ---
 # name: test_execute
   list([
     dict({
@@ -22,7 +12,7 @@
   list([
     dict({
       'Error': None,
-      'File': '@snowflake_cli_tmp_stage_1727969525/tests_integration/test_data/projects/stage_execute/script1.py',
+      'File': '@snowcli_testing_repo/branches/main/tests_integration/test_data/projects/stage_execute/script1.py',
       'Status': 'SUCCESS',
     }),
   ])
@@ -35,14 +25,4 @@
       'Status': 'SUCCESS',
     }),
   ])
-# ---
-# name: test_list_files
-  '''
-  093554 (22023): 01b6ce5e-090b-6508-0001-c1be067d48be: The specified tag 'no-such-tag' cannot be found in the Git Repository.
-  ╭─ Error ──────────────────────────────────────────────────────────────────────╮
-  │ 093554 (22023): 01b6ce5e-090b-6508-0001-c1be067d48be: The specified tag      │
-  │ 'no-such-tag' cannot be found in the Git Repository.                         │
-  ╰──────────────────────────────────────────────────────────────────────────────╯
-  
-  '''
 # ---

--- a/tests_integration/test_git.py
+++ b/tests_integration/test_git.py
@@ -289,6 +289,20 @@ def test_execute(runner, test_database, sf_git_repository, snapshot):
 
 
 @pytest.mark.integration
+def test_execute_python(runner, test_database, sf_git_repository, snapshot):
+    result = runner.invoke_with_connection_json(
+        [
+            "git",
+            "execute",
+            f"@{sf_git_repository.lower()}/branches/main/tests_integration/test_data/projects/stage_execute/script1.py",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert result.json == snapshot
+
+
+@pytest.mark.integration
 def test_execute_fqn_repo(runner, test_database, sf_git_repository):
     result_fqn = runner.invoke_with_connection_json(
         [

--- a/tests_integration/test_git.py
+++ b/tests_integration/test_git.py
@@ -161,7 +161,7 @@ def test_copy_to_stage(runner, sf_git_repository):
     result = runner.invoke_with_connection_json(
         ["git", "copy", repository_path, f"@{STAGE_NAME}"]
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     _assert_file_on_stage(f"{SUBDIR_ON_STAGE}/{FILE_IN_SUBDIR}")  # whole dir is copied
 
     # copy directory - copy contents


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix `snow git execute` for Python files:
1. Copy the files first to temporary stage to workaround missing Snow git feature
2. Strip leading and trailing quotes from input variables so the values are consistent between SQL and Python
3. Add support for temporary stage in `StageManager`
