### PR TITLE
SNOW-1706990 Add decorator to extract a single app and package from a PDFv2

### DIFF
--- a/tests_integration/nativeapp/test_bundle.py
+++ b/tests_integration/nativeapp/test_bundle.py
@@ -281,10 +281,12 @@ def test_nativeapp_bundle_throws_error_on_no_artifacts(template_setup):
 
     result = execute_bundle_command()
     assert result.exit_code == 1
-    assert_that_result_failed_with_message_containing(
-        result,
-        "No artifacts mapping found in project definition, nothing to do.",
+    expected_error = (
+        "No artifacts mapping found in project definition, nothing to do."
+        if definition_version.endswith("v2")
+        else "manifest.yml file not found in any Native App artifact sources"
     )
+    assert_that_result_failed_with_message_containing(result, expected_error)
 
 
 # Tests that bundle wipes out any existing deploy root to recreate it from scratch on every run


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
We eventually want to remove `NativeAppManager` and `NativeAppProjectModel` since they're only thin wrappers around the v2 entities right now. Since the `snow app` commands can only operate on a single package or app at a time, we need to adapt the definition that the user gives us if it doesn't conform. This PR adds `@single_app_and_package()` decorator to be used on `snow app` commands to perform this conversion.

If the user gives us a v1 definition, it is implicitly converted to a v2 definition with `app` and `pkg` entities using the same conversion as `snow helpers v1-to-v2`. If the user gives us a v2 definition, it is searched for a single package entity and up to one app entity using the same logic as the current `@nativeapp_definition_v2_to_v1()` decorator, including disambiguating using `--package-entity-id` and `--app-entity-id` options if necessary.

With this decorator, the `snow app` commands can operate natively on v2 entities instead of having to rely on `NativeAppManager` and `NativeAppProjectModel`, which only support v1 (In this PR, we demonstrate the usage of the decorator by applying it to `snow app bundle`).
