### PR TITLE
Allow converting PDFv1 to PDFv2 in-memory only

### DIFF
--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -54,10 +54,11 @@ class _CliGlobalContextManager:
     project_env_overrides_args: dict[str, str] = field(default_factory=dict)
 
     # FIXME: this property only exists to help implement
-    # nativeapp_definition_v2_to_v1. Consider changing the way
-    # this calculation is provided to commands in order to remove
-    # this logic (then make project_definition a non-cloned @property)
+    # nativeapp_definition_v2_to_v1 and single_app_and_package.
+    # Consider changing the way this calculation is provided to commands
+    # in order to remove this logic (then make project_definition a non-cloned @property)
     override_project_definition: ProjectDefinition | None = None
+    override_template_context: dict | None = None
 
     _definition_manager: DefinitionManager | None = None
 
@@ -97,6 +98,8 @@ class _CliGlobalContextManager:
 
     @property
     def template_context(self) -> dict:
+        if self.override_template_context:
+            return self.override_template_context
         return self._definition_manager_or_raise().template_context
 
     @property


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Extracted from #1667 to get separate CLI team codeowner review.

Allows converting a v1 definition to v2 only in-memory, without saving the resultant v2 definition to `snowflake.yml`. This will be used in a future decorator added in #1667 to allow v1 commands to operate natively on v2 entities by implicitly converting the definition.

Since the definition conversion process currently updates package script files in-place, we need a way to isolate those changes to a temp directory instead of touching the user's project directory. This is achieved by creating a tempdir to hold these conversions and by replacing the package script filenames in the project definition with absolute paths to those temp files, taking advantage of the (documented) fact that `Path(...) / "/tmp/foo"` ignores the first `Path` since the second is absolute, resulting in just `Path("/tmp/foo")`.

Since the definition contents will never be emitted to disk to be loaded in the future, another thing we need to do is evaluate templates in the converted project definition immediately instead of returning a definition with tags in it.

In addition, since we're modifying the project definition in-memory, we also need to override the template context to be used for future template expansions in other files, so this ability was added to the CLI global context manager.