### PR TITLE
SNOW-1706990 Convert `snow app deploy` to v2-native

### DIFF
--- a/tests_integration/nativeapp/test_feature_metrics.py
+++ b/tests_integration/nativeapp/test_feature_metrics.py
@@ -103,15 +103,16 @@ def test_sql_templating_emits_counter(
                 CLICounterField.PACKAGE_SCRIPTS: 0,
             },
         ),
-        # ensure that package scripts are picked up
+        # package scripts are auto-converted to post deploy scripts in v1
         (
             "app deploy",
             "integration_external",
             {
                 CLICounterField.SNOWPARK_PROCESSOR: 0,
                 CLICounterField.TEMPLATES_PROCESSOR: 0,
-                CLICounterField.POST_DEPLOY_SCRIPTS: 0,
-                CLICounterField.PACKAGE_SCRIPTS: 1,
+                CLICounterField.PDF_TEMPLATES: 1,
+                CLICounterField.POST_DEPLOY_SCRIPTS: 1,
+                CLICounterField.PACKAGE_SCRIPTS: 0,
             },
         ),
         # ensure post deploy scripts are picked up for v2


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Makes `snow app deploy` operate natively on v2 entities, like `snow ws deploy`. Updates `@single_app_and_package` to keep the correct `ctx.env`.
