### PR TITLE
SNOW-1706990 Convert `snow app run` to v2-native

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/_plugins/nativeapp/manager.py
@@ -244,7 +244,7 @@ class NativeAppManager:
 
     def get_snowsight_url(self) -> str:
         """Returns the URL that can be used to visit this app via Snowsight."""
-        return ApplicationEntity.get_snowsight_url(
+        return ApplicationEntity.get_snowsight_url_static(
             self.app_name, self.application_warehouse
         )
 

--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -418,36 +418,29 @@ def test_nativeapp_run_orphan(
             command = [*split(command), "--interactive"]  # show prompt in tests
             _input = "y\n"  # yes to drop app
 
-        if command[0] == "ws":
-            # TODO Remove this condition once ApplicationEntity.create_or_upgrade_app() supports calling drop()
-            with pytest.raises(NotImplementedError):
-                runner.invoke_with_connection(command, input=_input)
-        else:
-            result = runner.invoke_with_connection(command, input=_input)
-            assert result.exit_code == 0, result.output
-            if not force_flag:
-                assert (
-                    "Do you want the Snowflake CLI to drop the existing application object and recreate it?"
-                    in result.output
-                ), result.output
+        result = runner.invoke_with_connection(command, input=_input)
+        assert result.exit_code == 0, result.output
+        if not force_flag:
+            assert (
+                "Do you want the Snowflake CLI to drop the existing application object and recreate it?"
+                in result.output
+            ), result.output
 
-            # app + package exist
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show application packages like '{package_name}'",
-                    )
-                ),
-                dict(name=package_name),
-            )
-            assert contains_row_with(
-                row_from_snowflake_session(
-                    snowflake_session.execute_string(
-                        f"show applications like '{app_name}'"
-                    )
-                ),
-                dict(name=app_name, source=package_name),
-            )
+        # app + package exist
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(
+                    f"show application packages like '{package_name}'",
+                )
+            ),
+            dict(name=package_name),
+        )
+        assert contains_row_with(
+            row_from_snowflake_session(
+                snowflake_session.execute_string(f"show applications like '{app_name}'")
+            ),
+            dict(name=app_name, source=package_name),
+        )
 
 
 # Verifies that we can always cross-upgrade between different


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Converts `snow app run` to operate natively on v2 entities, like `snow ws deploy` on an app entity.
