### PR TITLE
Fix package installation for integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,12 @@ pre-install-commands = [
   "pip install test_external_plugins/snowpark_hello_single_command",
   "pip install test_external_plugins/multilingual_hello_command_group",
   "pip install pytest-xdist",
+  # snowflake-cli and snowflake-cli-labs are deps of the snowpark stuff above,
+  # so let's remove them and let hatch install the right version afterwards
+  # If we don't do this, there can be a mismatch between the version of these
+  # packages installed as dependencies of the snowpark plugins and the current
+  # commit being tested
+  "pip uninstall -y snowflake-cli snowflake-cli-labs",
 ]
 features = ["development"]
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Integration tests broke overnight with no code changes. My investigation seems to point to some global state being cached, perhaps hatch's venvs. This causes an installed version of `snowflake-cli` and/or `snowflake-cli-labs` to take precedence over the local code when importing files, causing `ModuleNotFoundError`s and tests to act as if the changes being tested aren't there.

The solution I found is to uninstall those two packages since hatch will implicitly do a `pip install -e .` afterwards, restoring the correct version in the venv.
