### PR TITLE
Fix `snow ws version drop` using the wrong action

### DIFF
--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -319,7 +319,7 @@ def version_drop(
     )
     ws.perform_action(
         entity_id,
-        EntityActions.VERSION_CREATE,
+        EntityActions.VERSION_DROP,
         version=version,
         interactive=interactive,
         force=force,

--- a/tests_integration/nativeapp/__snapshots__/test_version.ambr
+++ b/tests_integration/nativeapp/__snapshots__/test_version.ambr
@@ -1,4 +1,134 @@
 # serializer version: 1
+# name: test_nativeapp_version_create_package_no_magic_comment[app version create-app version list-app version drop-napp_init_v1]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[app version create-app version list-app version drop-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[app version create-app version list-ws version drop --entity-id=pkg-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[app version create-ws version list --entity-id=pkg-app version drop-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[app version create-ws version list --entity-id=pkg-ws version drop --entity-id=pkg-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
 # name: test_nativeapp_version_create_package_no_magic_comment[app version list-napp_init_v1]
   list([
     dict({
@@ -26,6 +156,110 @@
   ])
 # ---
 # name: test_nativeapp_version_create_package_no_magic_comment[app version list-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[ws version create --entity-id=pkg-app version list-app version drop-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[ws version create --entity-id=pkg-app version list-ws version drop --entity-id=pkg-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[ws version create --entity-id=pkg-ws version list --entity-id=pkg-app version drop-napp_init_v2]
+  list([
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 0,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+    dict({
+      'comment': None,
+      'dropped_on': None,
+      'label': None,
+      'log_level': 'OFF',
+      'patch': 1,
+      'review_status': 'NOT_REVIEWED',
+      'state': 'READY',
+      'trace_level': 'OFF',
+      'version': 'V1',
+    }),
+  ])
+# ---
+# name: test_nativeapp_version_create_package_no_magic_comment[ws version create --entity-id=pkg-ws version list --entity-id=pkg-ws version drop --entity-id=pkg-napp_init_v2]
   list([
     dict({
       'comment': None,


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
Fixes `snow ws version drop` accidentally performing the `VERSION_CREATE` action. Parametrized tests to use both `snow app version` and `snow ws version` commands, except for unsupported use-cases (`ws` command with a v1 project).
