### PR TITLE
SNOW-1706990 Make `snow app teardown` only operate on v2 entities

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/commands.py
@@ -21,7 +21,7 @@ import typer
 from click import MissingParameter
 from snowflake.cli._plugins.nativeapp.common_flags import ForceOption, InteractiveOption
 from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
-    single_app_and_package,
+    force_project_definition_v2,
 )
 from snowflake.cli._plugins.workspace.manager import WorkspaceManager
 from snowflake.cli.api.cli_global_context import get_cli_context
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
 
 @app.command(requires_connection=True)
 @with_project_definition()
-@single_app_and_package()
+@force_project_definition_v2()
 def create(
     version: Optional[str] = typer.Argument(
         None,
@@ -90,7 +90,7 @@ def create(
 
 @app.command("list", requires_connection=True)
 @with_project_definition()
-@single_app_and_package()
+@force_project_definition_v2()
 def version_list(
     **options,
 ) -> CommandResult:
@@ -112,7 +112,7 @@ def version_list(
 
 @app.command(requires_connection=True)
 @with_project_definition()
-@single_app_and_package()
+@force_project_definition_v2()
 def drop(
     version: Optional[str] = typer.Argument(
         None,

--- a/tests_integration/nativeapp/conftest.py
+++ b/tests_integration/nativeapp/conftest.py
@@ -50,9 +50,19 @@ def nativeapp_teardown(runner: SnowCLIRunner):
         env: dict | None = None,
         extra_args: list[str] | None = None,
     ):
+        # Back up project definition files in case the test
+        # modifies them and makes the teardown fail
+        backups = {
+            path: path.read_text()
+            for p in ["snowflake.yml", "snowflake.local.yml"]
+            if (path := (project_dir or Path()) / p).exists()
+        }
         try:
             yield
         finally:
+            for path, backup in backups.items():
+                path.write_text(backup)
+
             args = ["--force", "--cascade"]
             if project_dir:
                 args += ["--project", str(project_dir)]


### PR DESCRIPTION
Use the [no-whitespace diff](https://github.com/snowflakedb/snowflake-cli/pull/1709/files?w=1) for a more pleasant diff-viewing experience

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Converts `snow app teardown` to remove its use of `NativeAppTeardownProcessor` by converting the v1 definition to v2. Renamed `@single_app_and_package` to `@force_project_definition_v2` and made `single_app_and_package` a flag which can be disabled to allow passing through a v2 definition that has multiple app/package entities in it.
