### PR TITLE
SNOW-1706990 Remove NativeAppVersionCreateProcessor

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/version/version_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/version_processor.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntity,
@@ -24,50 +24,8 @@ from snowflake.cli._plugins.nativeapp.manager import (
     NativeAppCommandProcessor,
     NativeAppManager,
 )
-from snowflake.cli._plugins.nativeapp.run_processor import NativeAppRunProcessor
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.project.schemas.v1.native_app.native_app import NativeApp
-
-
-class NativeAppVersionCreateProcessor(NativeAppRunProcessor):
-    def __init__(self, project_definition: Dict, project_root: Path):
-        super().__init__(project_definition, project_root)
-
-    def process(
-        self,
-        version: Optional[str],
-        patch: Optional[int],
-        force: bool,
-        interactive: bool,
-        skip_git_check: bool,
-        *args,
-        **kwargs,
-    ):
-        return ApplicationPackageEntity.version_create(
-            console=cc,
-            project_root=self.project_root,
-            deploy_root=self.deploy_root,
-            bundle_root=self.bundle_root,
-            generated_root=self.generated_root,
-            artifacts=self.artifacts,
-            package_name=self.package_name,
-            package_role=self.package_role,
-            package_distribution=self.package_distribution,
-            prune=True,
-            recursive=True,
-            paths=None,
-            print_diff=True,
-            validate=True,
-            stage_fqn=self.stage_fqn,
-            package_warehouse=self.package_warehouse,
-            post_deploy_hooks=self.package_post_deploy_hooks,
-            package_scripts=self.package_scripts,
-            version=version,
-            patch=patch,
-            force=force,
-            interactive=interactive,
-            skip_git_check=skip_git_check,
-        )
 
 
 class NativeAppVersionDropProcessor(NativeAppManager, NativeAppCommandProcessor):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Updates version create tests to use `ApplicationPackageEntity` and removes `NativeAppVersionCreateProcessor`
