### PR TITLE
Allow snowflake.yml with only env section for SQL use-case

### DIFF
--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -115,7 +115,17 @@ class DefinitionV11(DefinitionV10):
 
 
 class DefinitionV20(_ProjectDefinitionBase):
-    entities: Dict[str, AnnotatedEntity] = Field(title="Entity definitions.")
+    entities: Dict[str, AnnotatedEntity] = Field(
+        title="Entity definitions.", default={}
+    )
+    env: Optional[Dict[str, Union[str, int, bool]]] = Field(
+        title="Default environment specification for this project.",
+        default=None,
+    )
+    mixins: Optional[Dict[str, Dict]] = Field(
+        title="Mixins to apply to entities",
+        default=None,
+    )
 
     @model_validator(mode="after")
     def validate_entities_identifiers(self):
@@ -162,16 +172,6 @@ class DefinitionV20(_ProjectDefinitionBase):
             raise ValueError(
                 f"Target type mismatch. Expected {target_type.__name__}, got {actual_target_type.__name__}"
             )
-
-    env: Optional[Dict[str, Union[str, int, bool]]] = Field(
-        title="Default environment specification for this project.",
-        default=None,
-    )
-
-    mixins: Optional[Dict[str, Dict]] = Field(
-        title="Mixins to apply to entities",
-        default=None,
-    )
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/project/test_project_definition_v2.py
+++ b/tests/project/test_project_definition_v2.py
@@ -216,6 +216,12 @@ from tests.nativeapp.factories import ProjectV11Factory
         ],
         [
             {
+                "env": {"string": "string", "int": 42, "bool": True},
+            },
+            None,
+        ],
+        [
+            {
                 "mixins": {
                     "snowpark_shared": {
                         "stage": "dev",

--- a/tests_integration/test_data/projects/sql/snowflake.yml
+++ b/tests_integration/test_data/projects/sql/snowflake.yml
@@ -1,0 +1,3 @@
+definition_version: 2
+env:
+  monty_python: "Knights of Nii"

--- a/tests_integration/test_sql.py
+++ b/tests_integration/test_sql.py
@@ -178,3 +178,24 @@ def test_sql_large_lobs_in_memory_tables(runner):
     )
 
     assert "VARCHAR(134217728)" in result.output
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "template",
+    [
+        "<% ctx.env.monty_python %>",
+        "&{ ctx.env.monty_python }",
+    ],
+)
+def test_sql_with_variables_from_project(runner, project_directory, template):
+    with project_directory("sql"):
+        result = runner.invoke_with_connection_json(
+            [
+                "sql",
+                "-q",
+                f"select '{template}' as var",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert result.json == [{"VAR": "Knights of Nii"}]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes ProjectDefinition to allow snowflake.yml with only env section
```
definition_version: 2
env:
  foo: 42
```
