### PR TITLE
Fix `snow app diff` with string identifier

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -122,7 +122,7 @@ def app_diff(
         package_id,
         EntityActions.BUNDLE,
     )
-    stage_fqn = f"{package.identifier.name}.{package.stage}"
+    stage_fqn = f"{package.fqn.name}.{package.stage}"
     diff: DiffResult = compute_stage_diff(
         local_root=Path(package.deploy_root), stage_fqn=stage_fqn
     )

--- a/tests_integration/nativeapp/test_diff.py
+++ b/tests_integration/nativeapp/test_diff.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from nativeapp.factories import ProjectV2Factory, ApplicationPackageEntityModelFactory
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("package_identifier", ["myapp_pkg", dict(name="myapp_pkg")])
+def test_app_diff(temp_dir, runner, package_identifier):
+    ProjectV2Factory(
+        pdf__entities=dict(
+            pkg=ApplicationPackageEntityModelFactory(
+                identifier=package_identifier,
+                artifacts=[{"src": "*", "dest": "./"}],
+            ),
+        ),
+        files={"setup.sql": ""},
+    )
+    result = runner.invoke_with_connection(["app", "deploy", "--no-validate"])
+    assert result.exit_code == 0
+
+    with open("README.md", "w") as f:
+        f.write("Hello world!")
+
+    result = runner.invoke_with_connection(["app", "diff"])
+    assert result.exit_code == 0
+    assert "README.md" in result.output

--- a/tests_integration/nativeapp/test_diff.py
+++ b/tests_integration/nativeapp/test_diff.py
@@ -1,8 +1,9 @@
-from pathlib import Path
-
 import pytest
 
-from nativeapp.factories import ProjectV2Factory, ApplicationPackageEntityModelFactory
+from tests.nativeapp.factories import (
+    ProjectV2Factory,
+    ApplicationPackageEntityModelFactory,
+)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes `snow app diff` crash by making it handle both kinds of identifiers (string and object)
