### PR TITLE
Delete the hidden `snow app init` command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
 
 ## Deprecations
 * Added deprecation warning in the description of `snow spcs service status` and `snow spcs image-repository list-tags`.
+* Completely removed the `snow app init` as it was replaced with `snow init` in Snowflake CLI 3.0
 
 ## New additions
 * Added `snow connection generate-jwt` command to generate JWT token for Snowflake connection.

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -22,7 +22,6 @@ from textwrap import dedent
 from typing import Generator, Iterable, List, Optional, cast
 
 import typer
-from click.exceptions import ClickException
 from snowflake.cli._plugins.nativeapp.common_flags import (
     ForceOption,
     InteractiveOption,
@@ -66,17 +65,6 @@ app = SnowTyperFactory(
 app.add_typer(versions_app)
 
 log = logging.getLogger(__name__)
-
-
-@app.command("init", hidden=True)
-def app_init(**options):
-    """
-    *** Deprecated. Use snow init instead ***
-
-    Initializes a Snowflake Native App project.
-    """
-
-    raise ClickException("This command has been removed. Use `snow init` instead.")
 
 
 @app.command("bundle")


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

Removed the `snow app init` command, since it was disabled and hidden in 3.0.
