### PR TITLE
SNOW-1706990 Remove static method for action_version_list

### DIFF
--- a/tests/nativeapp/fixtures.py
+++ b/tests/nativeapp/fixtures.py
@@ -14,10 +14,38 @@
 
 import unittest.mock as mock
 
+import factory
 import pytest
 from snowflake.cli._plugins.nativeapp.artifacts import BundleMap
+from snowflake.cli._plugins.nativeapp.entities.application import (
+    ApplicationEntity,
+    ApplicationEntityModel,
+)
+from snowflake.cli._plugins.nativeapp.entities.application_package import (
+    ApplicationPackageEntity,
+    ApplicationPackageEntityModel,
+)
+
+from tests.nativeapp.factories import (
+    ApplicationEntityModelFactory,
+    ApplicationPackageEntityModelFactory,
+)
 
 
 @pytest.fixture()
 def mock_bundle_map():
     yield mock.Mock(spec=BundleMap)
+
+
+@pytest.fixture()
+def application_package_entity(workspace_context):
+    data = ApplicationPackageEntityModelFactory(identifier=factory.Faker("word"))
+    model = ApplicationPackageEntityModel(**data)
+    return ApplicationPackageEntity(model, workspace_context)
+
+
+@pytest.fixture()
+def application_entity(workspace_context):
+    data = ApplicationEntityModelFactory(identifier=factory.Faker("word"))
+    model = ApplicationEntityModel(**data)
+    return ApplicationEntity(model, workspace_context)

--- a/tests_common/conftest.py
+++ b/tests_common/conftest.py
@@ -14,8 +14,13 @@
 
 import os
 import tempfile
+from pathlib import Path
+from unittest import mock
 
 import pytest
+
+from snowflake.cli._plugins.workspace.context import WorkspaceContext, ActionContext
+from snowflake.cli.api.console.abc import AbstractConsole
 
 
 @pytest.fixture
@@ -30,3 +35,23 @@ def temp_dir():
             # this has to happen before tmp_dir is cleaned up
             # so that we don't try to remove the cwd of the process
             os.chdir(initial_dir)
+
+
+@pytest.fixture()
+def mock_console():
+    yield mock.MagicMock(spec=AbstractConsole)
+
+
+@pytest.fixture()
+def workspace_context(mock_console):
+    return WorkspaceContext(
+        console=mock_console,
+        project_root=Path().resolve(),
+        get_default_role=lambda: "mock_role",
+        get_default_warehouse=lambda: "mock_warehouse",
+    )
+
+
+@pytest.fixture()
+def action_context():
+    return ActionContext(get_entity=lambda *args: None)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
The static and class methods on entities was intended as a stopgap to allow them to be called from `NativeAppManager` without an instance of the entity. Now that `NativeAppManager` is gone (#1749), we can get rid of the static and call the action on an instance instead. This also has the advantage of unit-testing the action methods, which were previously only run in integration tests.

This PR also adds some fixtures to create dummy entity instances, which will be useful in future unit tests (instead of needing to load a whole definition file).