### PR TITLE
SNOW-1758715 Convert app package deploy and validate to instance methods

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -352,7 +352,11 @@ def app_validate(
     package_id = options["package_entity_id"]
     package = ws.get_entity(package_id)
     if cli_context.output_format == OutputFormat.JSON:
-        return ObjectResult(package.get_validation_result(use_scratch_stage=True))
+        return ObjectResult(
+            package.get_validation_result(
+                use_scratch_stage=True, interactive=False, force=True
+            )
+        )
 
     ws.perform_action(
         package_id,

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -544,6 +544,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         stage_fqn: str,
         interactive: bool,
         force: bool,
+        run_post_deploy_hooks: bool = True,
     ) -> DiffResult:
         model = self._entity_model
         workspace_ctx = self._workspace_ctx
@@ -609,13 +610,14 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 print_diff=print_diff,
             )
 
-            self.execute_post_deploy_hooks(
-                console=console,
-                project_root=project_root,
-                post_deploy_hooks=(model.meta and model.meta.post_deploy),
-                package_name=package_name,
-                package_warehouse=package_warehouse,
-            )
+            if run_post_deploy_hooks:
+                self.execute_post_deploy_hooks(
+                    console=console,
+                    project_root=project_root,
+                    post_deploy_hooks=(model.meta and model.meta.post_deploy),
+                    package_name=package_name,
+                    package_warehouse=package_warehouse,
+                )
 
         if validate:
             self.validate_setup_script(
@@ -1140,6 +1142,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 stage_fqn=scratch_stage_fqn,
                 interactive=interactive,
                 force=force,
+                run_post_deploy_hooks=False,
             )
         prefixed_stage_fqn = StageManager.get_standard_stage_prefix(stage_fqn)
         sql_executor = get_sql_executor()

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1362,6 +1362,7 @@ def test_validate_use_scratch_stage(mock_execute, mock_deploy, temp_dir, mock_cu
         stage_fqn=f"{pkg_model.fqn.name}.{pkg_model.scratch_stage}",
         interactive=False,
         force=True,
+        run_post_deploy_hooks=False,
     )
     assert mock_execute.mock_calls == expected
 
@@ -1437,6 +1438,7 @@ def test_validate_failing_drops_scratch_stage(
         stage_fqn=f"{pkg_model.fqn.name}.{pkg_model.scratch_stage}",
         interactive=False,
         force=True,
+        run_post_deploy_hooks=False,
     )
     assert mock_execute.mock_calls == expected
 

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -46,7 +46,6 @@ from snowflake.cli._plugins.nativeapp.exceptions import (
     ObjectPropertyNotFoundError,
     SetupScriptFailedValidation,
 )
-from snowflake.cli._plugins.nativeapp.policy import AllowAlwaysPolicy
 from snowflake.cli._plugins.stage.diff import (
     DiffResult,
     StagePathType,
@@ -1353,29 +1352,16 @@ def test_validate_use_scratch_stage(mock_execute, mock_deploy, temp_dir, mock_cu
 
     pd = wm._project_definition  # noqa: SLF001
     pkg_model: ApplicationPackageEntityModel = pd.entities["app_pkg"]
-    project_root = wm._project_root  # noqa: SLF001
     mock_deploy.assert_called_with(
-        console=cc,
-        project_root=project_root,
-        deploy_root=project_root / pkg_model.deploy_root,
-        bundle_root=project_root / pkg_model.bundle_root,
-        generated_root=(
-            project_root / pkg_model.deploy_root / pkg_model.generated_root
-        ),
-        artifacts=pkg_model.artifacts,
         bundle_map=None,
-        package_name=pkg_model.fqn.name,
-        package_role=pkg_model.meta.role,
-        package_distribution=pkg_model.distribution,
         prune=True,
         recursive=True,
         paths=[],
         print_diff=False,
         validate=False,
         stage_fqn=f"{pkg_model.fqn.name}.{pkg_model.scratch_stage}",
-        package_warehouse=pkg_model.meta.warehouse,
-        post_deploy_hooks=[],
-        policy=AllowAlwaysPolicy(),
+        interactive=False,
+        force=True,
     )
     assert mock_execute.mock_calls == expected
 
@@ -1441,29 +1427,16 @@ def test_validate_failing_drops_scratch_stage(
 
     pd = wm._project_definition  # noqa: SLF001
     pkg_model: ApplicationPackageEntityModel = pd.entities["app_pkg"]
-    project_root = wm._project_root  # noqa: SLF001
     mock_deploy.assert_called_with(
-        console=cc,
-        project_root=project_root,
-        deploy_root=project_root / pkg_model.deploy_root,
-        bundle_root=project_root / pkg_model.bundle_root,
-        generated_root=(
-            project_root / pkg_model.deploy_root / pkg_model.generated_root
-        ),
-        artifacts=pkg_model.artifacts,
         bundle_map=None,
-        package_name=pkg_model.fqn.name,
-        package_role=pkg_model.meta.role,
-        package_distribution=pkg_model.distribution,
         prune=True,
         recursive=True,
         paths=[],
         print_diff=False,
         validate=False,
         stage_fqn=f"{pkg_model.fqn.name}.{pkg_model.scratch_stage}",
-        package_warehouse=pkg_model.meta.warehouse,
-        post_deploy_hooks=[],
-        policy=AllowAlwaysPolicy(),
+        interactive=False,
+        force=True,
     )
     assert mock_execute.mock_calls == expected
 
@@ -1511,7 +1484,12 @@ def test_validate_raw_returns_data(mock_execute, temp_dir, mock_cursor):
 
     wm = _get_wm()
     pkg = wm.get_entity("app_pkg")
-    assert pkg.get_validation_result(use_scratch_stage=False) == failure_data
+    assert (
+        pkg.get_validation_result(
+            use_scratch_stage=False, interactive=False, force=True
+        )
+        == failure_data
+    )
     assert mock_execute.mock_calls == expected
 
 

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -397,7 +397,7 @@ def test_process_no_version_exists_throws_bad_option_exception_two(
 @mock.patch.object(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
-@mock.patch.object(ApplicationPackageEntity, "deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -452,7 +452,7 @@ def test_process_no_existing_release_directives_or_versions(
 @mock.patch.object(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
-@mock.patch.object(ApplicationPackageEntity, "deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -515,7 +515,7 @@ def test_process_no_existing_release_directives_w_existing_version(
 @mock.patch.object(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
-@mock.patch.object(ApplicationPackageEntity, "deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -574,7 +574,7 @@ def test_process_existing_release_directives_user_does_not_proceed(
 @mock.patch.object(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
-@mock.patch.object(ApplicationPackageEntity, "deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -43,7 +43,7 @@ APP_ENTITY_GET_OBJECTS_OWNED_BY_APPLICATION = (
 APP_ENTITY_GET_ACCOUNT_EVENT_TABLE = f"{APP_ENTITY}.get_account_event_table"
 
 APP_PACKAGE_ENTITY = "snowflake.cli._plugins.nativeapp.entities.application_package.ApplicationPackageEntity"
-APP_PACKAGE_ENTITY_DEPLOY = f"{APP_PACKAGE_ENTITY}.deploy"
+APP_PACKAGE_ENTITY_DEPLOY = f"{APP_PACKAGE_ENTITY}._deploy"
 APP_PACKAGE_ENTITY_DISTRIBUTION_IN_SF = (
     f"{APP_PACKAGE_ENTITY}.get_app_pkg_distribution_in_snowflake"
 )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Updates `ApplicationPackageEntity` to make deploy and validation classmethods into instance methods, greatly simplifying the parameters being passed around.
