### PR TITLE
SNOW-1758715 Convert execute_post_deploy_hooks to instance method

### DIFF
--- a/tests/nativeapp/test_application_package_entity.py
+++ b/tests/nativeapp/test_application_package_entity.py
@@ -26,7 +26,6 @@ from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntityModel,
 )
 from snowflake.cli._plugins.workspace.context import ActionContext, WorkspaceContext
-from snowflake.cli.api.project.schemas.entities.common import SqlScriptHookType
 from snowflake.connector.cursor import DictCursor
 
 from tests.nativeapp.utils import (
@@ -164,16 +163,7 @@ def test_deploy(
         print_diff=True,
     )
     mock_validate.assert_called_once()
-    mock_execute_post_deploy_hooks.assert_called_once_with(
-        console=mock_console,
-        project_root=app_pkg._workspace_ctx.project_root,  # noqa SLF001
-        post_deploy_hooks=[
-            SqlScriptHookType(sql_script="scripts/package_post_deploy1.sql"),
-            SqlScriptHookType(sql_script="scripts/package_post_deploy2.sql"),
-        ],
-        package_name="pkg",
-        package_warehouse="wh",
-    )
+    mock_execute_post_deploy_hooks.assert_called_once_with()
     assert mock_execute.mock_calls == expected
 
 

--- a/tests/nativeapp/test_post_deploy_for_app.py
+++ b/tests/nativeapp/test_post_deploy_for_app.py
@@ -58,6 +58,7 @@ def test_sql_scripts(
     mock_execute_queries,
     mock_execute_query,
     temp_dir,
+    workspace_context,
 ):
     mock_conn.return_value = MockConnectionCtx()
     post_deploy_1 = dedent(
@@ -94,13 +95,8 @@ def test_sql_scripts(
     dm = DefinitionManager()
     mock_cli_ctx.return_value = dm.template_context
     app_model: ApplicationEntityModel = dm.project_definition.entities["app"]
-    ApplicationEntity.execute_post_deploy_hooks(
-        console=cc,
-        project_root=dm.project_root,
-        post_deploy_hooks=app_model.meta.post_deploy,
-        app_name=app_model.fqn.name,
-        app_warehouse=app_model.meta.warehouse or "MockWarehouse",
-    )
+    app = ApplicationEntity(app_model, workspace_context)
+    app.execute_post_deploy_hooks()
 
     mock_execute_query.assert_has_calls(
         [
@@ -172,51 +168,18 @@ def test_sql_scripts_with_no_warehouse_no_database(
 @mock.patch(SQL_EXECUTOR_EXECUTE)
 @mock_connection()
 def test_missing_sql_script(
-    mock_execute_query,
-    mock_conn,
-    project_directory,
+    mock_execute_query, mock_conn, project_directory, workspace_context
 ):
     mock_conn.return_value = MockConnectionCtx()
     with project_directory("napp_post_deploy_missing_file_v2") as project_dir:
         dm = DefinitionManager()
         app_model: ApplicationEntityModel = dm.project_definition.entities["myapp"]
+        app = ApplicationEntity(app_model, workspace_context)
 
         with pytest.raises(MissingScriptError) as err:
-            ApplicationEntity.execute_post_deploy_hooks(
-                console=cc,
-                project_root=dm.project_root,
-                post_deploy_hooks=app_model.meta.post_deploy,
-                app_name=app_model.fqn.name,
-                app_warehouse=app_model.meta.warehouse or "MockWarehouse",
-            )
+            app.execute_post_deploy_hooks()
 
         assert err.value.message == 'Script "scripts/missing.sql" does not exist'
-
-
-@mock.patch(SQL_EXECUTOR_EXECUTE)
-@mock_connection()
-def test_invalid_hook_type(
-    mock_conn,
-    mock_execute_query,
-    project_directory,
-):
-    mock_hook = mock.Mock()
-    mock_hook.invalid_type = "invalid_type"
-    mock_hook.sql_script = None
-    mock_conn.return_value = MockConnectionCtx()
-    with project_directory("napp_post_deploy_v2") as project_dir:
-        dm = DefinitionManager()
-        app_model: ApplicationEntityModel = dm.project_definition.entities["myapp"]
-
-        with pytest.raises(ValueError) as err:
-            ApplicationEntity.execute_post_deploy_hooks(
-                console=cc,
-                project_root=dm.project_root,
-                post_deploy_hooks=[mock_hook],
-                app_name=app_model.fqn.name,
-                app_warehouse=app_model.meta.warehouse or "MockWarehouse",
-            )
-        assert "Unsupported application post-deploy hook type" in str(err)
 
 
 @pytest.mark.parametrize(
@@ -251,6 +214,7 @@ def test_app_post_deploy_with_template(
     mock_execute_query,
     project_directory,
     template_syntax,
+    workspace_context,
 ):
     mock_conn.return_value = MockConnectionCtx()
     mock_cli_ctx.return_value = {"ctx": {"env": {"test": "test_value"}}}
@@ -269,14 +233,9 @@ def test_app_post_deploy_with_template(
             )
         dm = DefinitionManager()
         app_model: ApplicationEntityModel = dm.project_definition.entities["myapp"]
+        app = ApplicationEntity(app_model, workspace_context)
 
-        ApplicationEntity.execute_post_deploy_hooks(
-            console=cc,
-            project_root=dm.project_root,
-            post_deploy_hooks=app_model.meta.post_deploy,
-            app_name=app_model.fqn.name,
-            app_warehouse=app_model.meta.warehouse or "MockWarehouse",
-        )
+        app.execute_post_deploy_hooks()
 
         mock_execute_query.assert_has_calls(
             [
@@ -310,6 +269,7 @@ def test_app_post_deploy_with_mixed_syntax_template(
     mock_execute_queries,
     mock_execute_query,
     project_directory,
+    workspace_context,
 ):
     mock_conn.return_value = MockConnectionCtx()
     mock_cli_ctx.return_value = {"ctx": {"env": {"test": "test_value"}}}
@@ -329,15 +289,10 @@ def test_app_post_deploy_with_mixed_syntax_template(
             )
         dm = DefinitionManager()
         app_model: ApplicationEntityModel = dm.project_definition.entities["myapp"]
+        app = ApplicationEntity(app_model, workspace_context)
 
         with pytest.raises(InvalidTemplate) as err:
-            ApplicationEntity.execute_post_deploy_hooks(
-                console=cc,
-                project_root=dm.project_root,
-                post_deploy_hooks=app_model.meta.post_deploy,
-                app_name=app_model.fqn.name,
-                app_warehouse=app_model.meta.warehouse or "MockWarehouse",
-            )
+            app.execute_post_deploy_hooks()
 
         assert (
             "The SQL query in scripts/app_post_deploy1.sql mixes &{ ... } syntax and <% ... %> syntax."


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Converts `execute_post_deploy_hooks` for both entities to instance methods. Removes `test_invalid_hook_type` since it's now impossible to pass an invalid hook since Pydantic will fail to validate the model object (and will also fail if trying to set `model.meta.post_deploy` to an invalid hook afterwards).
