### PR TITLE
[SNOW-1739737] BUGFIX: Setting a default connection copies the connection from connections.toml to config.toml

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,8 @@
 * `snow --info` callback returns information about `SNOWFLAKE_HOME` variable.
 * Removed requirement of existence of any `requirements.txt` file for Python code execution via `snow git execute` command.
   Before the fix the file (even empty) was required to make the execution working.
+* Fixed saving of the config file updates when `connections.toml` exists.
+  Removed incorrect copying of connections from `connections.toml` to `config.toml`.
 
 
 # v3.1.0

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -345,6 +345,9 @@ def _dump_config(config_and_connections: Dict):
 
     if CONNECTIONS_FILE.exists():
         # update connections in connections.toml
+        # it will add only connections (maybe updated) which were originally read from connections.toml
+        # it won't add connections from config.toml
+        # because config manager doesn't have connections from config.toml if connections.toml exists
         _update_connections_toml(config_and_connections.get("connections") or {})
         # to config.toml save only connections from config.toml
         connections_to_save_in_config_toml = _read_config_file_toml().get("connections")

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -340,12 +340,12 @@ def _get_envs_for_path(*path) -> dict:
     }
 
 
-def _dump_config(whole_conf_cache: Dict):
-    config_toml_dict = whole_conf_cache.copy()
+def _dump_config(config_and_connections: Dict):
+    config_toml_dict = config_and_connections.copy()
 
     if CONNECTIONS_FILE.exists():
         # update connections in connections.toml
-        _update_connections_toml(whole_conf_cache.get("connections") or {})
+        _update_connections_toml(config_and_connections.get("connections") or {})
         # to config.toml save only connections from config.toml
         connections_to_save_in_config_toml = _read_config_file_toml().get("connections")
         config_toml_dict["connections"] = connections_to_save_in_config_toml
@@ -383,13 +383,11 @@ def get_feature_flags_section() -> Dict[str, bool | Literal["UNKNOWN"]]:
 
 
 def _read_config_file_toml() -> dict:
-    with open(CONFIG_MANAGER.file_path, "r") as f:
-        return tomlkit.loads(f.read()).unwrap()
+    return tomlkit.loads(CONFIG_MANAGER.file_path.read_text())
 
 
 def _read_connections_toml() -> dict:
-    with open(CONNECTIONS_FILE, "r") as f:
-        return tomlkit.loads(f.read()).unwrap()
+    return tomlkit.loads(CONNECTIONS_FILE.read_text())
 
 
 def _update_connections_toml(connections: dict):

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -383,11 +383,11 @@ def get_feature_flags_section() -> Dict[str, bool | Literal["UNKNOWN"]]:
 
 
 def _read_config_file_toml() -> dict:
-    return tomlkit.loads(CONFIG_MANAGER.file_path.read_text())
+    return tomlkit.loads(CONFIG_MANAGER.file_path.read_text()).unwrap()
 
 
 def _read_connections_toml() -> dict:
-    return tomlkit.loads(CONNECTIONS_FILE.read_text())
+    return tomlkit.loads(CONNECTIONS_FILE.read_text()).unwrap()
 
 
 def _update_connections_toml(connections: dict):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,7 +224,7 @@ def test_not_found_default_connection_from_evn_variable(test_root_path):
     )
 
 
-def test_no_copy_of_connection_to_config_toml_on_setting_default_connection(
+def test_correct_updates_of_connections_on_setting_default_connection(
     test_snowcli_config, snowflake_home
 ):
     from snowflake.cli.api.config import CONFIG_MANAGER
@@ -245,29 +245,55 @@ def test_no_copy_of_connection_to_config_toml_on_setting_default_connection(
     config_init(test_snowcli_config)
     set_config_value(section=None, key="default_connection_name", value="asdf_b")
 
-    assert CONFIG_MANAGER["default_connection_name"] == "asdf_b"
-    assert CONFIG_MANAGER["connections"] == {
-        "asdf_a": {
-            "database": "asdf_a_database",
-            "user": "asdf_a",
-            "account": "asdf_a",
-        },
-        "asdf_b": {
-            "database": "asdf_b_database",
-            "user": "asdf_b",
-            "account": "asdf_b",
-        },
-    }
+    def assert_correct_connections_loaded():
+        assert CONFIG_MANAGER["default_connection_name"] == "asdf_b"
+        assert CONFIG_MANAGER["connections"] == {
+            "asdf_a": {
+                "database": "asdf_a_database",
+                "user": "asdf_a",
+                "account": "asdf_a",
+            },
+            "asdf_b": {
+                "database": "asdf_b_database",
+                "user": "asdf_b",
+                "account": "asdf_b",
+            },
+        }
+
+    assert_correct_connections_loaded()
+
     with open(connections_toml) as f:
         connection_toml_content = f.read()
-        assert connection_toml_content.count("asdf_a") == 4
-        assert connection_toml_content.count("asdf_b") == 4
+        assert (
+            connection_toml_content.count("asdf_a") == 4
+        )  # connection still exists in connections.toml
+        assert (
+            connection_toml_content.count("asdf_b") == 4
+        )  # connection still exists in connections.toml
+        assert (
+            connection_toml_content.count("jwt") == 0
+        )  # connection from config.toml isn't copied to connections.toml
     with open(test_snowcli_config) as f:
         config_toml_content = f.read()
-        assert config_toml_content.count("asdf_a") == 0
+        assert (
+            config_toml_content.count("asdf_a") == 0
+        )  # connection from connections.toml isn't copied to config.toml
         assert (
             config_toml_content.count("asdf_b") == 1
-        )  # only default_config_name setting
+        )  # only default_config_name setting, connection from connections.toml isn't copied to config.toml
+        assert (
+            config_toml_content.count("connections.full") == 1
+        )  # connection still exists in config.toml
+        assert (
+            config_toml_content.count("connections.jwt") == 1
+        )  # connection still exists in config.toml
+        assert (
+            config_toml_content.count("dummy_flag = true") == 1
+        )  # other settings are not erased
+
+    # reinit config file and recheck loaded connections
+    config_init(test_snowcli_config)
+    assert_correct_connections_loaded()
 
 
 def test_connections_toml_override_config_toml(test_snowcli_config, snowflake_home):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,6 +260,7 @@ def test_correct_updates_of_connections_on_setting_default_connection(
             },
         }
 
+    # assert correct connections in memory after setting default connection name
     assert_correct_connections_loaded()
 
     with open(connections_toml) as f:

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -268,7 +268,7 @@ def temp_directory_for_app_zip(temp_dir) -> Generator:
     yield temp_dir.name
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def test_snowcli_config():
     test_config = TEST_DIR / "test.toml"
     with _named_temporary_file(suffix=".toml") as p:


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
  * Changed scope of unit tests' `test_snowcli_config` fixture from `session` to `function` to avoid side effects between tests.
  * Added an unit test confirming the bug
  * Bugfix in `config.py`. We were saving whole content of "conf file cache" to `config.toml`. Now we're saving connections to `connections.toml` if that file exists.

### Bug description
  * Conditions:
    * No connections in `config.toml`
    * Only one connection in `connections.toml` (“dev” connection)
    * Invoked command: `snow connection set-default "dev"`
  * Incorrect behaviour:
    * Default connection was changed correctly but “dev” connection details were copied from `connections.toml` to `config.toml`. User may don’t want to keep connection secrets in config.toml so IMO it looks like security issue.
  * Reason:
    * We were saving whole content of "conf file cache" to `config.toml` forgetting about existence of connections.toml as a source of connections.
