### PR TITLE
Fixes and improvements in E2E tests

### DIFF
--- a/test_external_plugins/broken_plugin/pyproject.toml
+++ b/test_external_plugins/broken_plugin/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 name = "override-build-in-commands"
 requires-python = ">=3.8"
 dependencies = [
-    "snowflake-cli-labs>=2.0.0"
+    "snowflake-cli>=2.0.0"
 ]
 version = "0.0.1"
 

--- a/test_external_plugins/failing_plugin/pyproject.toml
+++ b/test_external_plugins/failing_plugin/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 name = "override-build-in-commands"
 requires-python = ">=3.8"
 dependencies = [
-    "snowflake-cli-labs>=2.0.0"
+    "snowflake-cli>=2.0.0"
 ]
 version = "0.0.1"
 

--- a/test_external_plugins/multilingual_hello_command_group/pyproject.toml
+++ b/test_external_plugins/multilingual_hello_command_group/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 name = "snowflakecli-test-multilingual-hello-plugin"
 requires-python = ">=3.8"
 dependencies = [
-    "snowflake-cli-labs>=1.1.0"
+    "snowflake-cli>=1.1.0"
 ]
 version = "0.0.1"
 

--- a/test_external_plugins/override_build_in_command/pyproject.toml
+++ b/test_external_plugins/override_build_in_command/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 name = "override-build-in-commands"
 requires-python = ">=3.8"
 dependencies = [
-    "snowflake-cli-labs>=1.1.0"
+    "snowflake-cli>=1.1.0"
 ]
 version = "0.0.1"
 

--- a/test_external_plugins/snowpark_hello_single_command/pyproject.toml
+++ b/test_external_plugins/snowpark_hello_single_command/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 name = "snowflakecli-test-snowpark-hello-plugin"
 requires-python = ">=3.8"
 dependencies = [
-    "snowflake-cli-labs>=1.1.0"
+    "snowflake-cli>=1.1.0"
 ]
 version = "0.0.1"
 

--- a/tests_common/pycharm_debug.py
+++ b/tests_common/pycharm_debug.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from snowflake.cli._app.dev.pycharm_remote_debug import (
+    setup_pycharm_remote_debugger_if_provided,
+)
+
+# How to use remote debugger?
+# 1. Create "Python Remote Debugger" run configuration in PyCharm / IntelliJ.
+# 2. Install matching pydevd-pycharm via pip in your venv (see instructions in your remote debug run configuration window).
+# 3. Add invocation of setup_default_pycharm_remote_debugger() somewhere in your test code - I suggest to do it at the very beginning - in conftest.py.
+# 4. Run "remote debug" configuration, create breakpoints your tests and then run your tests, you can start the fun.
+def setup_default_pycharm_remote_debugger(
+    pycharm_debug_library_path: Optional[str] = None,
+):
+    setup_pycharm_remote_debugger_if_provided(
+        pycharm_debug_library_path=pycharm_debug_library_path
+        or "unused if you install pydevd-pycharm via pip",
+        pycharm_debug_server_host="localhost",
+        pycharm_debug_server_port=12345,
+    )

--- a/tests_e2e/__snapshots__/test_installation.ambr
+++ b/tests_e2e/__snapshots__/test_installation.ambr
@@ -14,7 +14,7 @@
                                                                                   
    Usage: snow [OPTIONS] COMMAND [ARGS]...                                        
                                                                                   
-   Snowflake CLI tool for developers.                                             
+   Snowflake CLI tool for developers [v3.2.0.dev0]                                
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --version                           Shows version of the Snowflake CLI       |

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -27,6 +27,10 @@ from tests_common import IS_WINDOWS
 
 TEST_DIR = Path(__file__).parent
 
+pytest_plugins = [
+    "tests_common",
+]
+
 
 def _clean_output(text: str):
     """


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
   * Fixed `snow --help` e2e test.
      * Bug reason: CLI was firstly installed in correct dev version but plugins which still required `snowflake-cli-labs` instead of `snowflake-cli` were able to find only officially released CLI versions and were overriding dev CLI with official CLI.
   * Added `pycharm_debug.py` manual util to simplify debugging of tests (especially integration and e2e tests).
   * Added `tests_common` as pytest plugin to e2e tests to make possible to run e2e tests locally.
