### PR TITLE
SNOW-1758715 Move small helper methods out of ApplicationEntity class

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -699,7 +699,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
             raise ValueError("first and last cannot be used together")
 
         account_event_table = get_snowflake_facade().get_account_event_table()
-        if not account_event_table or account_event_table == "NONE":
+        if account_event_table is None:
             raise NoEventTableForAccount()
 
         # resource_attributes uses the unquoted/uppercase app and package name

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -40,6 +40,7 @@ from snowflake.cli._plugins.nativeapp.policy import (
 from snowflake.cli._plugins.nativeapp.same_account_install_method import (
     SameAccountInstallMethod,
 )
+from snowflake.cli._plugins.nativeapp.sf_facade import get_snowflake_facade
 from snowflake.cli._plugins.nativeapp.utils import needs_confirmation
 from snowflake.cli._plugins.workspace.context import ActionContext
 from snowflake.cli.api.cli_global_context import get_cli_context
@@ -697,7 +698,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         if first >= 0 and last >= 0:
             raise ValueError("first and last cannot be used together")
 
-        account_event_table = _get_account_event_table()
+        account_event_table = get_snowflake_facade().get_account_event_table()
         if not account_event_table or account_event_table == "NONE":
             raise NoEventTableForAccount()
 
@@ -876,10 +877,3 @@ def _application_objects_to_str(
 
 def _application_object_to_str(obj: ApplicationOwnedObject) -> str:
     return f"({obj['type']}) {obj['name']}"
-
-
-def _get_account_event_table():
-    query = "show parameters like 'event_table' in account"
-    sql_executor = get_sql_executor()
-    results = sql_executor.execute_query(query, cursor_class=DictCursor)
-    return next((r["value"] for r in results if r["key"] == "EVENT_TABLE"), "")

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -28,7 +28,7 @@ from snowflake.cli.api.errno import (
 )
 from snowflake.cli.api.project.util import to_identifier
 from snowflake.cli.api.sql_execution import SqlExecutor
-from snowflake.connector import ProgrammingError
+from snowflake.connector import DictCursor, ProgrammingError
 
 
 class SnowflakeSQLFacade:
@@ -193,3 +193,8 @@ class SnowflakeSQLFacade:
                     raise UserScriptError(script_name, err.msg) from err
             except Exception as err:
                 handle_unclassified_error(err, f"Failed to run script {script_name}.")
+
+    def get_account_event_table(self) -> str:
+        query = "show parameters like 'event_table' in account"
+        results = self._sql_executor.execute_query(query, cursor_class=DictCursor)
+        return next((r["value"] for r in results if r["key"] == "EVENT_TABLE"), "")

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -34,6 +34,7 @@ from snowflake.cli._plugins.nativeapp.constants import (
 from snowflake.cli._plugins.nativeapp.entities.application import (
     ApplicationEntity,
     ApplicationEntityModel,
+    _get_account_event_table,
 )
 from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntity,
@@ -1482,7 +1483,7 @@ def test_account_event_table(mock_execute, temp_dir, mock_cursor):
     )
     mock_execute.side_effect = side_effects
 
-    assert ApplicationEntity.get_account_event_table() == event_table
+    assert _get_account_event_table() == event_table
 
 
 @mock.patch(SQL_EXECUTOR_EXECUTE)
@@ -1506,7 +1507,7 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     )
     mock_execute.side_effect = side_effects
 
-    assert ApplicationEntity.get_account_event_table() == ""
+    assert _get_account_event_table() == ""
 
 
 @pytest.mark.parametrize(

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1713,12 +1713,11 @@ def test_get_events_quoted_app_name(
     assert mock_execute.mock_calls == expected
 
 
-@pytest.mark.parametrize("return_value", [None, "NONE"])
 @mock.patch(SQL_FACADE_GET_ACCOUNT_EVENT_TABLE)
 def test_get_events_no_event_table(
-    mock_account_event_table, return_value, temp_dir, mock_cursor, workspace_context
+    mock_account_event_table, temp_dir, mock_cursor, workspace_context
 ):
-    mock_account_event_table.return_value = return_value
+    mock_account_event_table.return_value = None
     create_named_file(
         file_name="snowflake.yml",
         dir_name=temp_dir,

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -34,7 +34,6 @@ from snowflake.cli._plugins.nativeapp.constants import (
 from snowflake.cli._plugins.nativeapp.entities.application import (
     ApplicationEntity,
     ApplicationEntityModel,
-    _get_account_event_table,
 )
 from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntity,
@@ -75,12 +74,12 @@ from tests.nativeapp.patch_utils import (
     mock_get_app_pkg_distribution_in_sf,
 )
 from tests.nativeapp.utils import (
-    APP_ENTITY_GET_ACCOUNT_EVENT_TABLE,
     APP_PACKAGE_ENTITY_DEPLOY,
     APP_PACKAGE_ENTITY_GET_EXISTING_APP_PKG_INFO,
     APP_PACKAGE_ENTITY_IS_DISTRIBUTION_SAME,
     ENTITIES_UTILS_MODULE,
     SQL_EXECUTOR_EXECUTE,
+    SQL_FACADE_GET_ACCOUNT_EVENT_TABLE,
     mock_execute_helper,
     mock_snowflake_yml_file_v2,
     quoted_override_yml_file_v2,
@@ -1461,55 +1460,6 @@ def test_validate_raw_returns_data(mock_execute, temp_dir, mock_cursor):
     assert mock_execute.mock_calls == expected
 
 
-@mock.patch(SQL_EXECUTOR_EXECUTE)
-def test_account_event_table(mock_execute, temp_dir, mock_cursor):
-    create_named_file(
-        file_name="snowflake.yml",
-        dir_name=temp_dir,
-        contents=[mock_snowflake_yml_file_v2],
-    )
-
-    event_table = "db.schema.event_table"
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([dict(key="EVENT_TABLE", value=event_table)], []),
-                mock.call(
-                    "show parameters like 'event_table' in account",
-                    cursor_class=DictCursor,
-                ),
-            ),
-        ]
-    )
-    mock_execute.side_effect = side_effects
-
-    assert _get_account_event_table() == event_table
-
-
-@mock.patch(SQL_EXECUTOR_EXECUTE)
-def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
-    create_named_file(
-        file_name="snowflake.yml",
-        dir_name=temp_dir,
-        contents=[mock_snowflake_yml_file_v2],
-    )
-
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([], []),
-                mock.call(
-                    "show parameters like 'event_table' in account",
-                    cursor_class=DictCursor,
-                ),
-            ),
-        ]
-    )
-    mock_execute.side_effect = side_effects
-
-    assert _get_account_event_table() == ""
-
-
 @pytest.mark.parametrize(
     ["since", "expected_since_clause"],
     [
@@ -1616,7 +1566,7 @@ def test_account_event_table_not_set_up(mock_execute, temp_dir, mock_cursor):
     ],
 )
 @mock.patch(
-    APP_ENTITY_GET_ACCOUNT_EVENT_TABLE,
+    SQL_FACADE_GET_ACCOUNT_EVENT_TABLE,
     return_value="db.schema.event_table",
 )
 @mock.patch(SQL_EXECUTOR_EXECUTE)
@@ -1708,7 +1658,7 @@ def test_get_events(
 
 
 @mock.patch(
-    APP_ENTITY_GET_ACCOUNT_EVENT_TABLE,
+    SQL_FACADE_GET_ACCOUNT_EVENT_TABLE,
     return_value="db.schema.event_table",
 )
 @mock.patch(SQL_EXECUTOR_EXECUTE)
@@ -1764,7 +1714,7 @@ def test_get_events_quoted_app_name(
 
 
 @pytest.mark.parametrize("return_value", [None, "NONE"])
-@mock.patch(APP_ENTITY_GET_ACCOUNT_EVENT_TABLE)
+@mock.patch(SQL_FACADE_GET_ACCOUNT_EVENT_TABLE)
 def test_get_events_no_event_table(
     mock_account_event_table, return_value, temp_dir, mock_cursor, workspace_context
 ):
@@ -1784,7 +1734,7 @@ def test_get_events_no_event_table(
 
 
 @mock.patch(
-    APP_ENTITY_GET_ACCOUNT_EVENT_TABLE,
+    SQL_FACADE_GET_ACCOUNT_EVENT_TABLE,
     return_value="db.schema.non_existent_event_table",
 )
 @mock.patch(SQL_EXECUTOR_EXECUTE)
@@ -1846,7 +1796,7 @@ def test_get_events_event_table_dne_or_unauthorized(
 
 
 @mock.patch(
-    APP_ENTITY_GET_ACCOUNT_EVENT_TABLE,
+    SQL_FACADE_GET_ACCOUNT_EVENT_TABLE,
     return_value="db.schema.event_table",
 )
 @mock.patch(SQL_EXECUTOR_EXECUTE)

--- a/tests/nativeapp/test_sf_sql_facade.py
+++ b/tests/nativeapp/test_sf_sql_facade.py
@@ -28,7 +28,7 @@ from snowflake.cli.api.errno import (
     DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED,
     NO_WAREHOUSE_SELECTED_IN_SESSION,
 )
-from snowflake.connector import DatabaseError, Error
+from snowflake.connector import DatabaseError, DictCursor, Error
 from snowflake.connector.errors import (
     InternalServerError,
     ProgrammingError,
@@ -856,3 +856,40 @@ def test_use_db_bubbles_errors(
             pass
 
     assert error_message in str(err)
+
+
+@mock.patch(SQL_EXECUTOR_EXECUTE)
+def test_account_event_table(mock_execute_query, mock_cursor):
+    event_table = "db.schema.event_table"
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([dict(key="EVENT_TABLE", value=event_table)], []),
+                mock.call(
+                    "show parameters like 'event_table' in account",
+                    cursor_class=DictCursor,
+                ),
+            ),
+        ]
+    )
+    mock_execute_query.side_effect = side_effects
+
+    assert sql_facade.get_account_event_table() == event_table
+
+
+@mock.patch(SQL_EXECUTOR_EXECUTE)
+def test_account_event_table_not_set_up(mock_execute_query, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([], []),
+                mock.call(
+                    "show parameters like 'event_table' in account",
+                    cursor_class=DictCursor,
+                ),
+            ),
+        ]
+    )
+    mock_execute_query.side_effect = side_effects
+
+    assert sql_facade.get_account_event_table() == ""

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -40,7 +40,7 @@ APP_ENTITY_DROP_GENERIC_OBJECT = f"{APP_ENTITY_MODULE}.drop_generic_object"
 APP_ENTITY_GET_OBJECTS_OWNED_BY_APPLICATION = (
     f"{APP_ENTITY}.get_objects_owned_by_application"
 )
-APP_ENTITY_GET_ACCOUNT_EVENT_TABLE = f"{APP_ENTITY}.get_account_event_table"
+APP_ENTITY_GET_ACCOUNT_EVENT_TABLE = f"{APP_ENTITY_MODULE}._get_account_event_table"
 
 APP_PACKAGE_ENTITY = "snowflake.cli._plugins.nativeapp.entities.application_package.ApplicationPackageEntity"
 APP_PACKAGE_ENTITY_DEPLOY = f"{APP_PACKAGE_ENTITY}._deploy"

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -40,7 +40,6 @@ APP_ENTITY_DROP_GENERIC_OBJECT = f"{APP_ENTITY_MODULE}.drop_generic_object"
 APP_ENTITY_GET_OBJECTS_OWNED_BY_APPLICATION = (
     f"{APP_ENTITY}.get_objects_owned_by_application"
 )
-APP_ENTITY_GET_ACCOUNT_EVENT_TABLE = f"{APP_ENTITY_MODULE}._get_account_event_table"
 
 APP_PACKAGE_ENTITY = "snowflake.cli._plugins.nativeapp.entities.application_package.ApplicationPackageEntity"
 APP_PACKAGE_ENTITY_DEPLOY = f"{APP_PACKAGE_ENTITY}._deploy"
@@ -62,6 +61,10 @@ APP_PACKAGE_ENTITY_IS_DISTRIBUTION_SAME = (
 
 SQL_EXECUTOR_EXECUTE = f"{ENTITIES_COMMON_MODULE}.SqlExecutor._execute_query"
 SQL_EXECUTOR_EXECUTE_QUERIES = f"{ENTITIES_COMMON_MODULE}.SqlExecutor._execute_queries"
+
+SQL_FACADE_MODULE = "snowflake.cli._plugins.nativeapp.sf_facade"
+SQL_FACADE = f"{SQL_FACADE_MODULE}.SnowflakeSQLFacade"
+SQL_FACADE_GET_ACCOUNT_EVENT_TABLE = f"{SQL_FACADE}.get_account_event_table"
 
 mock_snowflake_yml_file = dedent(
     """\


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Moves `application_objects_to_str()` out from the `ApplicationEntity` class to be a module-level function and `get_account_event_table()` to the SQL facade since they're not part of the public API of the entity
