### PR TITLE
Fix wrong error messaging in snow app events

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -48,7 +48,10 @@ from snowflake.cli.api.commands.decorators import (
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.entities.common import EntityActions
-from snowflake.cli.api.exceptions import IncompatibleParametersError
+from snowflake.cli.api.exceptions import (
+    IncompatibleParametersError,
+    UnmetParametersError,
+)
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.output.types import (
     CommandResult,
@@ -452,7 +455,7 @@ def app_events(
     if (consumer_org and not consumer_account) or (
         consumer_account and not consumer_org
     ):
-        raise IncompatibleParametersError(["--consumer-org", "--consumer-account"])
+        raise UnmetParametersError(["--consumer-org", "--consumer-account"])
 
     if follow:
         if until:

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -190,6 +190,15 @@ class IncompatibleParametersError(UsageError):
         )
 
 
+class UnmetParametersError(UsageError):
+    def __init__(self, options: list[str]):
+        options_with_quotes = [f"'{option}'" for option in options]
+        comma_separated_options = ", ".join(options_with_quotes[:-1])
+        super().__init__(
+            f"Parameters {comma_separated_options} and {options_with_quotes[-1]} must be used simultaneously."
+        )
+
+
 class NoWarehouseSelectedInSessionError(ClickException):
     def __init__(self, msg: str):
         super().__init__(

--- a/tests_integration/nativeapp/test_events.py
+++ b/tests_integration/nativeapp/test_events.py
@@ -75,7 +75,7 @@ def test_app_events_paired_options(
         result = runner.invoke_with_connection(["app", "events", *command])
         assert_that_result_is_usage_error(
             result,
-            f"Parameters '{flag_names[0]}' and '{flag_names[1]}' are incompatible and cannot be used simultaneously.",
+            f"Parameters '{flag_names[0]}' and '{flag_names[1]}' must be used simultaneously.",
         )
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
The `--consumer-org` and `--consumer-account` flags must be used together, the error message was saying that they can't be used together.
