### PR TITLE
Create shortcut properties for entity model fields

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -119,24 +119,24 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
     """
 
     @property
-    def project_root(self):
+    def project_root(self) -> Path:
         return self._workspace_ctx.project_root
 
     @property
-    def package_entity_id(self):
+    def package_entity_id(self) -> str:
         return self._entity_model.from_.target
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._entity_model.fqn.name
 
     @property
-    def role(self):
+    def role(self) -> str:
         model = self._entity_model
         return (model.meta and model.meta.role) or self._workspace_ctx.default_role
 
     @property
-    def warehouse(self):
+    def warehouse(self) -> str:
         model = self._entity_model
         return (
             model.meta and model.meta.warehouse and to_identifier(model.meta.warehouse)

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -64,6 +64,7 @@ from snowflake.cli.api.metrics import CLICounterField
 from snowflake.cli.api.project.schemas.entities.common import (
     EntityModelBase,
     Identifier,
+    PostDeployHook,
     TargetField,
 )
 from snowflake.cli.api.project.schemas.updatable_model import DiscriminatorField
@@ -143,7 +144,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         ) or to_identifier(self._workspace_ctx.default_warehouse)
 
     @property
-    def post_deploy_hooks(self):
+    def post_deploy_hooks(self) -> list[PostDeployHook] | None:
         model = self._entity_model
         return model.meta and model.meta.post_deploy
 

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -118,6 +118,35 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
     A Native App application object, created from an application package.
     """
 
+    @property
+    def project_root(self):
+        return self._workspace_ctx.project_root
+
+    @property
+    def package_entity_id(self):
+        return self._entity_model.from_.target
+
+    @property
+    def name(self):
+        return self._entity_model.fqn.name
+
+    @property
+    def role(self):
+        model = self._entity_model
+        return (model.meta and model.meta.role) or self._workspace_ctx.default_role
+
+    @property
+    def warehouse(self):
+        model = self._entity_model
+        return (
+            model.meta and model.meta.warehouse and to_identifier(model.meta.warehouse)
+        ) or to_identifier(self._workspace_ctx.default_warehouse)
+
+    @property
+    def post_deploy_hooks(self):
+        model = self._entity_model
+        return model.meta and model.meta.post_deploy
+
     def action_deploy(
         self,
         action_ctx: ActionContext,
@@ -138,34 +167,14 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         Create or upgrade the application object using the given strategy
         (unversioned dev, versioned dev, or same-account release directive).
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        app_name = model.fqn.identifier
-        if model.meta:
-            app_role = model.meta.role or workspace_ctx.default_role
-        else:
-            app_role = workspace_ctx.default_role
-
         package_entity: ApplicationPackageEntity = action_ctx.get_entity(
-            model.from_.target
+            self.package_entity_id
         )
-        package_model: ApplicationPackageEntityModel = (
-            package_entity._entity_model  # noqa: SLF001
-        )
-        package_name = package_model.fqn.identifier
-        if package_model.meta and package_model.meta.role:
-            package_role = package_model.meta.role
-        else:
-            package_role = workspace_ctx.default_role
+        stage_fqn = stage_fqn or package_entity.stage_fqn
 
-        if not stage_fqn:
-            stage_fqn = f"{package_name}.{package_model.stage}"
-
-        is_interactive = False
         if force:
             policy = AllowAlwaysPolicy()
         elif interactive:
-            is_interactive = True
             policy = AskAlwaysPolicy()
         else:
             policy = DenyAlwaysPolicy()
@@ -185,14 +194,14 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         def drop_application_before_upgrade(cascade: bool = False):
             self.drop_application_before_upgrade(
                 policy=policy,
-                interactive=is_interactive,
+                interactive=interactive,
                 cascade=cascade,
             )
 
         # same-account release directive
         if from_release_directive:
             self.create_or_upgrade_app(
-                package_model=package_model,
+                package=package_entity,
                 stage_fqn=stage_fqn,
                 install_method=SameAccountInstallMethod.release_directive(),
                 drop_application_before_upgrade=drop_application_before_upgrade,
@@ -205,15 +214,15 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                 version_exists = package_entity.get_existing_version_info(version)
                 if not version_exists:
                     raise UsageError(
-                        f"Application package {package_name} does not have any version {version} defined. Use 'snow app version create' to define a version in the application package first."
+                        f"Application package {package_entity.name} does not have any version {version} defined. Use 'snow app version create' to define a version in the application package first."
                     )
             except ApplicationPackageDoesNotExistError as app_err:
                 raise UsageError(
-                    f"Application package {package_name} does not exist. Use 'snow app version create' to first create an application package and then define a version in it."
+                    f"Application package {package_entity.name} does not exist. Use 'snow app version create' to first create an application package and then define a version in it."
                 )
 
             self.create_or_upgrade_app(
-                package_model=package_model,
+                package=package_entity,
                 stage_fqn=stage_fqn,
                 install_method=SameAccountInstallMethod.versioned_dev(version, patch),
                 drop_application_before_upgrade=drop_application_before_upgrade,
@@ -223,7 +232,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         # unversioned dev
         deploy_package()
         self.create_or_upgrade_app(
-            package_model=package_model,
+            package=package_entity,
             stage_fqn=stage_fqn,
             install_method=SameAccountInstallMethod.unversioned_dev(),
             drop_application_before_upgrade=drop_application_before_upgrade,
@@ -241,14 +250,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         """
         Attempts to drop the application object if all validations and user prompts allow so.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        app_name = model.fqn.identifier
-        if model.meta and model.meta.role:
-            app_role = model.meta.role
-        else:
-            app_role = workspace_ctx.default_role
+        console = self._workspace_ctx.console
 
         needs_confirm = True
 
@@ -256,7 +258,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         show_obj_row = self.get_existing_app_info()
         if show_obj_row is None:
             console.warning(
-                f"Role {app_role} does not own any application object with the name {app_name}, or the application object does not exist."
+                f"Role {self.role} does not own any application object with the name {self.name}, or the application object does not exist."
             )
             return
 
@@ -268,9 +270,9 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
             should_drop_object = typer.confirm(
                 dedent(
                     f"""\
-                        Application object {app_name} was not created by Snowflake CLI.
+                        Application object {self.name} was not created by Snowflake CLI.
                         Application object details:
-                        Name: {app_name}
+                        Name: {self.name}
                         Created on: {show_obj_row["created_on"]}
                         Source: {show_obj_row["source"]}
                         Owner: {show_obj_row[OWNER_COL]}
@@ -282,7 +284,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                 )
             )
             if not should_drop_object:
-                console.message(f"Did not drop application object {app_name}.")
+                console.message(f"Did not drop application object {self.name}.")
                 # The user desires to keep the app, therefore we can't proceed since it would
                 # leave behind an orphan app when we get to dropping the package
                 raise typer.Abort()
@@ -299,7 +301,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
             if application_objects := self.get_objects_owned_by_application():
                 has_objects_to_drop = True
                 message_prefix = (
-                    f"The following objects are owned by application {app_name}"
+                    f"The following objects are owned by application {self.name}"
                 )
                 cascade_true_message = f"{message_prefix} and will be dropped:"
                 cascade_false_message = f"{message_prefix} and will NOT be dropped:"
@@ -309,9 +311,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
             if e.errno != APPLICATION_NO_LONGER_AVAILABLE:
                 raise
             application_objects = []
-            message_prefix = (
-                f"Could not determine which objects are owned by application {app_name}"
-            )
+            message_prefix = f"Could not determine which objects are owned by application {self.name}"
             has_objects_to_drop = True  # potentially, but we don't know what they are
             cascade_true_message = (
                 f"{message_prefix}, an unknown number of objects will be dropped."
@@ -366,8 +366,8 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         drop_generic_object(
             console=console,
             object_type="application",
-            object_name=app_name,
-            role=app_role,
+            object_name=self.name,
+            role=self.role,
             cascade=cascade,
         )
 
@@ -388,16 +388,12 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         *args,
         **kwargs,
     ):
-        model = self._entity_model
         package_entity: ApplicationPackageEntity = action_ctx.get_entity(
-            model.from_.target
-        )
-        package_model: ApplicationPackageEntityModel = (
-            package_entity._entity_model  # noqa: SLF001
+            self.package_entity_id
         )
         if follow:
             return self.stream_events(
-                package_name=package_model.fqn.identifier,
+                package_name=package_entity.name,
                 interval_seconds=interval_seconds,
                 since=since,
                 record_types=record_types,
@@ -409,7 +405,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
             )
         else:
             return self.get_events(
-                package_name=package_model.fqn.identifier,
+                package_name=package_entity.name,
                 since=since,
                 until=until,
                 record_types=record_types,
@@ -425,56 +421,32 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         """
         Returns all application objects owned by this application.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        app_name = model.fqn.identifier
-        app_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(app_role):
+        with sql_executor.use_role(self.role):
             results = sql_executor.execute_query(
-                f"show objects owned by application {app_name}"
+                f"show objects owned by application {self.name}"
             ).fetchall()
             return [{"name": row[1], "type": row[2]} for row in results]
 
     def create_or_upgrade_app(
         self,
-        package_model: ApplicationPackageEntityModel,
+        package: ApplicationPackageEntity,
         stage_fqn: str,
         install_method: SameAccountInstallMethod,
         drop_application_before_upgrade: Optional[Callable] = None,
     ):
         model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        project_root = workspace_ctx.project_root
-
-        app_name = model.fqn.identifier
+        console = self._workspace_ctx.console
         debug_mode = model.debug
-        if model.meta:
-            app_role = model.meta.role or workspace_ctx.default_role
-            app_warehouse = model.meta.warehouse or workspace_ctx.default_warehouse
-            post_deploy_hooks = model.meta.post_deploy
-        else:
-            app_role = workspace_ctx.default_role
-            app_warehouse = workspace_ctx.default_warehouse
-            post_deploy_hooks = None
 
-        package_name = package_model.fqn.identifier
-        if package_model.meta and package_model.meta.role:
-            package_role = package_model.meta.role
-        else:
-            package_role = workspace_ctx.default_role
-
-        if not stage_fqn:
-            stage_fqn = f"{package_name}.{package_model.stage}"
+        stage_fqn = stage_fqn or package.stage_fqn
         stage_schema = extract_schema(stage_fqn)
 
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(app_role):
+        with sql_executor.use_role(self.role):
 
             # 1. Need to use a warehouse to create an application object
-            with sql_executor.use_warehouse(app_warehouse):
+            with sql_executor.use_warehouse(self.warehouse):
 
                 # 2. Check for an existing application by the same name
                 show_app_row = self.get_existing_app_info()
@@ -483,19 +455,19 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                 if show_app_row:
 
                     install_method.ensure_app_usable(
-                        app_name=app_name,
-                        app_role=app_role,
+                        app_name=self.name,
+                        app_role=self.role,
                         show_app_row=show_app_row,
                     )
 
                     # If all the above checks are in order, proceed to upgrade
                     try:
                         console.step(
-                            f"Upgrading existing application object {app_name}."
+                            f"Upgrading existing application object {self.name}."
                         )
                         using_clause = install_method.using_clause(stage_fqn)
                         upgrade_cursor = sql_executor.execute_query(
-                            f"alter application {app_name} upgrade {using_clause}",
+                            f"alter application {self.name} upgrade {using_clause}",
                         )
                         print_messages(console, upgrade_cursor)
 
@@ -503,7 +475,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                             # if debug_mode is present (controlled), ensure it is up-to-date
                             if debug_mode is not None:
                                 sql_executor.execute_query(
-                                    f"alter application {app_name} set debug_mode = {debug_mode}"
+                                    f"alter application {self.name} set debug_mode = {debug_mode}"
                                 )
 
                         # hooks always executed after a create or upgrade
@@ -522,18 +494,18 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                                 raise NotImplementedError
 
                 # 4. With no (more) existing application objects, create an application object using the release directives
-                console.step(f"Creating new application object {app_name} in account.")
+                console.step(f"Creating new application object {self.name} in account.")
 
-                if app_role != package_role:
-                    with sql_executor.use_role(package_role):
+                if self.role != package.role:
+                    with sql_executor.use_role(package.role):
                         sql_executor.execute_query(
-                            f"grant install, develop on application package {package_name} to role {app_role}"
+                            f"grant install, develop on application package {package.name} to role {self.role}"
                         )
                         sql_executor.execute_query(
-                            f"grant usage on schema {package_name}.{stage_schema} to role {app_role}"
+                            f"grant usage on schema {package.name}.{stage_schema} to role {self.role}"
                         )
                         sql_executor.execute_query(
-                            f"grant read on stage {stage_fqn} to role {app_role}"
+                            f"grant read on stage {stage_fqn} to role {self.role}"
                         )
 
                 try:
@@ -550,8 +522,8 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                     create_cursor = sql_executor.execute_query(
                         dedent(
                             f"""\
-                        create application {app_name}
-                            from application package {package_name} {using_clause} {debug_mode_clause}
+                        create application {self.name}
+                            from application package {package.name} {using_clause} {debug_mode_clause}
                             comment = {SPECIAL_COMMENT}
                         """
                         ),
@@ -565,37 +537,26 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                     generic_sql_error_handler(err)
 
     def execute_post_deploy_hooks(self):
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        project_root = workspace_ctx.project_root
-        app_name = model.fqn.identifier
-        post_deploy_hooks = model.meta and model.meta.post_deploy
+        console = self._workspace_ctx.console
 
         get_cli_context().metrics.set_counter_default(
             CLICounterField.POST_DEPLOY_SCRIPTS, 0
         )
 
-        if post_deploy_hooks:
+        if self.post_deploy_hooks:
             with self.use_application_warehouse():
                 execute_post_deploy_hooks(
                     console=console,
-                    project_root=project_root,
-                    post_deploy_hooks=post_deploy_hooks,
+                    project_root=self.project_root,
+                    post_deploy_hooks=self.post_deploy_hooks,
                     deployed_object_type="application",
-                    database_name=app_name,
+                    database_name=self.name,
                 )
 
     @contextmanager
     def use_application_warehouse(self):
-        model = self._entity_model
-        ctx = self._workspace_ctx
-        app_warehouse = (
-            model.meta and model.meta.warehouse and to_identifier(model.meta.warehouse)
-        ) or to_identifier(ctx.default_warehouse)
-
-        if app_warehouse:
-            with get_sql_executor().use_warehouse(app_warehouse):
+        if self.warehouse:
+            with get_sql_executor().use_warehouse(self.warehouse):
                 yield
         else:
             raise ClickException(
@@ -612,13 +573,10 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         Check for an existing application object by the same name as in project definition, in account.
         It executes a 'show applications like' query and returns the result as single row, if one exists.
         """
-        model = self._entity_model
-        ctx = self._workspace_ctx
-        role = (model.meta and model.meta.role) or ctx.default_role
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(role):
+        with sql_executor.use_role(self.role):
             return sql_executor.show_specific_object(
-                "applications", model.fqn.name, name_col=NAME_COL
+                "applications", self.name, name_col=NAME_COL
             )
 
     def drop_application_before_upgrade(
@@ -627,9 +585,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         interactive: bool,
         cascade: bool = False,
     ):
-        model = self._entity_model
         console = self._workspace_ctx.console
-        app_name = model.fqn.identifier
 
         if cascade:
             try:
@@ -638,7 +594,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                         application_objects
                     )
                     console.message(
-                        f"The following objects are owned by application {app_name} and need to be dropped:\n{application_objects_str}"
+                        f"The following objects are owned by application {self.name} and need to be dropped:\n{application_objects_str}"
                     )
             except ProgrammingError as err:
                 if err.errno != APPLICATION_NO_LONGER_AVAILABLE:
@@ -661,10 +617,10 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
                 raise typer.Exit(1)
         try:
             cascade_msg = " (cascade)" if cascade else ""
-            console.step(f"Dropping application object {app_name}{cascade_msg}.")
+            console.step(f"Dropping application object {self.name}{cascade_msg}.")
             cascade_sql = " cascade" if cascade else ""
             sql_executor = get_sql_executor()
-            sql_executor.execute_query(f"drop application {app_name}{cascade_sql}")
+            sql_executor.execute_query(f"drop application {self.name}{cascade_sql}")
         except ProgrammingError as err:
             if err.errno == APPLICATION_OWNS_EXTERNAL_OBJECTS and not cascade:
                 # We need to cascade the deletion, let's try again (only if we didn't try with cascade already)
@@ -689,9 +645,6 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
         first: int = -1,
         last: int = -1,
     ):
-        model = self._entity_model
-        app_name = model.fqn.identifier
-
         record_types = record_types or []
         scopes = scopes or []
 
@@ -703,7 +656,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
             raise NoEventTableForAccount()
 
         # resource_attributes uses the unquoted/uppercase app and package name
-        app_name = unquote_identifier(app_name)
+        app_name = unquote_identifier(self.name)
         package_name = unquote_identifier(package_name)
         org_name = unquote_identifier(consumer_org)
         account_name = unquote_identifier(consumer_account)
@@ -833,7 +786,7 @@ class ApplicationEntity(EntityBase[ApplicationEntityModel]):
 
     def get_snowsight_url(self) -> str:
         """Returns the URL that can be used to visit this app via Snowsight."""
-        name = identifier_for_url(self._entity_model.fqn.name)
+        name = identifier_for_url(self.name)
         with self.use_application_warehouse():
             sql_executor = get_sql_executor()
             return make_snowsight_url(

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -147,6 +147,51 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
     A Native App application package.
     """
 
+    @property
+    def project_root(self):
+        return self._workspace_ctx.project_root
+
+    @property
+    def deploy_root(self):
+        return self.project_root / self._entity_model.deploy_root
+
+    @property
+    def bundle_root(self):
+        return self.project_root / self._entity_model.bundle_root
+
+    @property
+    def generated_root(self):
+        return self.deploy_root / self._entity_model.generated_root
+
+    @property
+    def name(self):
+        return self._entity_model.fqn.name
+
+    @property
+    def role(self):
+        model = self._entity_model
+        return (model.meta and model.meta.role) or self._workspace_ctx.default_role
+
+    @property
+    def warehouse(self):
+        model = self._entity_model
+        return (
+            model.meta and model.meta.warehouse and to_identifier(model.meta.warehouse)
+        ) or to_identifier(self._workspace_ctx.default_warehouse)
+
+    @property
+    def stage_fqn(self):
+        return f"{self.name}.{self._entity_model.stage}"
+
+    @property
+    def scratch_stage_fqn(self):
+        return f"{self.name}.{self._entity_model.scratch_stage}"
+
+    @property
+    def post_deploy_hooks(self):
+        model = self._entity_model
+        return model.meta and model.meta.post_deploy
+
     def action_bundle(self, action_ctx: ActionContext, *args, **kwargs):
         return self._bundle()
 
@@ -163,7 +208,6 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         *args,
         **kwargs,
     ):
-        model = self._entity_model
         return self._deploy(
             bundle_map=None,
             prune=prune,
@@ -171,21 +215,13 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             paths=paths,
             print_diff=True,
             validate=validate,
-            stage_fqn=stage_fqn or f"{model.fqn.identifier}.{model.stage}",
+            stage_fqn=stage_fqn or self.stage_fqn,
             interactive=interactive,
             force=force,
         )
 
     def action_drop(self, action_ctx: ActionContext, force_drop: bool, *args, **kwargs):
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        package_name = model.fqn.identifier
-        if model.meta and model.meta.role:
-            package_role = model.meta.role
-        else:
-            package_role = workspace_ctx.default_role
-
+        console = self._workspace_ctx.console
         sql_executor = get_sql_executor()
         needs_confirm = True
 
@@ -193,13 +229,13 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         show_obj_row = self.get_existing_app_pkg_info()
         if show_obj_row is None:
             console.warning(
-                f"Role {package_role} does not own any application package with the name {package_name}, or the application package does not exist."
+                f"Role {self.role} does not own any application package with the name {self.name}, or the application package does not exist."
             )
             return
 
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             # 2. Check for versions in the application package
-            show_versions_query = f"show versions in application package {package_name}"
+            show_versions_query = f"show versions in application package {self.name}"
             show_versions_cursor = sql_executor.execute_query(
                 show_versions_query, cursor_class=DictCursor
             )
@@ -217,7 +253,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         actual_distribution = self.get_app_pkg_distribution_in_snowflake()
         if not self.verify_project_distribution():
             console.warning(
-                f"Dropping application package {package_name} with distribution '{actual_distribution}'."
+                f"Dropping application package {self.name} with distribution '{actual_distribution}'."
             )
 
         # 4. If distribution is internal, check if created by the Snowflake CLI
@@ -228,12 +264,12 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             else:
                 if needs_confirmation(needs_confirm, force_drop):
                     console.warning(
-                        f"Application package {package_name} was not created by Snowflake CLI."
+                        f"Application package {self.name} was not created by Snowflake CLI."
                     )
         else:
             if needs_confirmation(needs_confirm, force_drop):
                 console.warning(
-                    f"Application package {package_name} in your Snowflake account has distribution property '{EXTERNAL_DISTRIBUTION}' and could be associated with one or more of your listings on Snowflake Marketplace."
+                    f"Application package {self.name} in your Snowflake account has distribution property '{EXTERNAL_DISTRIBUTION}' and could be associated with one or more of your listings on Snowflake Marketplace."
                 )
 
         if needs_confirmation(needs_confirm, force_drop):
@@ -241,7 +277,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 dedent(
                     f"""\
                         Application package details:
-                        Name: {package_name}
+                        Name: {self.name}
                         Created on: {show_obj_row["created_on"]}
                         Distribution: {actual_distribution}
                         Owner: {show_obj_row[OWNER_COL]}
@@ -251,15 +287,15 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 )
             )
             if not should_drop_object:
-                console.message(f"Did not drop application package {package_name}.")
+                console.message(f"Did not drop application package {self.name}.")
                 return  # The user desires to keep the application package, therefore exit gracefully
 
         # All validations have passed, drop object
         drop_generic_object(
             console=console,
             object_type="application package",
-            object_name=package_name,
-            role=package_role,
+            object_name=(self.name),
+            role=(self.role),
         )
 
     def action_validate(
@@ -285,14 +321,9 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         Get all existing versions, if defined, for an application package.
         It executes a 'show versions in application package' query and returns all the results.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
-            show_obj_query = f"show versions in application package {package_name}"
+        with sql_executor.use_role(self.role):
+            show_obj_query = f"show versions in application package {self.name}"
             show_obj_cursor = sql_executor.execute_query(show_obj_query)
 
             if show_obj_cursor.rowcount is None:
@@ -314,13 +345,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         """
         Perform bundle, application package creation, stage upload, version and/or patch to an application package.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-
-        console = workspace_ctx.console
-        deploy_root = workspace_ctx.project_root / model.deploy_root
-        stage_fqn = f"{package_name}.{model.stage}"
+        console = self._workspace_ctx.console
 
         if force:
             policy = AllowAlwaysPolicy()
@@ -347,7 +372,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 )
             )
             bundle_map = self._bundle()
-            version, patch = find_version_info_in_manifest_file(deploy_root)
+            version, patch = find_version_info_in_manifest_file(self.deploy_root)
             if not version:
                 raise ClickException(
                     "Manifest.yml file does not contain a value for the version field."
@@ -359,12 +384,12 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 if not self.get_existing_version_info(version):
                     raise BadOptionUsage(
                         option_name="patch",
-                        message=f"Cannot create a custom patch when version {version} is not defined in the application package {package_name}. Try again without using --patch.",
+                        message=f"Cannot create a custom patch when version {version} is not defined in the application package {self.name}. Try again without using --patch.",
                     )
             except ApplicationPackageDoesNotExistError as app_err:
                 raise BadOptionUsage(
                     option_name="patch",
-                    message=f"Cannot create a custom patch when application package {package_name} does not exist. Try again without using --patch.",
+                    message=f"Cannot create a custom patch when application package {self.name} does not exist. Try again without using --patch.",
                 )
 
         if git_policy.should_proceed():
@@ -377,7 +402,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             paths=[],
             print_diff=True,
             validate=True,
-            stage_fqn=stage_fqn,
+            stage_fqn=self.stage_fqn,
             interactive=interactive,
             force=force,
         )
@@ -394,14 +419,14 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             console.warning(
                 dedent(
                     f"""\
-                    Version {version} already defined in application package {package_name} and in release directive(s): {release_directive_names}.
+                    Version {version} already defined in application package {self.name} and in release directive(s): {release_directive_names}.
                     """
                 )
             )
 
             user_prompt = (
                 f"Are you sure you want to create a new patch for version {version} in application "
-                f"package {package_name}? Once added, this operation cannot be undone."
+                f"package {self.name}? Once added, this operation cannot be undone."
             )
             if not policy.should_proceed(user_prompt):
                 if interactive:
@@ -433,13 +458,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         """
         Drops a version defined in an application package. If --force is provided, then no user prompts will be executed.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-
-        console = workspace_ctx.console
-        deploy_root = workspace_ctx.project_root / model.deploy_root
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
+        console = self._workspace_ctx.console
 
         if force:
             interactive = False
@@ -450,7 +469,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         # 1. Check for existing an existing application package
         show_obj_row = self.get_existing_app_pkg_info()
         if not show_obj_row:
-            raise ApplicationPackageDoesNotExistError(package_name)
+            raise ApplicationPackageDoesNotExistError(self.name)
 
         # 2. Check distribution of the existing application package
         actual_distribution = self.get_app_pkg_distribution_in_snowflake()
@@ -459,7 +478,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         ):
             console.warning(
                 f"Continuing to execute version drop on application package "
-                f"{package_name} with distribution '{actual_distribution}'."
+                f"{self.name} with distribution '{actual_distribution}'."
             )
 
         # 3. If the user did not pass in a version string, determine from manifest.yml
@@ -473,7 +492,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 )
             )
             self._bundle()
-            version, _ = find_version_info_in_manifest_file(deploy_root)
+            version, _ = find_version_info_in_manifest_file(self.deploy_root)
             if not version:
                 raise ClickException(
                     "Manifest.yml file does not contain a value for the version field."
@@ -483,13 +502,13 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         version = to_identifier(version)
 
         console.step(
-            f"About to drop version {version} in application package {package_name}."
+            f"About to drop version {version} in application package {self.name}."
         )
 
         # If user did not provide --force, ask for confirmation
         user_prompt = (
             f"Are you sure you want to drop version {version} "
-            f"in application package {package_name}? "
+            f"in application package {self.name}? "
             f"Once dropped, this operation cannot be undone."
         )
         if not policy.should_proceed(user_prompt):
@@ -504,37 +523,28 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
         # Drop the version
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             try:
                 sql_executor.execute_query(
-                    f"alter application package {package_name} drop version {version}"
+                    f"alter application package {self.name} drop version {version}"
                 )
             except ProgrammingError as err:
                 raise err  # e.g. version is referenced in a release directive(s)
 
         console.message(
-            f"Version {version} in application package {package_name} dropped successfully."
+            f"Version {version} in application package {self.name} dropped successfully."
         )
 
     def _bundle(self):
         model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-
-        project_root = workspace_ctx.project_root
-        deploy_root = workspace_ctx.project_root / model.deploy_root
-        bundle_root = workspace_ctx.project_root / model.bundle_root
-        generated_root = (
-            workspace_ctx.project_root / model.deploy_root / model.generated_root
-        )
-
-        bundle_map = build_bundle(project_root, deploy_root, model.artifacts)
+        bundle_map = build_bundle(self.project_root, self.deploy_root, model.artifacts)
         bundle_context = BundleContext(
-            package_name=model.fqn.identifier,
+            package_name=self.name,
             artifacts=model.artifacts,
-            project_root=project_root,
-            bundle_root=bundle_root,
-            deploy_root=deploy_root,
-            generated_root=generated_root,
+            project_root=self.project_root,
+            bundle_root=self.bundle_root,
+            deploy_root=self.deploy_root,
+            generated_root=self.generated_root,
         )
         compiler = NativeAppCompiler(bundle_context)
         compiler.compile_artifacts()
@@ -555,7 +565,6 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
     ) -> DiffResult:
         model = self._entity_model
         workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
         if force:
             policy = AllowAlwaysPolicy()
         elif interactive:
@@ -564,9 +573,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             policy = DenyAlwaysPolicy()
 
         console = workspace_ctx.console
-        deploy_root = workspace_ctx.project_root / model.deploy_root
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-        stage_fqn = stage_fqn or f"{package_name}.{model.stage}"
+        stage_fqn = stage_fqn or self.stage_fqn
 
         # 1. Create a bundle if one wasn't passed in
         bundle_map = bundle_map or self._bundle()
@@ -579,16 +586,16 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             if not policy.should_proceed("Proceed with using this package?"):
                 raise typer.Abort() from e
 
-        with get_sql_executor().use_role(package_role):
+        with get_sql_executor().use_role(self.role):
             # 3. Upload files from deploy root local folder to the above stage
             stage_schema = extract_schema(stage_fqn)
             diff = sync_deploy_root_with_stage(
                 console=console,
-                deploy_root=deploy_root,
-                package_name=package_name,
+                deploy_root=self.deploy_root,
+                package_name=self.name,
                 stage_schema=stage_schema,
                 bundle_map=bundle_map,
-                role=package_role,
+                role=self.role,
                 prune=prune,
                 recursive=recursive,
                 stage_fqn=stage_fqn,
@@ -615,15 +622,10 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         the latest patch in the version as a single row, if one exists. Otherwise,
         returns None.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             try:
-                query = f"show versions like {identifier_to_show_like_pattern(version)} in application package {package_name}"
+                query = f"show versions like {identifier_to_show_like_pattern(version)} in application package {self.name}"
                 cursor = sql_executor.execute_query(query, cursor_class=DictCursor)
 
                 if cursor.rowcount is None:
@@ -640,7 +642,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
             except ProgrammingError as err:
                 if err.msg.__contains__("does not exist or not authorized"):
-                    raise ApplicationPackageDoesNotExistError(package_name)
+                    raise ApplicationPackageDoesNotExistError(self.name)
                 else:
                     generic_sql_error_handler(err=err)
                     return None
@@ -652,15 +654,10 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         Get all existing release directives, if present, set on the version defined in an application package.
         It executes a 'show release directives in application package' query and returns the filtered results, if they exist.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             show_obj_query = (
-                f"show release directives in application package {package_name}"
+                f"show release directives in application package {self.name}"
             )
             show_obj_cursor = sql_executor.execute_query(
                 show_obj_query, cursor_class=DictCursor
@@ -680,55 +677,45 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         """
         Defines a new version in an existing application package.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-        stage_fqn = f"{package_name}.{model.stage}"
+        console = self._workspace_ctx.console
 
         # Make the version a valid identifier, adding quotes if necessary
         version = to_identifier(version)
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             console.step(
-                f"Defining a new version {version} in application package {package_name}"
+                f"Defining a new version {version} in application package {self.name}"
             )
             add_version_query = dedent(
                 f"""\
-                    alter application package {package_name}
+                    alter application package {self.name}
                         add version {version}
-                        using @{stage_fqn}
+                        using @{self.stage_fqn}
                 """
             )
             sql_executor.execute_query(add_version_query, cursor_class=DictCursor)
             console.message(
-                f"Version {version} created for application package {package_name}."
+                f"Version {version} created for application package {self.name}."
             )
 
     def add_new_patch_to_version(self, version: str, patch: Optional[int] = None):
         """
         Add a new patch, optionally a custom one, to an existing version in an application package.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-        stage_fqn = f"{package_name}.{model.stage}"
+        console = self._workspace_ctx.console
 
         # Make the version a valid identifier, adding quotes if necessary
         version = to_identifier(version)
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             console.step(
-                f"Adding new patch to version {version} defined in application package {package_name}"
+                f"Adding new patch to version {version} defined in application package {self.name}"
             )
             add_version_query = dedent(
                 f"""\
-                    alter application package {package_name}
+                    alter application package {self.name}
                         add patch {patch if patch else ""} for version {version}
-                        using @{stage_fqn}
+                        using @{self.stage_fqn}
                 """
             )
             result_cursor = sql_executor.execute_query(
@@ -738,7 +725,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             show_row = result_cursor.fetchall()[0]
             new_patch = show_row["patch"]
             console.message(
-                f"Patch {new_patch} created for version {version} defined in application package {package_name}."
+                f"Patch {new_patch} created for version {version} defined in application package {self.name}."
             )
 
     def check_index_changes_in_git_repo(
@@ -752,12 +739,10 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         from git import Repo
         from git.exc import InvalidGitRepositoryError
 
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        project_root = workspace_ctx.project_root
+        console = self._workspace_ctx.console
 
         try:
-            repo = Repo(project_root, search_parent_directories=True)
+            repo = Repo(self.project_root, search_parent_directories=True)
             assert repo.git_dir is not None
 
             # Check if the repo has any changes, including untracked files
@@ -790,30 +775,21 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         Check for an existing application package by the same name as in project definition, in account.
         It executes a 'show application packages like' query and returns the result as single row, if one exists.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             return sql_executor.show_specific_object(
-                "application packages", model.fqn.identifier, name_col=NAME_COL
+                "application packages", self.name, name_col=NAME_COL
             )
 
     def get_app_pkg_distribution_in_snowflake(self) -> str:
         """
         Returns the 'distribution' attribute of a 'describe application package' SQL query, in lowercase.
         """
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
+        with sql_executor.use_role(self.role):
             try:
                 desc_cursor = sql_executor.execute_query(
-                    f"describe application package {package_name}"
+                    f"describe application package {self.name}"
                 )
             except ProgrammingError as err:
                 generic_sql_error_handler(err)
@@ -827,7 +803,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         raise ObjectPropertyNotFoundError(
             property_name="distribution",
             object_type="application package",
-            object_name=package_name,
+            object_name=self.name,
         )
 
     def verify_project_distribution(
@@ -851,7 +827,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             workspace_ctx.console.warning(
                 dedent(
                     f"""\
-                    Application package {model.fqn.identifier} in your Snowflake account has distribution property {actual_distribution},
+                    Application package {self.name} in your Snowflake account has distribution property {actual_distribution},
                     which does not match the value specified in project definition file: {project_def_distribution}.
                     """
                 )
@@ -861,14 +837,8 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
     @contextmanager
     def use_package_warehouse(self):
-        model = self._entity_model
-        ctx = self._workspace_ctx
-        package_warehouse = (
-            model.meta and model.meta.warehouse and to_identifier(model.meta.warehouse)
-        ) or to_identifier(ctx.default_warehouse)
-
-        if package_warehouse:
-            with get_sql_executor().use_warehouse(package_warehouse):
+        if self.warehouse:
+            with get_sql_executor().use_warehouse(self.warehouse):
                 yield
         else:
             raise ClickException(
@@ -885,11 +855,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         Creates the application package with our up-to-date stage if none exists.
         """
         model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        package_name = model.fqn.identifier
-        package_role = (model.meta and model.meta.role) or workspace_ctx.default_role
-        package_distribution = model.distribution
+        console = self._workspace_ctx.console
 
         # 1. Check for existing application package
         show_obj_row = self.get_existing_app_pkg_info()
@@ -901,7 +867,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 expected_distribution=actual_distribution
             ):
                 console.warning(
-                    f"Continuing to execute `snow app run` on application package {package_name} with distribution '{actual_distribution}'."
+                    f"Continuing to execute `snow app run` on application package {self.name} with distribution '{actual_distribution}'."
                 )
 
             # 3. If actual_distribution is external, skip comment check
@@ -909,44 +875,39 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 row_comment = show_obj_row[COMMENT_COL]
 
                 if row_comment not in ALLOWED_SPECIAL_COMMENTS:
-                    raise ApplicationPackageAlreadyExistsError(package_name)
+                    raise ApplicationPackageAlreadyExistsError(self.name)
 
             return
 
         # If no application package pre-exists, create an application package, with the specified distribution in the project definition file.
         sql_executor = get_sql_executor()
-        with sql_executor.use_role(package_role):
-            console.step(f"Creating new application package {package_name} in account.")
+        with sql_executor.use_role(self.role):
+            console.step(f"Creating new application package {self.name} in account.")
             sql_executor.execute_query(
                 dedent(
                     f"""\
-                    create application package {package_name}
+                    create application package {self.name}
                         comment = {SPECIAL_COMMENT}
-                        distribution = {package_distribution}
+                        distribution = {model.distribution}
                 """
                 )
             )
 
     def execute_post_deploy_hooks(self):
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        console = workspace_ctx.console
-        project_root = workspace_ctx.project_root
-        package_name = model.fqn.identifier
-        post_deploy_hooks = model.meta and model.meta.post_deploy
+        console = self._workspace_ctx.console
 
         get_cli_context().metrics.set_counter_default(
             CLICounterField.POST_DEPLOY_SCRIPTS, 0
         )
 
-        if post_deploy_hooks:
+        if self.post_deploy_hooks:
             with self.use_package_warehouse():
                 execute_post_deploy_hooks(
                     console=console,
-                    project_root=project_root,
-                    post_deploy_hooks=post_deploy_hooks,
+                    project_root=self.project_root,
+                    post_deploy_hooks=self.post_deploy_hooks,
                     deployed_object_type="application package",
-                    database_name=package_name,
+                    database_name=self.name,
                 )
 
     def validate_setup_script(
@@ -981,14 +942,9 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         self, use_scratch_stage: bool, interactive: bool, force: bool
     ):
         """Call system$validate_native_app_setup() to validate deployed Native App setup script."""
-        model = self._entity_model
-        workspace_ctx = self._workspace_ctx
-        package_name = model.fqn.identifier
-
-        stage_fqn = f"{package_name}.{model.stage}"
-        scratch_stage_fqn = f"{package_name}.{model.scratch_stage}"
+        stage_fqn = self.stage_fqn
         if use_scratch_stage:
-            stage_fqn = scratch_stage_fqn
+            stage_fqn = self.scratch_stage_fqn
             self._deploy(
                 bundle_map=None,
                 prune=True,
@@ -996,7 +952,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 paths=[],
                 print_diff=False,
                 validate=False,
-                stage_fqn=scratch_stage_fqn,
+                stage_fqn=self.scratch_stage_fqn,
                 interactive=interactive,
                 force=force,
                 run_post_deploy_hooks=False,
@@ -1009,7 +965,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             )
         except ProgrammingError as err:
             if err.errno == DOES_NOT_EXIST_OR_NOT_AUTHORIZED:
-                raise ApplicationPackageDoesNotExistError(package_name)
+                raise ApplicationPackageDoesNotExistError(self.name)
             generic_sql_error_handler(err)
         else:
             if not cursor.rowcount:
@@ -1017,11 +973,10 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             return json.loads(cursor.fetchone()[0])
         finally:
             if use_scratch_stage:
-                workspace_ctx.console.step(f"Dropping stage {scratch_stage_fqn}.")
-                package_role = (
-                    model.meta and model.meta.role
-                ) or workspace_ctx.default_role
-                with sql_executor.use_role(package_role):
+                self._workspace_ctx.console.step(
+                    f"Dropping stage {self.scratch_stage_fqn}."
+                )
+                with sql_executor.use_role(self.role):
                     sql_executor.execute_query(
-                        f"drop stage if exists {scratch_stage_fqn}"
+                        f"drop stage if exists {self.scratch_stage_fqn}"
                     )

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -59,6 +59,7 @@ from snowflake.cli.api.metrics import CLICounterField
 from snowflake.cli.api.project.schemas.entities.common import (
     EntityModelBase,
     Identifier,
+    SqlScriptHookType,
 )
 from snowflake.cli.api.project.schemas.updatable_model import (
     DiscriminatorField,
@@ -148,47 +149,47 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
     """
 
     @property
-    def project_root(self):
+    def project_root(self) -> Path:
         return self._workspace_ctx.project_root
 
     @property
-    def deploy_root(self):
+    def deploy_root(self) -> Path:
         return self.project_root / self._entity_model.deploy_root
 
     @property
-    def bundle_root(self):
+    def bundle_root(self) -> Path:
         return self.project_root / self._entity_model.bundle_root
 
     @property
-    def generated_root(self):
+    def generated_root(self) -> Path:
         return self.deploy_root / self._entity_model.generated_root
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._entity_model.fqn.name
 
     @property
-    def role(self):
+    def role(self) -> str:
         model = self._entity_model
         return (model.meta and model.meta.role) or self._workspace_ctx.default_role
 
     @property
-    def warehouse(self):
+    def warehouse(self) -> str:
         model = self._entity_model
         return (
             model.meta and model.meta.warehouse and to_identifier(model.meta.warehouse)
         ) or to_identifier(self._workspace_ctx.default_warehouse)
 
     @property
-    def stage_fqn(self):
+    def stage_fqn(self) -> str:
         return f"{self.name}.{self._entity_model.stage}"
 
     @property
-    def scratch_stage_fqn(self):
+    def scratch_stage_fqn(self) -> str:
         return f"{self.name}.{self._entity_model.scratch_stage}"
 
     @property
-    def post_deploy_hooks(self):
+    def post_deploy_hooks(self) -> list[SqlScriptHookType] | None:
         model = self._entity_model
         return model.meta and model.meta.post_deploy
 

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -59,7 +59,7 @@ from snowflake.cli.api.metrics import CLICounterField
 from snowflake.cli.api.project.schemas.entities.common import (
     EntityModelBase,
     Identifier,
-    SqlScriptHookType,
+    PostDeployHook,
 )
 from snowflake.cli.api.project.schemas.updatable_model import (
     DiscriminatorField,
@@ -189,7 +189,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         return f"{self.name}.{self._entity_model.scratch_stage}"
 
     @property
-    def post_deploy_hooks(self) -> list[SqlScriptHookType] | None:
+    def post_deploy_hooks(self) -> list[PostDeployHook] | None:
         model = self._entity_model
         return model.meta and model.meta.post_deploy
 

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -126,7 +126,7 @@ def test_sync_deploy_root_with_stage(
 
     assert mock_diff_result.has_changes()
     mock_bundle_map = mock.Mock(spec=BundleMap)
-    package_name = pkg_model.fqn.identifier
+    package_name = pkg_model.fqn.name
     stage_fqn = f"{package_name}.{pkg_model.stage}"
     sync_deploy_root_with_stage(
         console=cc,
@@ -201,7 +201,7 @@ def test_sync_deploy_root_with_stage_prune(
     pkg_model: ApplicationPackageEntityModel = dm.project_definition.entities["app_pkg"]
 
     mock_bundle_map = mock.Mock(spec=BundleMap)
-    package_name = pkg_model.fqn.identifier
+    package_name = pkg_model.fqn.name
     stage_fqn = f"{package_name}.{pkg_model.stage}"
     mock_console = mock.MagicMock()
     sync_deploy_root_with_stage(

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -113,6 +113,7 @@ def _create_or_upgrade_app(
         get_default_warehouse=lambda: "mock_warehouse",
     )
     app = ApplicationEntity(app_model, ctx)
+    pkg = ApplicationPackageEntity(pkg_model, ctx)
     stage_fqn = f"{pkg_model.fqn.name}.{pkg_model.stage}"
 
     def drop_application_before_upgrade(cascade: bool = False):
@@ -123,7 +124,7 @@ def _create_or_upgrade_app(
         )
 
     return app.create_or_upgrade_app(
-        package_model=pkg_model,
+        package=pkg,
         stage_fqn=stage_fqn,
         install_method=install_method,
         drop_application_before_upgrade=drop_application_before_upgrade,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adds properties to the native app entities to make usage of model fields a bit simpler and safer (especially the derived ones like paths).

For example, to get the package name, we can call `self.name` instead of `self._entity_model.fqn.name`.
