### PR TITLE
Add `--retain-comments` option to `snow sql`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,7 +19,7 @@
 ## Deprecations
 
 ## New additions
-
+* Added `--retain-comments` option to `snow sql` command to allow passing comments to Snowflake.
 ## Fixes and improvements
 * `snow --info` callback returns information about `SNOWFLAKE_HOME` variable.
 * Removed requirement of existence of any `requirements.txt` file for Python code execution via `snow git execute` command.

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
+import typer
 from snowflake.cli._plugins.sql.manager import SqlManager
 from snowflake.cli.api.commands.decorators import with_project_definition
 from snowflake.cli.api.commands.flags import (
@@ -63,6 +64,11 @@ def execute_sql(
         "String in format of key=value. If provided the SQL content will "
         "be treated as template and rendered using provided data.",
     ),
+    retain_comments: Optional[bool] = typer.Option(
+        False,
+        "--retain-comments",
+        help="Retains comments in queries passed to Snowflake",
+    ),
     **options,
 ) -> CommandResult:
     """
@@ -80,7 +86,9 @@ def execute_sql(
     if data_override:
         data = {v.key: v.value for v in parse_key_value_variables(data_override)}
 
-    single_statement, cursors = SqlManager().execute(query, files, std_in, data=data)
+    single_statement, cursors = SqlManager().execute(
+        query, files, std_in, data=data, retain_comments=retain_comments
+    )
     if single_statement:
         return QueryResult(next(cursors))
     return MultipleResults((QueryResult(c) for c in cursors))

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -8057,18 +8057,21 @@
    client-side.                                                                   
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --query     -q      TEXT  Query to execute.                                  |
-  | --filename  -f      FILE  File to execute.                                   |
-  | --stdin     -i            Read the query from standard input. Use it when    |
-  |                           piping input to this command.                      |
-  | --variable  -D      TEXT  String in format of key=value. If provided the SQL |
-  |                           content will be treated as template and rendered   |
-  |                           using provided data.                               |
-  | --project   -p      TEXT  Path where Snowflake project resides. Defaults to  |
-  |                           current working directory.                         |
-  | --env               TEXT  String in format of key=value. Overrides variables |
-  |                           from env section used for templates.               |
-  | --help      -h            Show this message and exit.                        |
+  | --query            -q      TEXT  Query to execute.                           |
+  | --filename         -f      FILE  File to execute.                            |
+  | --stdin            -i            Read the query from standard input. Use it  |
+  |                                  when piping input to this command.          |
+  | --variable         -D      TEXT  String in format of key=value. If provided  |
+  |                                  the SQL content will be treated as template |
+  |                                  and rendered using provided data.           |
+  | --retain-comments                Retains comments in queries passed to       |
+  |                                  Snowflake                                   |
+  | --project          -p      TEXT  Path where Snowflake project resides.       |
+  |                                  Defaults to current working directory.      |
+  | --env                      TEXT  String in format of key=value. Overrides    |
+  |                                  variables from env section used for         |
+  |                                  templates.                                  |
+  | --help             -h            Show this message and exit.                 |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |

--- a/tests/__snapshots__/test_sql.ambr
+++ b/tests/__snapshots__/test_sql.ambr
@@ -12,18 +12,21 @@
    client-side.                                                                   
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --query     -q      TEXT  Query to execute.                                  |
-  | --filename  -f      FILE  File to execute.                                   |
-  | --stdin     -i            Read the query from standard input. Use it when    |
-  |                           piping input to this command.                      |
-  | --variable  -D      TEXT  String in format of key=value. If provided the SQL |
-  |                           content will be treated as template and rendered   |
-  |                           using provided data.                               |
-  | --project   -p      TEXT  Path where Snowflake project resides. Defaults to  |
-  |                           current working directory.                         |
-  | --env               TEXT  String in format of key=value. Overrides variables |
-  |                           from env section used for templates.               |
-  | --help      -h            Show this message and exit.                        |
+  | --query            -q      TEXT  Query to execute.                           |
+  | --filename         -f      FILE  File to execute.                            |
+  | --stdin            -i            Read the query from standard input. Use it  |
+  |                                  when piping input to this command.          |
+  | --variable         -D      TEXT  String in format of key=value. If provided  |
+  |                                  the SQL content will be treated as template |
+  |                                  and rendered using provided data.           |
+  | --retain-comments                Retains comments in queries passed to       |
+  |                                  Snowflake                                   |
+  | --project          -p      TEXT  Path where Snowflake project resides.       |
+  |                                  Defaults to current working directory.      |
+  | --env                      TEXT  String in format of key=value. Overrides    |
+  |                                  variables from env section used for         |
+  |                                  templates.                                  |
+  | --help             -h            Show this message and exit.                 |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix for #1740 
Adds `--retain-comments` option to `snow sql` command
