### PR TITLE
SNOW-1772200 Convert templates in artifacts when converting PDF from v1 to v2

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -674,14 +674,25 @@ def build_bundle(
     if resolved_root.exists():
         delete(resolved_root)
 
-    bundle_map = BundleMap(project_root=project_root, deploy_root=deploy_root)
-    for artifact in artifacts:
-        bundle_map.add(artifact)
-
+    bundle_map = bundle_artifacts(project_root, deploy_root, artifacts)
     if bundle_map.is_empty():
         raise ArtifactError(
             "No artifacts mapping found in project definition, nothing to do."
         )
+
+    return bundle_map
+
+
+def bundle_artifacts(
+    project_root: Path, deploy_root: Path, artifacts: list[PathMapping]
+):
+    """
+    Internal implementation of build_bundle that assumes
+    that validation is being done by the caller.
+    """
+    bundle_map = BundleMap(project_root=project_root, deploy_root=deploy_root)
+    for artifact in artifacts:
+        bundle_map.add(artifact)
 
     for (absolute_src, absolute_dest) in bundle_map.all_mappings(
         absolute=True, expand_directories=False

--- a/src/snowflake/cli/_plugins/nativeapp/codegen/templates/templates_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/templates/templates_processor.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import jinja2
 from snowflake.cli._plugins.nativeapp.artifacts import BundleMap
@@ -49,7 +49,9 @@ class TemplatesProcessor(ArtifactProcessor):
     Processor class to perform template expansion on all relevant artifacts (specified in the project definition file).
     """
 
-    def expand_templates_in_file(self, src: Path, dest: Path) -> None:
+    def expand_templates_in_file(
+        self, src: Path, dest: Path, template_context: dict[str, Any] | None = None
+    ) -> None:
         """
         Expand templates in the file.
         """
@@ -74,7 +76,7 @@ class TemplatesProcessor(ArtifactProcessor):
                         else get_client_side_jinja_env()
                     )
                     expanded_template = jinja_env.from_string(file.contents).render(
-                        get_cli_context().template_context
+                        template_context or get_cli_context().template_context
                     )
 
                 # For now, we are printing the source file path in the error message

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -490,6 +490,7 @@ def _convert_templates_in_files(
         # and if we're doing a permanent conversion. If we're doing an in-memory conversion,
         # the CLI global template context is already populated with the v1 definition, so
         # we don't want to convert the v1 template references in artifact files
+        metrics.set_counter_default(CLICounterField.TEMPLATES_PROCESSOR, 0)
         if not in_memory and any(
             processor.name == TEMPLATES_PROCESSOR
             for artifact in pkg_model.artifacts

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -491,11 +491,13 @@ def _convert_templates_in_files(
         # the CLI global template context is already populated with the v1 definition, so
         # we don't want to convert the v1 template references in artifact files
         metrics.set_counter_default(CLICounterField.TEMPLATES_PROCESSOR, 0)
-        if not in_memory and any(
-            processor.name == TEMPLATES_PROCESSOR
+        artifacts_to_template = [
+            artifact
             for artifact in pkg_model.artifacts
             for processor in artifact.processors
-        ):
+            if processor.name == TEMPLATES_PROCESSOR
+        ]
+        if not in_memory and artifacts_to_template:
             metrics.set_counter(CLICounterField.TEMPLATES_PROCESSOR, 1)
 
             # Create a temporary directory to hold the expanded templates,
@@ -514,37 +516,35 @@ def _convert_templates_in_files(
                     ),
                 )
                 template_processor = TemplatesProcessor(bundle_ctx)
-                for artifact in na.artifacts:
-                    for processor in artifact.processors:
-                        if processor.name == TEMPLATES_PROCESSOR:
-                            bundle_map = BundleMap(
-                                project_root=project_root, deploy_root=deploy_root
-                            )
-                            bundle_map.add(artifact)
+                for artifact in artifacts_to_template:
+                    bundle_map = BundleMap(
+                        project_root=project_root, deploy_root=deploy_root
+                    )
+                    bundle_map.add(artifact)
 
-                            for src, dest in bundle_map.all_mappings(
-                                absolute=True, expand_directories=False
-                            ):
-                                # Copy the mapping from the source root to the deploy root,
-                                # since the processor expects the artifacts to have
-                                # already been bundled (we can't call build_bundle() since it
-                                # checks that the deploy_root is a child of the project_root,
-                                # which isn't the case here)
-                                symlink_or_copy(src, dest, deploy_root=deploy_root)
+                    for src, dest in bundle_map.all_mappings(
+                        absolute=True, expand_directories=False
+                    ):
+                        # Copy the mapping from the source root to the deploy root,
+                        # since the processor expects the artifacts to have
+                        # already been bundled (we can't call build_bundle() since it
+                        # checks that the deploy_root is a child of the project_root,
+                        # which isn't the case here)
+                        symlink_or_copy(src, dest, deploy_root=deploy_root)
 
-                            for src, dest in bundle_map.all_mappings(
-                                absolute=True, expand_directories=True
-                            ):
-                                if src.is_dir():
-                                    continue
-                                # We call the implementation directly instead of calling process()
-                                # since we need access to the BundleMap to copy files anyways
-                                template_processor.expand_templates_in_file(
-                                    src, dest, replacement_template_context
-                                )
-                                # Copy the expanded file back to its original source location if it was modified
-                                if not dest.is_symlink():
-                                    shutil.copyfile(dest, src)
+                    for src, dest in bundle_map.all_mappings(
+                        absolute=True, expand_directories=True
+                    ):
+                        if src.is_dir():
+                            continue
+                        # We call the implementation directly instead of calling process()
+                        # since we need access to the BundleMap to copy files anyways
+                        template_processor.expand_templates_in_file(
+                            src, dest, replacement_template_context
+                        )
+                        # Copy the expanded file back to its original source location if it was modified
+                        if not dest.is_symlink():
+                            shutil.copyfile(dest, src)
 
         # Convert package script files to post-deploy hooks
         metrics.set_counter_default(CLICounterField.PACKAGE_SCRIPTS, 0)

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -608,7 +608,7 @@ class _EnvFaker:
 
 class _FnFaker:
     def __getitem__(self, item):
-        return lambda *args, **kwargs: _make_template(
+        return lambda *args: _make_template(
             f"fn.{item}({', '.join(repr(a) for a in args)})"
         )
 

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -122,7 +122,7 @@ def convert_project_definition_to_v2(
             project_root, definition_v1.native_app, template_context
         )
         if definition_v1.native_app
-        else {}
+        else ({}, {})
     )
     envs = convert_envs_to_v2(definition_v1)
 
@@ -149,13 +149,14 @@ def convert_project_definition_to_v2(
     # also need to be migrated to point to the v2 entities
     replacement_template_context = deepcopy(template_context) or {}
     deep_merge_dicts(replacement_template_context, native_app_template_context)
-    _convert_templates_in_files(
-        project_root,
-        definition_v1,
-        definition_v2,
-        in_memory,
-        replacement_template_context,
-    )
+    if replacement_template_context:
+        _convert_templates_in_files(
+            project_root,
+            definition_v1,
+            definition_v2,
+            in_memory,
+            replacement_template_context,
+        )
 
     return definition_v2
 

--- a/tests_integration/helpers/test_v1_to_v2.py
+++ b/tests_integration/helpers/test_v1_to_v2.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from snowflake.cli._plugins.nativeapp.codegen.compiler import TEMPLATES_PROCESSOR
+from tests.nativeapp.factories import ProjectV11Factory
+
+
+@pytest.mark.integration
+def test_v1_to_v2_converts_templates_in_files(temp_dir, runner):
+    native_app_name = "my_native_app_project"
+
+    expected_conversions = {
+        # Reference to app field should be converted to v2
+        "<% ctx.native_app.application.name %>": "<% ctx.entities.app.identifier %>",
+        # Reference to nested app field should be converted to v2
+        "<% ctx.native_app.application.role %>": "<% ctx.entities.app.meta.role %>",
+        # Reference to package field should be converted to v2
+        "<% ctx.native_app.package.name %>": "<% ctx.entities.pkg.identifier %>",
+        # Reference to nested package field should be converted to v2
+        "<% ctx.native_app.package.role %>": "<% ctx.entities.pkg.meta.role %>",
+        # Reference to native_app name field should be a literal
+        "<% ctx.native_app.name %>": native_app_name,
+        # Reference to ctx.env field should remain as is
+        "<% ctx.env.FOO %>": "<% ctx.env.FOO %>",
+        # Reference to fn field should remain as is
+        "<% fn.get_username('test') %>": "<% fn.get_username('test') %>",
+    }
+
+    file_with_templates = "app/file.txt"
+    ProjectV11Factory(
+        pdf__native_app__name=native_app_name,
+        pdf__native_app__package__name="my_pkg",
+        pdf__native_app__application__name="my_app",
+        pdf__native_app__artifacts=[
+            dict(src="app/*", processors=[TEMPLATES_PROCESSOR])
+        ],
+        files={
+            "app/manifest.yml": "",  # It just needs to exist for the definition conversion
+            file_with_templates: "\n".join(expected_conversions.keys()),
+        },
+    )
+
+    result = runner.invoke(["helpers", "v1-to-v2"], env={"FOO": "bar"})
+    assert result.exit_code == 0, result.output
+
+    file_contents = Path(file_with_templates).read_text()
+    expected_file_contents = "\n".join(expected_conversions.values())
+    assert file_contents == expected_file_contents, file_contents

--- a/tests_integration/helpers/test_v1_to_v2.py
+++ b/tests_integration/helpers/test_v1_to_v2.py
@@ -10,7 +10,7 @@ from tests.nativeapp.factories import ProjectV11Factory
 def test_v1_to_v2_converts_templates_in_files(temp_dir, runner):
     native_app_name = "my_native_app_project"
 
-    expected_conversions = {
+    src_to_result = {
         # Reference to app field should be converted to v2
         "<% ctx.native_app.application.name %>": "<% ctx.entities.app.identifier %>",
         # Reference to nested app field should be converted to v2
@@ -26,24 +26,43 @@ def test_v1_to_v2_converts_templates_in_files(temp_dir, runner):
         # Reference to fn field should remain as is
         "<% fn.get_username('test') %>": "<% fn.get_username('test') %>",
     }
+    source_contents = "\n".join(src_to_result.keys())
+    expected_templated_contents = "\n".join(src_to_result.values())
 
-    file_with_templates = "app/file.txt"
+    files_using_template_processor = [
+        "templated.txt",
+        "app/templated.txt",
+        "app/manifest.yml",
+        "nested/dir/templated.txt",
+    ]
+    files_not_using_template_processor = [
+        "untemplated.txt",
+    ]
+
     ProjectV11Factory(
         pdf__native_app__name=native_app_name,
         pdf__native_app__package__name="my_pkg",
         pdf__native_app__application__name="my_app",
         pdf__native_app__artifacts=[
-            dict(src="app/*", processors=[TEMPLATES_PROCESSOR])
+            dict(src="templated.txt", processors=[TEMPLATES_PROCESSOR]),
+            dict(src="untemplated.txt"),
+            dict(src="app/*", processors=[TEMPLATES_PROCESSOR]),
+            dict(src="nested/*", processors=[TEMPLATES_PROCESSOR]),
         ],
         files={
-            "app/manifest.yml": "",  # It just needs to exist for the definition conversion
-            file_with_templates: "\n".join(expected_conversions.keys()),
+            filename: source_contents
+            for filename in (
+                files_using_template_processor + files_not_using_template_processor
+            )
         },
     )
 
     result = runner.invoke(["helpers", "v1-to-v2"], env={"FOO": "bar"})
     assert result.exit_code == 0, result.output
 
-    file_contents = Path(file_with_templates).read_text()
-    expected_file_contents = "\n".join(expected_conversions.values())
-    assert file_contents == expected_file_contents, file_contents
+    for filename in files_using_template_processor:
+        file_contents = Path(filename).read_text()
+        assert file_contents == expected_templated_contents, filename
+    for filename in files_not_using_template_processor:
+        file_contents = Path(filename).read_text()
+        assert file_contents == source_contents, filename


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
When running `snow helpers v1-to-v2`, the structure of the project definition changes, and so does the structure of the template context. If artifacts are using the `templates` processor, the files could have references to v1 fields, like `ctx.native_app.stage`, for example. These references would then be invalid after the v2 conversion, since the template context now only has data about v2 entities. We therefore need to convert these template references to the equivalent v2 references using information from the conversion process. We don't convert `ctx.env.` or `fn.` references since those don't change from v1 to v2.
