### PR TITLE
implement depth & total span limits with tests

### DIFF
--- a/src/snowflake/cli/api/metrics.py
+++ b/src/snowflake/cli/api/metrics.py
@@ -263,13 +263,7 @@ class CLIMetrics:
 
     @property
     def num_spans_past_total_limit(self) -> int:
-        return max(
-            0,
-            # we don't count the spans past the depth limit since they would not be reported
-            len(self._completed_spans)
-            - self.num_spans_past_depth_limit
-            - self.SPAN_TOTAL_LIMIT,
-        )
+        return max(0, len(self._completed_spans) - self.SPAN_TOTAL_LIMIT)
 
     @property
     def completed_spans(self) -> List[Dict]:

--- a/src/snowflake/cli/api/metrics.py
+++ b/src/snowflake/cli/api/metrics.py
@@ -17,7 +17,8 @@ import time
 import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
-from typing import ClassVar, Dict, Iterator, List, Optional
+from heapq import nsmallest
+from typing import ClassVar, Dict, Iterator, List, Optional, Set
 
 
 class CLIMetricsInvalidUsageError(RuntimeError):
@@ -84,24 +85,52 @@ class CLIMetricsSpan:
     START_TIME_KEY: ClassVar[str] = "start_time"
     EXECUTION_TIME_KEY: ClassVar[str] = "execution_time"
     ERROR_KEY: ClassVar[str] = "error"
+    COUNT_SPANS_IN_SUBTREE_KEY: ClassVar[str] = "count_spans_in_subtree"
+    SPAN_DEPTH_KEY: ClassVar[str] = "span_depth"
+    # denotes whether direct children were pruned from telemetry payload
+    TRIMMED_KEY: ClassVar[str] = "trimmed"
 
+    # constructor vars
     name: str
     start_time: float  # relative to when the command first started executing
     parent: Optional[CLIMetricsSpan] = None
 
-    # ensure we get unique ids for each step for the parent-child link in case of steps with the same name
-    step_id: str = field(init=False, default_factory=lambda: uuid.uuid4().hex)
+    # vars for reporting
+    span_id: str = field(init=False, default_factory=lambda: uuid.uuid4().hex)
     execution_time: Optional[float] = field(init=False, default=None)
     error: Optional[BaseException] = field(init=False, default=None)
+    span_depth: int = field(init=False, default=1)
+    count_spans_in_subtree: int = field(init=False, default=1)
 
+    # vars for postprocessing
+    children: Set[CLIMetricsSpan] = field(init=False, default_factory=set)
+
+    # private state
     # start time of the step from the monotonic clock in order to calculate execution time
     _monotonic_start: float = field(
         init=False, default_factory=lambda: time.monotonic()
     )
 
+    def __hash__(self) -> int:
+        return hash(self.span_id)
+
     def __post_init__(self):
         if not self.name:
-            raise CLIMetricsInvalidUsageError("step name must not be empty")
+            raise CLIMetricsInvalidUsageError("span name must not be empty")
+
+        if self.parent:
+            self.parent.add_child(self)
+            self.span_depth = self.parent.span_depth + 1
+
+    def increment_subtree_node_count(self) -> None:
+        self.count_spans_in_subtree += 1
+
+        if self.parent:
+            self.parent.increment_subtree_node_count()
+
+    def add_child(self, child: CLIMetricsSpan) -> None:
+        self.children.add(child)
+        self.increment_subtree_node_count()
 
     def finish(self, error: Optional[BaseException] = None) -> None:
         """
@@ -119,19 +148,21 @@ class CLIMetricsSpan:
 
     def to_dict(self) -> Dict:
         """
-        Custom dict conversion function to be used for reporting telemetry, with only the required fields
+        Custom dict conversion function to be used for reporting telemetry
         """
 
         return {
-            self.ID_KEY: self.step_id,
+            self.ID_KEY: self.span_id,
             self.NAME_KEY: self.name,
             self.START_TIME_KEY: self.start_time,
             self.PARENT_KEY: self.parent.name if self.parent is not None else None,
-            self.PARENT_ID_KEY: self.parent.step_id
+            self.PARENT_ID_KEY: self.parent.span_id
             if self.parent is not None
             else None,
             self.EXECUTION_TIME_KEY: self.execution_time,
             self.ERROR_KEY: type(self.error).__name__ if self.error else None,
+            self.COUNT_SPANS_IN_SUBTREE_KEY: self.count_spans_in_subtree,
+            self.SPAN_DEPTH_KEY: self.span_depth,
         }
 
 
@@ -140,6 +171,10 @@ class CLIMetrics:
     """
     Class to track various metrics across the execution of a command
     """
+
+    # limits for reporting purposes
+    SPAN_DEPTH_LIMIT: ClassVar[int] = 5
+    SPAN_TOTAL_LIMIT: ClassVar[int] = 100
 
     _counters: Dict[str, int] = field(init=False, default_factory=dict)
     # stack of in progress spans as command is executing
@@ -214,14 +249,56 @@ class CLIMetrics:
         return self._counters.copy()
 
     @property
+    def num_spans_past_depth_limit(self) -> int:
+        return len(
+            [
+                span
+                for span in self._completed_spans
+                if span.span_depth > self.SPAN_DEPTH_LIMIT
+            ]
+        )
+
+    @property
+    def num_spans_past_total_limit(self) -> int:
+        return max(
+            0,
+            # we don't count the spans past the depth limit since they would not be reported
+            len(self._completed_spans)
+            - self.num_spans_past_depth_limit
+            - self.SPAN_TOTAL_LIMIT,
+        )
+
+    @property
     def completed_spans(self) -> List[Dict]:
         """
-        returns the completed spans tracked throughout a command, sorted by start time, for reporting telemetry
+        Returns the completed spans tracked throughout a command, sorted by start time, for reporting telemetry
+
+        Ensures that the spans we send are within the configured limits and marks
+        certain spans as trimmed if their children would bypass the limits we set
         """
-        return [
-            step.to_dict()
-            for step in sorted(
-                self._completed_spans,
-                key=lambda step: step.start_time,
+        # take spans breadth-first within the depth and total limits
+        # since we care more about the big picture than granularity
+        spans_to_report = set(
+            nsmallest(
+                n=self.SPAN_TOTAL_LIMIT,
+                iterable=(
+                    span
+                    for span in self._completed_spans
+                    if span.span_depth <= self.SPAN_DEPTH_LIMIT
+                ),
+                key=lambda span: (span.span_depth, span.start_time),
             )
+        )
+
+        # sort by start time to make reading the payload easier
+        sorted_spans_to_report = sorted(
+            spans_to_report, key=lambda span: span.start_time
+        )
+
+        return [
+            {
+                **span.to_dict(),
+                CLIMetricsSpan.TRIMMED_KEY: not span.children <= spans_to_report,
+            }
+            for span in sorted_spans_to_report
         ]

--- a/tests/api/metrics/test_metrics_spans.py
+++ b/tests/api/metrics/test_metrics_spans.py
@@ -301,7 +301,39 @@ def test_metrics_spans_empty_name_raises_error():
     assert err.match("span name must not be empty")
 
 
-def test_metrics_spans_passing_depth_limit_should_add_to_counter_and_not_emit():
+@mock.patch(
+    "time.monotonic",
+    side_effect=[
+        110535.515,
+        110535.656,
+        110536.093,
+        110536.656,
+        110537.375,
+        110537.89,
+        110538.093,
+        110538.484,
+        110539.046,
+        110539.968,
+        110540.578,
+        110541.218,
+        110541.546,
+        110541.781,
+        110542.687,
+        110542.781,
+        110543.39,
+        110544.359,
+        110545.296,
+        110545.812,
+        110546.265,
+        110546.5,
+        110547.078,
+        110547.984,
+        110548.078,
+    ],
+)
+def test_metrics_spans_passing_depth_limit_should_add_to_counter_and_not_emit(
+    mock_time_monotonic,
+):
     # given
     metrics = CLIMetrics()
 

--- a/tests/api/metrics/test_metrics_spans.py
+++ b/tests/api/metrics/test_metrics_spans.py
@@ -322,15 +322,14 @@ def test_metrics_spans_passing_total_limit_are_collected_breadth_first():
     )
 
 
-def test_metrics_spans_passing_depth_limit_when_total_limit_reached_should_not_add_to_total_count():
+def test_metrics_spans_passing_both_limits_should_add_to_both_counts():
     # given
     metrics = CLIMetrics()
 
     # when
     create_spans(metrics, width=CLIMetrics.SPAN_TOTAL_LIMIT, depth=1)
-    # the 10 spans past the depth limit would not be reported and so do not count towards the total limit
     create_spans(metrics, width=1, depth=CLIMetrics.SPAN_DEPTH_LIMIT + 10)
 
     # then
-    assert metrics.num_spans_past_total_limit == CLIMetrics.SPAN_DEPTH_LIMIT
+    assert metrics.num_spans_past_total_limit == CLIMetrics.SPAN_DEPTH_LIMIT + 10
     assert metrics.num_spans_past_depth_limit == 10

--- a/tests/api/metrics/test_metrics_spans.py
+++ b/tests/api/metrics/test_metrics_spans.py
@@ -281,7 +281,6 @@ def test_metrics_spans_passing_depth_limit_should_add_to_counter_and_not_emit(
     create_spans(metrics, width=1, depth=CLIMetrics.SPAN_DEPTH_LIMIT + 3)
 
     # then
-
     assert metrics.num_spans_past_total_limit == 0
     assert metrics.num_spans_past_depth_limit == 3
 
@@ -296,7 +295,12 @@ def test_metrics_spans_passing_depth_limit_should_add_to_counter_and_not_emit(
         == CLIMetrics.SPAN_DEPTH_LIMIT
     )
 
-    assert completed_spans[0][CLIMetricsSpan.SPAN_COUNT_IN_SUBTREE_KEY] == 8
+    # should match the total number of spans created regardless of limit
+    assert (
+        completed_spans[0][CLIMetricsSpan.SPAN_COUNT_IN_SUBTREE_KEY]
+        == CLIMetrics.SPAN_DEPTH_LIMIT + 3
+    )
+    # the 3 spans created under this one that went beyond the limit + itself
     assert completed_spans[-1][CLIMetricsSpan.SPAN_COUNT_IN_SUBTREE_KEY] == 4
 
 
@@ -308,6 +312,7 @@ def test_metrics_spans_passing_total_limit_are_collected_breadth_first():
     create_spans(metrics, width=CLIMetrics.SPAN_TOTAL_LIMIT + 1, depth=2)
 
     # then
+    # extra (1 * 2) spans created past the limit
     assert metrics.num_spans_past_total_limit == CLIMetrics.SPAN_TOTAL_LIMIT + 2
     assert metrics.num_spans_past_depth_limit == 0
 

--- a/tests/api/metrics/test_metrics_spans.py
+++ b/tests/api/metrics/test_metrics_spans.py
@@ -301,7 +301,7 @@ def test_metrics_spans_passing_depth_limit_should_add_to_counter_and_not_emit(
         == CLIMetrics.SPAN_DEPTH_LIMIT + 3
     )
     # the 3 spans created under this one that went beyond the limit + itself
-    assert completed_spans[-1][CLIMetricsSpan.SPAN_COUNT_IN_SUBTREE_KEY] == 4
+    assert completed_spans[-1][CLIMetricsSpan.SPAN_COUNT_IN_SUBTREE_KEY] == 3 + 1
 
 
 def test_metrics_spans_passing_total_limit_are_collected_breadth_first():


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
- implement depth and total limits for spans so that the column housing the telemetry doesn't blow up
- added `count_spans_in_subtree`, `span_depth`, `trimmed` fields to reporting dict to make investigation easier if we do reach the limits
- chose to do metadata augmentation on the span tree as we're making it to make the postprocessing easier (e.g. no need to build an adjacency matrix and bfs at the end, we can use simple python builtins, which makes the implementation cleaner/more declarative, and easier to read and maintain imo
