### PR TITLE
SNOW-1763420 Allow creating version with only MANAGE VERSIONS privilege

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,7 +40,7 @@
 * Fixed saving of the config file updates when `connections.toml` exists.
   Removed incorrect copying of connections from `connections.toml` to `config.toml`.
 * Fixes `snow connection generate-jwt` to work with keys with no passphrase.
-
+* The privilege to create a schema or stage is no longer required to run `snow app version create` if the schema and stage already exist.
 
 # v3.1.0
 

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -359,10 +359,11 @@ class SnowflakeSQLFacade:
         @param [Optional] role: Role to switch to while running this script. Current role will be used if no role is passed in.
         @param [Optional] database: Database to use while running this script.
         """
-        identifier = to_identifier(name)
+        fqn = FQN.from_string(name)
+        identifier = to_identifier(fqn.name)
         with (
             self._use_role_optional(role),
-            self._use_database_optional(database),
+            self._use_database_optional(fqn.database or database),
         ):
             try:
                 self._sql_executor.execute_query(
@@ -414,14 +415,15 @@ class SnowflakeSQLFacade:
     ):
         """
         Creates a stage.
-        @param name: Name of the stage to check for. Can be a fully qualified name or just the stage name, in which case the current database and schema or the database and schema passed in will be used.
+        @param name: Name of the stage to create. Can be a fully qualified name or just the stage name, in which case the current database and schema or the database and schema passed in will be used.
         @param [Optional] encryption_type: Encryption type for the stage. Default is Snowflake SSE. Pass an empty string to disable encryption.
         @param [Optional] enable_directory: Directory settings for the stage. Default is enabled.
         @param [Optional] role: Role to switch to while running this script. Current role will be used if no role is passed in.
         @param [Optional] database: Database to use while running this script.
         @param [Optional] schema: Schema to use while running this script.
         """
-        identifier = to_identifier(name)
+        fqn = FQN.from_string(name)
+        identifier = to_identifier(fqn.name)
         query = f"create stage if not exists {identifier}"
         if encryption_type:
             query += f" encryption = (type = '{encryption_type}')"
@@ -429,8 +431,8 @@ class SnowflakeSQLFacade:
             query += f" directory = (enable = {str(enable_directory)})"
         with (
             self._use_role_optional(role),
-            self._use_database_optional(database),
-            self._use_schema_optional(schema),
+            self._use_database_optional(fqn.database or database),
+            self._use_schema_optional(fqn.schema or schema),
         ):
             try:
                 self._sql_executor.execute_query(query)

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -359,12 +359,15 @@ class SnowflakeSQLFacade:
         @param [Optional] role: Role to switch to while running this script. Current role will be used if no role is passed in.
         @param [Optional] database: Database to use while running this script.
         """
+        identifier = to_identifier(name)
         with (
             self._use_role_optional(role),
             self._use_database_optional(database),
         ):
             try:
-                self._sql_executor.execute_query(f"create schema if not exists {name}")
+                self._sql_executor.execute_query(
+                    f"create schema if not exists {identifier}"
+                )
             except ProgrammingError as err:
                 if err.errno == INSUFFICIENT_PRIVILEGES:
                     raise InsufficientPrivilegesError(
@@ -418,7 +421,8 @@ class SnowflakeSQLFacade:
         @param [Optional] database: Database to use while running this script.
         @param [Optional] schema: Schema to use while running this script.
         """
-        query = f"create stage if not exists {name}"
+        identifier = to_identifier(name)
+        query = f"create stage if not exists {identifier}"
         if encryption_type:
             query += f" encryption = (type = '{encryption_type}')"
         if enable_directory:
@@ -448,10 +452,11 @@ class SnowflakeSQLFacade:
         @param package_name: Name of the package
         @param [Optional] role: Role to switch to while running this script. Current role will be used if no role is passed in.
         """
+        package_identifier = to_identifier(package_name)
         with self._use_role_optional(role):
             try:
                 cursor = self._sql_executor.execute_query(
-                    f"show release directives in application package {package_name}",
+                    f"show release directives in application package {package_identifier}",
                     cursor_class=DictCursor,
                 )
             except ProgrammingError as err:

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -107,22 +107,15 @@ def sync_deploy_root_with_stage(
         A `DiffResult` instance describing the changes that were performed.
     """
 
-    sql_executor = get_sql_executor()
+    sql_facade = get_snowflake_facade()
     # Does a stage already exist within the application package, or we need to create one?
     # Using "if not exists" should take care of either case.
     console.step(
         f"Checking if stage {stage_fqn} exists, or creating a new one if none exists."
     )
-    with sql_executor.use_role(role):
-        sql_executor.execute_query(
-            f"create schema if not exists {package_name}.{stage_schema}"
-        )
-        sql_executor.execute_query(
-            f"""
-                    create stage if not exists {stage_fqn}
-                    encryption = (TYPE = 'SNOWFLAKE_SSE')
-                    DIRECTORY = (ENABLE = TRUE)"""
-        )
+    if not sql_facade.stage_exists(stage_fqn):
+        sql_facade.create_schema(stage_schema, database=package_name)
+        sql_facade.create_stage(stage_fqn)
 
     # Perform a diff operation and display results to the user for informational purposes
     if print_diff:

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -165,6 +165,7 @@ def test_sync_deploy_root_with_stage(
     )
 
 
+@mock.patch(SQL_FACADE_STAGE_EXISTS)
 @mock.patch(SQL_EXECUTOR_EXECUTE)
 @mock.patch(f"{ENTITIES_UTILS_MODULE}.sync_local_diff_with_stage")
 @mock.patch(f"{ENTITIES_UTILS_MODULE}.compute_stage_diff")
@@ -187,11 +188,13 @@ def test_sync_deploy_root_with_stage_prune(
     mock_compute_stage_diff,
     mock_local_diff_with_stage,
     mock_execute,
+    mock_stage_exists,
     prune,
     only_on_stage_files,
     expected_warn,
     temp_dir,
 ):
+    mock_stage_exists.return_value = True
     mock_compute_stage_diff.return_value = DiffResult(only_on_stage=only_on_stage_files)
     create_named_file(
         file_name="snowflake.yml",

--- a/tests/nativeapp/test_sf_sql_facade.py
+++ b/tests/nativeapp/test_sf_sql_facade.py
@@ -97,7 +97,7 @@ def assert_in_context(
 
     expected_inner_calls = [mock.call("select 1"), mock.call("select 2")]
     mock_cms = [(mock_use_role, mock.call("test_role")), (mock_use_warehouse, mock.call("test_wh"))]
-    with assert_within_use_calls(expected_inner_calls, mock_execute_query, mock_cms):
+    with assert_in_context(expected_inner_calls, mock_execute_query, mock_cms):
         sql_facade.foo()
 
     This will assert that use_role and use_warehouse are called with the correct arguments and that

--- a/tests/nativeapp/test_sf_sql_facade.py
+++ b/tests/nativeapp/test_sf_sql_facade.py
@@ -1343,20 +1343,60 @@ def test_stage_exists(
         [
             (
                 mock_cursor([(stage,)], ["name"]),
-                mock.call("show stages like 'TEST\\\\_STAGE' in schema"),
+                mock.call(f"show stages like 'TEST\\\\_STAGE'"),
             )
         ]
     )
     mock_execute_query.side_effect = side_effects
 
-    expected_use_objects = [
-        (mock_use_role, mock.call(None)),
-        (mock_use_database, mock.call(None)),
-        (mock_use_schema, mock.call(None)),
-    ]
+    expected_use_objects = [(mock_use_role, mock.call(None))]
     expected_execute_query = [(mock_execute_query, call) for call in expected]
     with assert_in_context(expected_use_objects, expected_execute_query):
         assert sql_facade.stage_exists(stage)
+
+
+def test_stage_exists_fqn(
+    mock_execute_query, mock_cursor, mock_use_role, mock_use_database, mock_use_schema
+):
+    stage = "test_db.test_schema.test_stage"
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([(stage,)], ["name"]),
+                mock.call(
+                    f"show stages like 'TEST\\\\_STAGE' in schema test_db.test_schema"
+                ),
+            )
+        ]
+    )
+    mock_execute_query.side_effect = side_effects
+
+    expected_use_objects = [(mock_use_role, mock.call(None))]
+    expected_execute_query = [(mock_execute_query, call) for call in expected]
+    with assert_in_context(expected_use_objects, expected_execute_query):
+        assert sql_facade.stage_exists(stage)
+
+
+def test_stage_exists_database_and_schema_options(
+    mock_execute_query, mock_cursor, mock_use_role, mock_use_database, mock_use_schema
+):
+    stage = "test_stage"
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([(stage,)], ["name"]),
+                mock.call(
+                    f"show stages like 'TEST\\\\_STAGE' in schema test_db.test_schema"
+                ),
+            )
+        ]
+    )
+    mock_execute_query.side_effect = side_effects
+
+    expected_use_objects = [(mock_use_role, mock.call(None))]
+    expected_execute_query = [(mock_execute_query, call) for call in expected]
+    with assert_in_context(expected_use_objects, expected_execute_query):
+        assert sql_facade.stage_exists(stage, database="test_db", schema="test_schema")
 
 
 def test_stage_exists_returns_false_for_empty_result(

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -70,6 +70,9 @@ SQL_FACADE_MODULE = "snowflake.cli._plugins.nativeapp.sf_facade"
 SQL_FACADE = f"{SQL_FACADE_MODULE}.SnowflakeSQLFacade"
 SQL_FACADE_GET_ACCOUNT_EVENT_TABLE = f"{SQL_FACADE}.get_account_event_table"
 SQL_FACADE_EXECUTE_USER_SCRIPT = f"{SQL_FACADE}.execute_user_script"
+SQL_FACADE_STAGE_EXISTS = f"{SQL_FACADE}.stage_exists"
+SQL_FACADE_CREATE_SCHEMA = f"{SQL_FACADE}.create_schema"
+SQL_FACADE_CREATE_STAGE = f"{SQL_FACADE}.create_stage"
 
 mock_snowflake_yml_file = dedent(
     """\


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
If a user only has the following permissions:
- `MONITOR` on the package
- `USAGE` on the stage’s schema
- `READ` on the stage
- `MANAGE VERSIONS` on the package
They should still be able to create a new version. 

To remove the requirement to have privilege to create a stage, we now check if the stage exists instead of doing `create stage if not exists`. To remove the requirement to have privilege to check for release directives, we now show a different warning if we couldn't check whether a version is already included in a release directive.
