### PR TITLE
SNOW-1789074: SPCS Log streaming - SNOWCLI

### DIFF
--- a/src/snowflake/cli/_plugins/spcs/common.py
+++ b/src/snowflake/cli/_plugins/spcs/common.py
@@ -95,6 +95,10 @@ def handle_object_already_exists(
         raise error
 
 
+def extract_log(log):
+    return log[0] if isinstance(log, tuple) else log
+
+
 def filter_log_timestamp(log: str, include_timestamps: bool) -> str:
     if include_timestamps:
         return log

--- a/src/snowflake/cli/_plugins/spcs/common.py
+++ b/src/snowflake/cli/_plugins/spcs/common.py
@@ -95,10 +95,6 @@ def handle_object_already_exists(
         raise error
 
 
-def extract_log(log):
-    return log[0] if isinstance(log, tuple) else log
-
-
 def filter_log_timestamp(log: str, include_timestamps: bool) -> str:
     if include_timestamps:
         return log
@@ -106,13 +102,10 @@ def filter_log_timestamp(log: str, include_timestamps: bool) -> str:
         return log.split(" ", 1)[1] if " " in log else log
 
 
-def _new_logs_only(
-    prev_log_records: list[str], new_log_records: list[str]
-) -> list[str]:
+def new_logs_only(prev_log_records: list[str], new_log_records: list[str]) -> list[str]:
     # Sort the log records, we get time-ordered logs
     # due to ISO 8601 timestamp format in the log content
     # eg: 2024-10-22T01:12:29.873896187Z Count: 1
-    # prev_log_records_sorted = sorted(prev_log_records)
     new_log_records_sorted = sorted(new_log_records)
 
     # Get the first new log record to establish the overlap point

--- a/src/snowflake/cli/_plugins/spcs/common.py
+++ b/src/snowflake/cli/_plugins/spcs/common.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
+import re
 import sys
-from typing import TextIO
+from typing import Optional, TextIO
 
 from click import ClickException
 from snowflake.cli.api.constants import ObjectType
@@ -93,6 +94,26 @@ def handle_object_already_exists(
         )
     else:
         raise error
+
+
+def extract_timestamp_from_log(log_line: str) -> Optional[str]:
+    timestamp_pattern = re.compile(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)")
+    match = timestamp_pattern.search(log_line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def filter_log_timestamp(log: str, include_timestamps: bool) -> str:
+    if include_timestamps:
+        return log
+    else:
+        return re.sub(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+",
+            "",
+            log,
+            flags=re.MULTILINE,
+        )
 
 
 class NoPropertiesProvidedError(ClickException):

--- a/src/snowflake/cli/_plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/services/commands.py
@@ -236,7 +236,7 @@ def logs(
         False, "--follow", "-f", help="Continue polling for logs.", is_flag=True
     ),
     follow_interval: int = typer.Option(
-        5,
+        2,
         "--follow_interval",
         help="Polling interval in seconds when using the --follow flag",
     ),
@@ -253,7 +253,9 @@ def logs(
     if follow:
         stream: Iterable[CommandResult] = (
             MessageResult(
-                filter_log_timestamp("\n".join(log_batch), include_timestamps)
+                "\n".join(
+                    filter_log_timestamp(log, include_timestamps) for log in log_batch
+                )
             )
             for log_batch in manager.stream_logs(
                 service_name=name.identifier,
@@ -279,7 +281,6 @@ def logs(
         )
         stream = (MessageResult(extract_log(log)) for log in logs)
 
-    # return StreamResult(stream)
     return StreamResult(cast(Generator[CommandResult, None, None], stream))
 
 

--- a/src/snowflake/cli/_plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/services/commands.py
@@ -225,9 +225,6 @@ def logs(
     num_lines: int = typer.Option(
         500, "--num-lines", help="Number of lines to retrieve."
     ),
-    previous_logs: bool = typer.Option(
-        False, "--previous-logs", "-p", help="Retrieve previous logs", is_flag=True
-    ),
     since_timestamp: Optional[str] = typer.Option(
         "", "--since", help="Timestamp to retrieve logs from"
     ),
@@ -248,8 +245,6 @@ def logs(
     Retrieves local logs from a service container.
     """
     if follow:
-        if previous_logs:
-            raise IncompatibleParametersError(["--follow", "--previous-logs"])
         if num_lines != 500:
             raise IncompatibleParametersError(["--follow", "--num-lines"])
 
@@ -267,9 +262,7 @@ def logs(
                 container_name=container_name,
                 instance_id=instance_id,
                 num_lines=num_lines,
-                previous_logs=previous_logs,
                 since_timestamp=since_timestamp,
-                include_timestamps=include_timestamps,
                 interval_seconds=follow_interval,
             )
         )
@@ -280,7 +273,6 @@ def logs(
             container_name=container_name,
             instance_id=instance_id,
             num_lines=num_lines,
-            previous_logs=previous_logs,
             since_timestamp=since_timestamp,
             include_timestamps=include_timestamps,
         )

--- a/src/snowflake/cli/_plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/services/commands.py
@@ -227,7 +227,7 @@ def logs(
         False, "--previous-logs", "-p", help="Retrieve previous logs", is_flag=True
     ),
     since_timestamp: Optional[str] = typer.Option(
-        "", "--since-timestamp", help="Timestamp to retrieve logs from"
+        "", "--since", help="Timestamp to retrieve logs from"
     ),
     include_timestamps: bool = typer.Option(
         False, "--include-timestamps", help="Include timestamps in logs", is_flag=True
@@ -236,7 +236,9 @@ def logs(
         False, "--follow", "-f", help="Continue polling for logs.", is_flag=True
     ),
     follow_interval: int = typer.Option(
-        5, "--watch", help="Polling interval in seconds when using the --follow flag"
+        5,
+        "--follow_interval",
+        help="Polling interval in seconds when using the --follow flag",
     ),
     **options,
 ):

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import List, Optional
 
 import yaml
-from dateutil import parser
 from snowflake.cli._plugins.object.common import Tag
 from snowflake.cli._plugins.spcs.common import (
     NoPropertiesProvidedError,
@@ -182,34 +181,13 @@ class ServiceManager(SqlExecutionMixin):
                     log_lines = log_block.split("\n")
                     log_lines = [line for line in log_lines if line.strip()]
 
-                    first_log_timestamp_str = extract_timestamp_from_log(log_lines[0])
-
-                    first_log_timestamp_parsed = (
-                        parser.isoparse(first_log_timestamp_str)
-                        if first_log_timestamp_str
-                        else None
-                    )
-                    prev_timestamp_parsed = (
-                        parser.isoparse(prev_timestamp) if prev_timestamp else None
-                    )
-
-                    if first_log_timestamp_parsed and (
-                        not prev_timestamp_parsed
-                        or first_log_timestamp_parsed > prev_timestamp_parsed
-                    ):
-                        yield log_lines
-                    else:
-                        matching_index = None
-                        for i, log_line in enumerate(log_lines):
-                            if prev_content and log_line == prev_content:
-                                matching_index = i
-                                break
-                        if matching_index is not None:
+                    if log_lines:
+                        if prev_content and prev_content in log_lines:
+                            matching_index = log_lines.index(prev_content)
                             yield log_lines[matching_index + 1 :]
                         else:
                             yield log_lines
 
-                    if log_lines:
                         prev_content = log_lines[-1]
                         prev_timestamp = extract_timestamp_from_log(prev_content)
 

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -140,13 +140,12 @@ class ServiceManager(SqlExecutionMixin):
         instance_id: str,
         container_name: str,
         num_lines: int,
-        previous_logs: bool = False,
         since_timestamp: str = "",
         include_timestamps: bool = False,
     ):
         return self.execute_query(
             f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', "
-            f"{num_lines}, {previous_logs}, '{since_timestamp}', {include_timestamps});"
+            f"{num_lines}, False, '{since_timestamp}', {include_timestamps});"
         )
 
     def stream_logs(
@@ -155,9 +154,7 @@ class ServiceManager(SqlExecutionMixin):
         instance_id: str,
         container_name: str,
         num_lines: int,
-        previous_logs: bool,
         since_timestamp: str,
-        include_timestamps: bool,
         interval_seconds: int,
     ):
         try:
@@ -170,7 +167,6 @@ class ServiceManager(SqlExecutionMixin):
                     instance_id=instance_id,
                     container_name=container_name,
                     num_lines=num_lines,
-                    previous_logs=False,
                     since_timestamp=prev_timestamp,
                     include_timestamps=True,
                 )

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -15,13 +15,16 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import List, Optional
 
 import yaml
+from dateutil import parser
 from snowflake.cli._plugins.object.common import Tag
 from snowflake.cli._plugins.spcs.common import (
     NoPropertiesProvidedError,
+    extract_timestamp_from_log,
     handle_object_already_exists,
     strip_empty_lines,
 )
@@ -133,11 +136,87 @@ class ServiceManager(SqlExecutionMixin):
         return self.execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")
 
     def logs(
-        self, service_name: str, instance_id: str, container_name: str, num_lines: int
+        self,
+        service_name: str,
+        instance_id: str,
+        container_name: str,
+        num_lines: int,
+        previous_logs: bool = False,
+        since_timestamp: str = "",
+        include_timestamps: bool = False,
     ):
         return self.execute_query(
-            f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines});"
+            f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', "
+            f"{num_lines}, {previous_logs}, '{since_timestamp}', {include_timestamps});"
         )
+
+    def stream_logs(
+        self,
+        service_name: str,
+        instance_id: str,
+        container_name: str,
+        num_lines: int,
+        previous_logs: bool,
+        since_timestamp: str,
+        include_timestamps: bool,
+        interval_seconds: int,
+    ):
+        try:
+            prev_timestamp = since_timestamp
+            prev_content = None
+
+            while True:
+                cursor = self.logs(
+                    service_name=service_name,
+                    instance_id=instance_id,
+                    container_name=container_name,
+                    num_lines=num_lines,
+                    previous_logs=False,
+                    since_timestamp=prev_timestamp,
+                    include_timestamps=True,
+                )
+                new_logs = cursor.fetchall()
+
+                if new_logs:
+                    log_block = new_logs[0][0]
+                    log_lines = log_block.split("\n")
+                    log_lines = [line for line in log_lines if line.strip()]
+
+                    first_log_timestamp_str = extract_timestamp_from_log(log_lines[0])
+
+                    first_log_timestamp_parsed = (
+                        parser.isoparse(first_log_timestamp_str)
+                        if first_log_timestamp_str
+                        else None
+                    )
+                    prev_timestamp_parsed = (
+                        parser.isoparse(prev_timestamp) if prev_timestamp else None
+                    )
+
+                    if first_log_timestamp_parsed and (
+                        not prev_timestamp_parsed
+                        or first_log_timestamp_parsed > prev_timestamp_parsed
+                    ):
+                        yield log_lines
+                    else:
+                        matching_index = None
+                        for i, log_line in enumerate(log_lines):
+                            if prev_content and log_line == prev_content:
+                                matching_index = i
+                                break
+                        if matching_index is not None:
+                            yield log_lines[matching_index + 1 :]
+                        else:
+                            yield log_lines
+
+                    if log_lines:
+                        prev_content = log_lines[-1]
+                        prev_timestamp = extract_timestamp_from_log(prev_content)
+
+                time.sleep(interval_seconds)
+
+        except KeyboardInterrupt:
+            return
 
     def upgrade_spec(self, service_name: str, spec_path: Path):
         spec = self._read_yaml(spec_path)

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -181,13 +181,13 @@ class ServiceManager(SqlExecutionMixin):
                     new_log_records = log_block.split("\n")
                     new_log_records = [line for line in new_log_records if line.strip()]
                     if new_log_records:
-                        new_log_lines = _new_logs_only(
+                        dedup_log_records = _new_logs_only(
                             prev_log_records, new_log_records
                         )
-                        yield new_log_lines
+                        yield dedup_log_records
 
-                        prev_log_records = new_log_lines
-                        prev_timestamp = prev_log_records[-1].split(" ", 1)[0]
+                        prev_timestamp = dedup_log_records[-1].split(" ", 1)[0]
+                        prev_log_records = dedup_log_records
 
                 time.sleep(interval_seconds)
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7309,14 +7309,20 @@
   |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | *  --container-name          TEXT     Name of the container.                 |
-  |                                       [required]                             |
-  | *  --instance-id             TEXT     ID of the service instance, starting   |
-  |                                       with 0.                                |
-  |                                       [required]                             |
-  |    --num-lines               INTEGER  Number of lines to retrieve.           |
-  |                                       [default: 500]                         |
-  |    --help            -h               Show this message and exit.            |
+  | *  --container-name              TEXT     Name of the container.             |
+  |                                           [required]                         |
+  | *  --instance-id                 TEXT     ID of the service instance,        |
+  |                                           starting with 0.                   |
+  |                                           [required]                         |
+  |    --num-lines                   INTEGER  Number of lines to retrieve.       |
+  |                                           [default: 500]                     |
+  |    --since                       TEXT     Timestamp to retrieve logs from    |
+  |    --include-timestamps                   Include timestamps in logs         |
+  |    --follow              -f               Continue polling for logs.         |
+  |    --follow-interval             INTEGER  Polling interval in seconds when   |
+  |                                           using the --follow flag            |
+  |                                           [default: 2]                       |
+  |    --help                -h               Show this message and exit.        |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -435,9 +435,21 @@ def test_logs(mock_execute_query):
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
     result = ServiceManager().logs(service_name, "10", container_name, 42)
-    expected_query = (
-        "call SYSTEM$GET_SERVICE_LOGS('test_service', '10', 'test_container', 42);"
+    expected_query = "call SYSTEM$GET_SERVICE_LOGS('test_service', '10', 'test_container', 42, False, '', False);"
+    mock_execute_query.assert_called_once_with(expected_query)
+    assert result == cursor
+
+
+@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_logs_optional_parameter(mock_execute_query):
+    service_name = "test_service"
+    container_name = "test_container"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ServiceManager().logs(
+        service_name, "10", container_name, 42, False, "", False
     )
+    expected_query = "call SYSTEM$GET_SERVICE_LOGS('test_service', '10', 'test_container', 42, False, '', False);"
     mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -446,9 +446,7 @@ def test_logs_optional_parameter(mock_execute_query):
     container_name = "test_container"
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
-    result = ServiceManager().logs(
-        service_name, "10", container_name, 42, False, "", False
-    )
+    result = ServiceManager().logs(service_name, "10", container_name, 42, "", False)
     expected_query = "call SYSTEM$GET_SERVICE_LOGS('test_service', '10', 'test_container', 42, False, '', False);"
     mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -440,7 +440,7 @@ def test_logs(mock_execute_query):
     assert result == cursor
 
 
-@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager._execute_query")
+@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager.execute_query")
 def test_logs_optional_parameter(mock_execute_query):
     service_name = "test_service"
     container_name = "test_container"
@@ -504,7 +504,7 @@ def test_stream_logs(mock_sleep, mock_logs):
     mock_sleep.assert_has_calls([call(interval_seconds), call(interval_seconds)])
 
 
-@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager._execute_query")
+@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager.execute_query")
 def test_logs_incompatible_flags(mock_execute_query, runner):
     result = runner.invoke(
         [

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -55,6 +55,7 @@ def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
 
 @pytest.mark.integration
+@pytest.mark.xfail(reason="Consistently timing out on execute call")
 def test_job_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
     test_steps, job_service_name = _test_steps

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -37,7 +37,7 @@ def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
     test_steps.list_should_return_service(service_name)
     test_steps.wait_until_service_is_running(service_name)
     test_steps.logs_should_return_service_logs(
-        service_name, "hello-world", '"GET /healthcheck HTTP/1.1" 200 -'
+        service_name, "hello-world", "Serving Flask app 'echo_service'"
     )
     test_steps.suspend_service(service_name)
     test_steps.wait_until_service_is_suspended(service_name)

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -55,7 +55,6 @@ def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
 
 @pytest.mark.integration
-@pytest.mark.xfail(reason="Consistently timing out on execute call")
 def test_job_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
     test_steps, job_service_name = _test_steps

--- a/tests_integration/spcs/testing_utils/spcs_services_utils.py
+++ b/tests_integration/spcs/testing_utils/spcs_services_utils.py
@@ -52,6 +52,7 @@ class SnowparkServicesTestSteps:
     )
     schema = "public"
     container_name = "hello-world"
+    ISO8601_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z")
 
     def __init__(self, setup: SnowparkServicesTestSetup):
         self._setup = setup
@@ -114,22 +115,15 @@ class SnowparkServicesTestSteps:
         # Assert this instead of full payload due to log coloring
         assert expected_log in result.output
         payload = json.loads(result.output)
-        is_valid = self.verify_included_timestamps(payload)
-        assert is_valid == True
+        self.verify_included_timestamps(payload)
 
-    def verify_included_timestamps(self, log_output) -> bool:
-        iso8601_pattern = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z"
+    def verify_included_timestamps(self, log_output):
         log_message = log_output.get("message", "")
         lines = log_message.split("\n")
         for line in lines:
             if not line.strip():
                 continue
-
-            match = re.match(iso8601_pattern, line)
-            if not match:
-                return False
-
-        return True
+            assert self.ISO8601_PATTERN.match(line)
 
     def list_should_return_service(self, service_name: str) -> None:
         result = self._execute_list()

--- a/tests_integration/spcs/testing_utils/spcs_services_utils.py
+++ b/tests_integration/spcs/testing_utils/spcs_services_utils.py
@@ -108,6 +108,8 @@ class SnowparkServicesTestSteps:
         self, service_name: str, container_name: str, expected_log: str
     ) -> None:
         result = self._execute_logs(service_name, container_name)
+        print(result)
+        print(result.output)
         assert result.output
         # Assert this instead of full payload due to log coloring
         assert service_name in result.output
@@ -344,7 +346,7 @@ class SnowparkServicesTestSteps:
     def _execute_logs(
         self, service_name: str, container_name: str, num_lines: int = 500
     ):
-        return self._setup.runner.invoke_with_connection(
+        return self._setup.runner.invoke_with_connection_json(
             [
                 "spcs",
                 "service",
@@ -356,6 +358,7 @@ class SnowparkServicesTestSteps:
                 "0",
                 "--num-lines",
                 str(num_lines),
+                "--include-timestamps",
                 *self._database_schema_args(),
             ],
         )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
The updated snow spcs service logs command now supports additional parameters for enhanced log retrieval and monitoring:
--since: Start log retrieval from a specified UTC timestamp.
--include-timestamps: Add timestamps to log entries for log streaming.
--follow (-f): Stream logs in real-time.
--follow-interval: Customize polling intervals during log streaming.

Design Doc:
https://docs.google.com/document/d/1hvGC97jfvhfcg6gyPnFUl5j2-Xc1MKWy6C7ftc5JZ1c/edit?tab=t.0#heading=h.an8exbgprj8y
