### PR TITLE
Add --label to version create

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 * Added `--replace` and `--if-not-exists` options to `snow object create` command.
 * `snow stage copy` supports `--recursive` flag to copy local files and subdirectories recursively to stage. Including
   glob support.
+* Added `--label` option to `snow app version create` command to allow adding labels to versions and patches.
 
 ## Fixes and improvements
 * `snow --info` callback returns information about `SNOWFLAKE_HOME` variable.

--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import itertools
 import os
+from collections import namedtuple
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
@@ -754,19 +755,24 @@ def find_setup_script_file(deploy_root: Path) -> Path:
         )
 
 
+VersionInfo = namedtuple("VersionInfo", ["version_name", "patch_number", "label"])
+
+
 def find_version_info_in_manifest_file(
     deploy_root: Path,
-) -> Tuple[Optional[str], Optional[int]]:
+) -> VersionInfo:
     """
     Find version and patch, if available, in the manifest.yml file.
     """
     name_field = "name"
     patch_field = "patch"
+    label_field = "label"
 
     manifest_content = find_and_read_manifest_file(deploy_root=deploy_root)
 
     version_name: Optional[str] = None
     patch_number: Optional[int] = None
+    label: Optional[str] = None
 
     version_info = manifest_content.get("version", None)
     if version_info:
@@ -774,5 +780,7 @@ def find_version_info_in_manifest_file(
             version_name = to_identifier(str(version_info[name_field]))
         if patch_field in version_info:
             patch_number = int(version_info[patch_field])
+        if label_field in version_info:
+            label = str(version_info[label_field])
 
-    return version_name, patch_number
+    return VersionInfo(version_name, patch_number, label)

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -667,7 +667,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             f"Defining a new version {version}{with_label_prompt} in application package {self.name}"
         )
         get_snowflake_facade().create_version_in_package(
-            package_role=self.role,
+            role=self.role,
             package_name=self.name,
             stage_fqn=self.stage_fqn,
             version=version,
@@ -691,7 +691,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             f"Adding new patch to version {version}{with_label_prompt} defined in application package {self.name}"
         )
         new_patch = get_snowflake_facade().add_patch_to_package_version(
-            package_role=self.role,
+            role=self.role,
             package_name=self.name,
             stage_fqn=self.stage_fqn,
             version=version,

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -330,7 +330,6 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
             return show_obj_cursor
 
-    # PJ-TODO: check what label=None does
     def action_version_create(
         self,
         action_ctx: ActionContext,
@@ -736,7 +735,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
         # Label must be a string literal
         with_label_query = (
-            f"label={to_string_literal(label)}" if label is not None else ""
+            f"\nlabel={to_string_literal(label)}" if label is not None else ""
         )
         # Use raw string in prompt
         with_label_prompt = f" labeled {label}" if label else ""
@@ -749,8 +748,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 f"""\
                     alter application package {self.name}
                         add version {version}
-                        using @{self.stage_fqn}
-                        {with_label_query}
+                        using @{self.stage_fqn}{with_label_query}
                 """
             )
             sql_executor.execute_query(add_version_query, cursor_class=DictCursor)
@@ -773,7 +771,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
 
         # Label must be a string literal
         with_label_query = (
-            f"label={to_string_literal(label)}" if label is not None else ""
+            f"\nlabel={to_string_literal(label)}" if label is not None else ""
         )
         # Use raw string in prompt
         with_label_prompt = f" labeled {label}" if label else ""
@@ -786,8 +784,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 f"""\
                     alter application package {self.name}
                         add patch {patch if patch else ""} for version {version}
-                        using @{self.stage_fqn}
-                        {with_label_query}
+                        using @{self.stage_fqn}{with_label_query}
                 """
             )
             result_cursor = sql_executor.execute_query(

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -688,7 +688,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         with_label_prompt = f" labeled {label}" if label else ""
 
         console.step(
-            f"Adding new patch to version {version} defined in application package {self.name}"
+            f"Adding new patch to version {version}{with_label_prompt} defined in application package {self.name}"
         )
         new_patch = get_snowflake_facade().add_patch_to_package_version(
             package_role=self.role,

--- a/src/snowflake/cli/_plugins/nativeapp/sf_facade_exceptions.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_facade_exceptions.py
@@ -70,6 +70,13 @@ class UnknownConnectorError(_BaseFacadeError):
         super().__init__(f"Unknown error occurred. {msg}")
 
 
+class ExpectedObjectNotProvidedError(_BaseFacadeError):
+    """Raised when a required object of UseObjectType is None"""
+
+    def __init__(self, object_type: UseObjectType):
+        super().__init__(f"Expected required {object_type} object but received None")
+
+
 class UserScriptError(ClickException):
     """Exception raised when user-provided scripts fail."""
 

--- a/src/snowflake/cli/_plugins/nativeapp/sf_facade_exceptions.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_facade_exceptions.py
@@ -70,11 +70,11 @@ class UnknownConnectorError(_BaseFacadeError):
         super().__init__(f"Unknown error occurred. {msg}")
 
 
-class ExpectedObjectNotProvidedError(_BaseFacadeError):
-    """Raised when a required object of UseObjectType is None"""
+class UnexpectedResultError(_BaseFacadeError):
+    """Raised when an unexpected result was returned from execution of a SQL command"""
 
-    def __init__(self, object_type: UseObjectType):
-        super().__init__(f"Expected required {object_type} object but received None")
+    def __init__(self, msg):
+        super().__init__(f"Received unexpected result from query. {msg}")
 
 
 class UserScriptError(ClickException):

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -194,10 +194,10 @@ class SnowflakeSQLFacade:
     ):
         """
         Creates a new version in an existing application package.
-        @param role: Switch to this role while executing create version.
         @param package_name: Name of the application package to alter.
         @param stage_fqn: Stage fully qualified name.
         @param version: Version name to create.
+        @param [Optional] role: Switch to this role while executing create version.
         @param [Optional] label: Label for this version, visible to consumers.
         """
 
@@ -235,12 +235,12 @@ class SnowflakeSQLFacade:
     ) -> int:
         """
         Add a new patch, optionally a custom one, to an existing version in an application package.
-        @param role: Switch to this role while executing create version.
         @param package_name: Name of the application package to alter.
         @param stage_fqn: Stage fully qualified name.
         @param version: Version name to create.
         @param [Optional] patch: Patch number to create.
         @param [Optional] label: Label for this patch, visible to consumers.
+        @param [Optional] role: Switch to this role while executing create version.
 
         @return patch number created for the version.
         """

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -131,9 +131,6 @@ class SnowflakeSQLFacade:
         """
         return self._use_object_optional(UseObjectType.SCHEMA, schema_name)
 
-    def _use_role(self, role: str):
-        return self._use_role_optional(role)
-
     def execute_user_script(
         self,
         queries: str,
@@ -189,15 +186,15 @@ class SnowflakeSQLFacade:
 
     def create_version_in_package(
         self,
-        package_role: str,
         package_name: str,
         stage_fqn: str,
         version: str,
         label: str | None = None,
+        role: str | None = None,
     ):
         """
         Creates a new version in an existing application package.
-        @param package_role: Switch to this role while executing create version.
+        @param role: Switch to this role while executing create version.
         @param package_name: Name of the application package to alter.
         @param stage_fqn: Stage fully qualified name.
         @param version: Version name to create.
@@ -218,7 +215,7 @@ class SnowflakeSQLFacade:
                     using @{stage_fqn}{with_label_cause}
             """
         )
-        with self._use_role(package_role):
+        with self._use_role_optional(role):
             try:
                 self._sql_executor.execute_query(add_version_query)
             except Exception as err:
@@ -229,16 +226,16 @@ class SnowflakeSQLFacade:
 
     def add_patch_to_package_version(
         self,
-        package_role: str,
         package_name: str,
         stage_fqn: str,
         version: str,
         patch: int | None = None,
         label: str | None = None,
+        role: str | None = None,
     ) -> int:
         """
         Add a new patch, optionally a custom one, to an existing version in an application package.
-        @param package_role: Switch to this role while executing create version.
+        @param role: Switch to this role while executing create version.
         @param package_name: Name of the application package to alter.
         @param stage_fqn: Stage fully qualified name.
         @param version: Version name to create.
@@ -263,7 +260,7 @@ class SnowflakeSQLFacade:
                      using @{stage_fqn}{with_label_clause}
              """
         )
-        with self._use_role(package_role):
+        with self._use_role_optional(role):
             try:
                 result_cursor = self._sql_executor.execute_query(
                     add_patch_query, cursor_class=DictCursor

--- a/src/snowflake/cli/_plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/commands.py
@@ -18,7 +18,6 @@ import logging
 from typing import Optional
 
 import typer
-from click import MissingParameter
 from snowflake.cli._plugins.nativeapp.common_flags import ForceOption, InteractiveOption
 from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
     force_project_definition_v2,
@@ -54,6 +53,11 @@ def create(
         help=f"""The patch number you want to create for an existing version.
         Defaults to undefined if it is not set, which means the Snowflake CLI either uses the patch specified in the `manifest.yml` file or automatically generates a new patch number.""",
     ),
+    label: Optional[str] = typer.Option(
+        None,
+        "--label",
+        help="A label for the version that is displayed to consumers. If unset, the version label specified in `manifest.yml` file is used.",
+    ),
     skip_git_check: Optional[bool] = typer.Option(
         False,
         "--skip-git-check",
@@ -67,8 +71,6 @@ def create(
     """
     Adds a new patch to the provided version defined in your application package. If the version does not exist, creates a version with patch 0.
     """
-    if version is None and patch is not None:
-        raise MissingParameter("Cannot provide a patch without version!")
 
     cli_context = get_cli_context()
     ws = WorkspaceManager(
@@ -81,6 +83,7 @@ def create(
         EntityActions.VERSION_CREATE,
         version=version,
         patch=patch,
+        label=label,
         force=force,
         interactive=interactive,
         skip_git_check=skip_git_check,

--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -22,7 +22,6 @@ from typing import List, Optional
 
 import typer
 import yaml
-from click import MissingParameter
 from snowflake.cli._plugins.nativeapp.artifacts import BundleMap
 from snowflake.cli._plugins.nativeapp.common_flags import (
     ForceOption,
@@ -263,6 +262,11 @@ def version_create(
         help=f"""The patch number you want to create for an existing version.
         Defaults to undefined if it is not set, which means the Snowflake CLI either uses the patch specified in the `manifest.yml` file or automatically generates a new patch number.""",
     ),
+    label: Optional[str] = typer.Option(
+        None,
+        "--label",
+        help="A label for the version that is displayed to consumers. If unset, the version label specified in `manifest.yml` file is used.",
+    ),
     skip_git_check: Optional[bool] = typer.Option(
         False,
         "--skip-git-check",
@@ -274,8 +278,6 @@ def version_create(
     **options,
 ):
     """Creates a new version for the specified entity."""
-    if version is None and patch is not None:
-        raise MissingParameter("Cannot provide a patch without version!")
 
     cli_context = get_cli_context()
     ws = WorkspaceManager(
@@ -287,6 +289,7 @@ def version_create(
         EntityActions.VERSION_CREATE,
         version=version,
         patch=patch,
+        label=label,
         skip_git_check=skip_git_check,
         interactive=interactive,
         force=force,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -483,31 +483,6 @@
   
   '''
 # ---
-# name: test_help_messages[app.init]
-  '''
-                                                                                  
-   Usage: default app init [OPTIONS]                                              
-                                                                                  
-   *** Deprecated. Use snow init instead ***                                      
-   Initializes a Snowflake Native App project.                                    
-                                                                                  
-  +- Options --------------------------------------------------------------------+
-  | --help  -h        Show this message and exit.                                |
-  +------------------------------------------------------------------------------+
-  +- Global configuration -------------------------------------------------------+
-  | --format           [TABLE|JSON]  Specifies the output format.                |
-  |                                  [default: TABLE]                            |
-  | --verbose  -v                    Displays log entries for log levels info    |
-  |                                  and higher.                                 |
-  | --debug                          Displays log entries for log levels debug   |
-  |                                  and higher; debug logs contains additional  |
-  |                                  information.                                |
-  | --silent                         Turns off intermediate output to console.   |
-  +------------------------------------------------------------------------------+
-  
-  
-  '''
-# ---
 # name: test_help_messages[app.open]
   '''
                                                                                   
@@ -1034,6 +1009,15 @@
   |                                                       automatically          |
   |                                                       generates a new patch  |
   |                                                       number.                |
+  |                                                       [default: None]        |
+  | --label                                      TEXT     A label for the        |
+  |                                                       version that is        |
+  |                                                       displayed to           |
+  |                                                       consumers. If unset,   |
+  |                                                       the version label      |
+  |                                                       specified in           |
+  |                                                       manifest.yml file is   |
+  |                                                       used.                  |
   |                                                       [default: None]        |
   | --skip-git-check                                      When enabled, the      |
   |                                                       Snowflake CLI skips    |

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -1409,12 +1409,7 @@ def test_find_version_info_in_manifest_file(version_name, patch_name, label):
 
     deploy_root_structure = {"manifest.yml": safe_dump(manifest_contents)}
     with temp_local_dir(deploy_root_structure) as deploy_root:
-        version_info = find_version_info_in_manifest_file(deploy_root=deploy_root)
-        v, p, l = (
-            version_info.version_name,
-            version_info.patch_number,
-            version_info.label,
-        )
+        v, p, l = find_version_info_in_manifest_file(deploy_root=deploy_root)
         if version_name is None:
             assert v is None
         else:

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -324,10 +324,12 @@ def test_process_no_version_from_user_no_version_in_manifest(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.ApplicationPackageEntity.get_existing_version_info",
     return_value=None,
 )
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @pytest.mark.parametrize("force", [True, False])
 @pytest.mark.parametrize("interactive", [True, False])
 @pytest.mark.parametrize("skip_git_check", [True, False])
 def test_process_no_version_exists_throws_bad_option_exception_one(
+    mock_bundle,
     mock_existing_version_info,
     force,
     interactive,
@@ -356,10 +358,12 @@ def test_process_no_version_exists_throws_bad_option_exception_one(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.ApplicationPackageEntity.get_existing_version_info",
     side_effect=ApplicationPackageDoesNotExistError("app_pkg"),
 )
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @pytest.mark.parametrize("force", [True, False])
 @pytest.mark.parametrize("interactive", [True, False])
 @pytest.mark.parametrize("skip_git_check", [True, False])
 def test_process_no_version_exists_throws_bad_option_exception_two(
+    mock_bundle,
     mock_existing_version_info,
     force,
     interactive,
@@ -392,6 +396,7 @@ def test_process_no_version_exists_throws_bad_option_exception_two(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
 @mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -407,6 +412,7 @@ def test_process_no_existing_release_directives_or_versions(
     mock_add_new_version,
     mock_existing_version_info,
     mock_rd,
+    mock_bundle,
     mock_deploy,
     mock_check_git,
     mock_find_version,
@@ -447,6 +453,7 @@ def test_process_no_existing_release_directives_or_versions(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
 @mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -464,6 +471,7 @@ def test_process_no_existing_release_directives_w_existing_version(
     mock_add_new_version,
     mock_existing_version_info,
     mock_rd,
+    mock_bundle,
     mock_deploy,
     mock_check_git,
     mock_find_version,
@@ -510,6 +518,7 @@ def test_process_no_existing_release_directives_w_existing_version(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
 @mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -528,6 +537,7 @@ def test_process_existing_release_directives_user_does_not_proceed(
     mock_existing_version_info,
     mock_typer_confirm,
     mock_rd,
+    mock_bundle,
     mock_deploy,
     mock_check_git,
     interactive,
@@ -569,6 +579,7 @@ def test_process_existing_release_directives_user_does_not_proceed(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None
 )
 @mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -593,6 +604,7 @@ def test_process_existing_release_directives_w_existing_version_two(
     mock_add_patch,
     mock_existing_version_info,
     mock_rd,
+    mock_bundle,
     mock_deploy,
     mock_check_git,
     force,
@@ -640,6 +652,7 @@ def test_process_existing_release_directives_w_existing_version_two(
     ),
 )
 @mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -656,6 +669,7 @@ def test_manifest_version_info_not_used(
     mock_create_version,
     mock_existing_version,
     mock_rd,
+    mock_bundle,
     mock_deploy,
     mock_find_info_manifest,
     temp_dir,
@@ -700,6 +714,7 @@ def test_manifest_version_info_not_used(
     ),
 )
 @mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
 @mock.patch.object(
     ApplicationPackageEntity,
     "get_existing_release_directive_info_for_version",
@@ -718,6 +733,7 @@ def test_manifest_patch_is_not_used(
     mock_create_patch,
     mock_existing_version,
     mock_rd,
+    mock_bundle,
     mock_deploy,
     mock_find_info_manifest,
     patch,
@@ -906,5 +922,5 @@ def test_patch_from_manifest(
         label=cli_label if cli_label is not None else manifest_label,
     )
     mock_console.warning.assert_called_with(
-        f"Cannot resolve version. Found patch: {manifest_patch} in manifest.yml which is different from provided patch {cli_patch}. Re-run command with --force to ignore patch in manifest.yml"
+        f"Cannot resolve version. Found patch: {manifest_patch} in manifest.yml which is different from provided patch {cli_patch}."
     )

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -15,6 +15,7 @@
 import os
 from textwrap import dedent
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 import typer
@@ -35,12 +36,15 @@ from snowflake.cli._plugins.nativeapp.policy import (
 )
 from snowflake.cli._plugins.workspace.context import ActionContext, WorkspaceContext
 from snowflake.cli.api.console import cli_console as cc
+from snowflake.cli.api.console.abc import AbstractConsole
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.connector.cursor import DictCursor
 
+from tests.nativeapp.factories import ApplicationPackageEntityModelFactory, PdfV2Factory
 from tests.nativeapp.utils import (
     APPLICATION_PACKAGE_ENTITY_MODULE,
     SQL_EXECUTOR_EXECUTE,
+    SQL_FACADE,
     mock_execute_helper,
     mock_snowflake_yml_file_v2,
 )
@@ -58,12 +62,13 @@ def _version_create(
     interactive: bool,
     skip_git_check: bool,
     label: str | None = None,
+    console: AbstractConsole | None = None,
 ):
     dm = DefinitionManager()
     pd = dm.project_definition
     pkg_model: ApplicationPackageEntityModel = pd.entities["app_pkg"]
     ctx = WorkspaceContext(
-        console=cc,
+        console=console or cc,
         project_root=dm.project_root,
         get_default_role=lambda: "mock_role",
         get_default_warehouse=lambda: "mock_warehouse",
@@ -309,6 +314,7 @@ def test_process_no_version_from_user_no_version_in_manifest(
             force=force,
             interactive=interactive,
             skip_git_check=skip_git_check,
+            label="version_label",
         )  # last three parameters do not matter here, so it should succeed for all policies.
     mock_version_info_in_manifest.assert_called_once()
 
@@ -625,3 +631,280 @@ def test_process_existing_release_directives_w_existing_version_two(
     mock_deploy.assert_called_once()
     assert mock_existing_version_info.call_count == 2
     mock_add_patch.assert_called_once()
+
+
+@mock.patch(
+    f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
+    return_value=VersionInfo(
+        version_name="manifest_version", patch_number="2", label="manifest_label"
+    ),
+)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(
+    ApplicationPackageEntity,
+    "get_existing_release_directive_info_for_version",
+    return_value=None,
+)
+@mock.patch.object(
+    ApplicationPackageEntity, "get_existing_version_info", return_value=None
+)
+@mock.patch(
+    f"{SQL_FACADE}.create_version_in_package",
+    return_value=None,
+)
+def test_manifest_version_info_not_used(
+    mock_create_version,
+    mock_existing_version,
+    mock_rd,
+    mock_deploy,
+    mock_find_info_manifest,
+    temp_dir,
+    mock_cursor,
+):
+
+    role = "package_role"
+    stage = "app_src.stage"
+
+    version_cli = "version name from cli"
+    PdfV2Factory(
+        entities=dict(
+            app_pkg=ApplicationPackageEntityModelFactory(
+                stage=stage, meta__role=role, meta__warehouse="pkg_wh"
+            ),
+        )
+    )
+
+    _version_create(
+        version=version_cli,
+        patch=None,
+        label=None,
+        skip_git_check=True,
+        interactive=True,
+        force=False,
+    )
+
+    mock_create_version.assert_called_with(
+        package_role=role,
+        package_name="app_pkg",
+        stage_fqn=f"app_pkg.{stage}",
+        version=version_cli,
+        label="",
+    )
+    mock_find_info_manifest.assert_not_called()
+
+
+@mock.patch(
+    f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
+    return_value=VersionInfo(
+        version_name="manifest_version", patch_number="4", label="manifest_label"
+    ),
+)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(
+    ApplicationPackageEntity,
+    "get_existing_release_directive_info_for_version",
+    return_value=None,
+)
+@mock.patch.object(
+    ApplicationPackageEntity, "get_existing_version_info", return_value=True
+)
+@mock.patch(
+    f"{SQL_FACADE}.add_patch_to_package_version",
+    return_value=None,
+)
+@pytest.mark.parametrize("label", [None, "some label"])
+@pytest.mark.parametrize("patch", [None, 2, 7])
+def test_manifest_patch_is_not_used(
+    mock_create_patch,
+    mock_existing_version,
+    mock_rd,
+    mock_deploy,
+    mock_find_info_manifest,
+    patch,
+    label,
+    temp_dir,
+    mock_cursor,
+):
+
+    role = "package_role"
+    stage = "app_src.stage"
+
+    version_cli = "version name from cli"
+    PdfV2Factory(
+        entities=dict(
+            app_pkg=ApplicationPackageEntityModelFactory(
+                stage=stage, meta__role=role, meta__warehouse="pkg_wh"
+            ),
+        )
+    )
+
+    _version_create(
+        version=version_cli,
+        patch=patch,
+        label=label,
+        skip_git_check=True,
+        interactive=True,
+        force=False,
+    )
+
+    mock_create_patch.assert_called_with(
+        package_role=role,
+        package_name="app_pkg",
+        stage_fqn=f"app_pkg.{stage}",
+        version=version_cli,
+        patch=patch,
+        # ensure empty label is used to replace label from manifest.yml
+        label=label or "",
+    )
+    mock_find_info_manifest.assert_not_called()
+
+
+@mock.patch(
+    f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
+)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
+@mock.patch.object(
+    ApplicationPackageEntity,
+    "get_existing_release_directive_info_for_version",
+    return_value=None,
+)
+@mock.patch.object(
+    ApplicationPackageEntity,
+    "get_existing_version_info",
+    return_value=True,  # so we can use patch
+)
+@mock.patch(
+    f"{SQL_FACADE}.add_patch_to_package_version",
+    return_value=None,
+)
+@pytest.mark.parametrize("manifest_label", [None, "some label", ""])
+@pytest.mark.parametrize("manifest_patch", [None, 4])
+@pytest.mark.parametrize("cli_label", [None, "", "cli label"])
+def test_version_from_manifest(
+    mock_create_patch,
+    mock_existing_version,
+    mock_rd,
+    mock_bundle,
+    mock_deploy,
+    mock_find_info_manifest,
+    cli_label,
+    manifest_patch,
+    manifest_label,
+    temp_dir,
+    mock_cursor,
+):
+
+    mock_find_info_manifest.return_value = VersionInfo(
+        version_name="manifest_version",
+        patch_number=manifest_patch,
+        label=manifest_label,
+    )
+
+    role = "package_role"
+    stage = "app_src.stage"
+
+    PdfV2Factory(
+        entities=dict(
+            app_pkg=ApplicationPackageEntityModelFactory(
+                stage=stage, meta__role=role, meta__warehouse="pkg_wh"
+            ),
+        )
+    )
+
+    # no version or patch through cli
+    _version_create(
+        version=None,
+        patch=None,
+        label=cli_label,
+        skip_git_check=True,
+        interactive=True,
+        force=False,
+    )
+
+    mock_create_patch.assert_called_with(
+        package_role=role,
+        package_name="app_pkg",
+        stage_fqn=f"app_pkg.{stage}",
+        version="manifest_version",
+        patch=manifest_patch,
+        label=cli_label if cli_label is not None else manifest_label,
+    )
+
+
+@mock.patch(
+    f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
+)
+@mock.patch.object(ApplicationPackageEntity, "_deploy", return_value=None)
+@mock.patch.object(ApplicationPackageEntity, "_bundle", return_value=None)
+@mock.patch.object(
+    ApplicationPackageEntity,
+    "get_existing_release_directive_info_for_version",
+    return_value=None,
+)
+@mock.patch.object(
+    ApplicationPackageEntity,
+    "get_existing_version_info",
+    return_value=True,  # so we can use patch
+)
+@mock.patch(
+    f"{SQL_FACADE}.add_patch_to_package_version",
+    return_value=None,
+)
+@pytest.mark.parametrize("manifest_label", [None, "some label", ""])
+@pytest.mark.parametrize("cli_label", [None, "", "cli label"])
+def test_patch_from_manifest(
+    mock_create_patch,
+    mock_existing_version,
+    mock_rd,
+    mock_bundle,
+    mock_deploy,
+    mock_find_info_manifest,
+    cli_label,
+    manifest_label,
+    temp_dir,
+    mock_cursor,
+):
+    manifest_patch = 4
+    cli_patch = 2
+    mock_find_info_manifest.return_value = VersionInfo(
+        version_name="manifest_version",
+        patch_number=manifest_patch,
+        label=manifest_label,
+    )
+
+    role = "package_role"
+    stage = "app_src.stage"
+    mock_console = MagicMock()
+    PdfV2Factory(
+        entities=dict(
+            app_pkg=ApplicationPackageEntityModelFactory(
+                stage=stage, meta__role=role, meta__warehouse="pkg_wh"
+            ),
+        )
+    )
+
+    # patch through cli, but no version
+    _version_create(
+        version=None,
+        patch=cli_patch,
+        label=cli_label,
+        skip_git_check=True,
+        interactive=True,
+        # Force to skip confirmation on patch override
+        force=True,
+        console=mock_console,
+    )
+
+    mock_create_patch.assert_called_with(
+        package_role=role,
+        package_name="app_pkg",
+        stage_fqn=f"app_pkg.{stage}",
+        version="manifest_version",
+        # cli patch overrides the manifest
+        patch=cli_patch,
+        label=cli_label if cli_label is not None else manifest_label,
+    )
+    mock_console.warning.assert_called_with(
+        f"Cannot resolve version. Found patch: {manifest_patch} in manifest.yml which is different from provided patch {cli_patch}. Re-run command with --force to ignore patch in manifest.yml"
+    )

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -697,7 +697,7 @@ def test_manifest_version_info_not_used(
     )
 
     mock_create_version.assert_called_with(
-        package_role=role,
+        role=role,
         package_name="app_pkg",
         stage_fqn=f"app_pkg.{stage}",
         version=version_cli,
@@ -763,7 +763,7 @@ def test_manifest_patch_is_not_used(
     )
 
     mock_create_patch.assert_called_with(
-        package_role=role,
+        role=role,
         package_name="app_pkg",
         stage_fqn=f"app_pkg.{stage}",
         version=version_cli,
@@ -838,7 +838,7 @@ def test_version_from_manifest(
     )
 
     mock_create_patch.assert_called_with(
-        package_role=role,
+        role=role,
         package_name="app_pkg",
         stage_fqn=f"app_pkg.{stage}",
         version="manifest_version",
@@ -912,7 +912,7 @@ def test_patch_from_manifest(
     )
 
     mock_create_patch.assert_called_with(
-        package_role=role,
+        role=role,
         package_name="app_pkg",
         stage_fqn=f"app_pkg.{stage}",
         version="manifest_version",

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -159,7 +159,6 @@ def test_add_version(
                             using @app_pkg.app_src.stage
                     """
                     ),
-                    cursor_class=DictCursor,
                 ),
             ),
             (None, mock.call("use role old_role")),

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -19,6 +19,7 @@ from unittest import mock
 import pytest
 import typer
 from click import BadOptionUsage, ClickException
+from snowflake.cli._plugins.nativeapp.artifacts import VersionInfo
 from snowflake.cli._plugins.nativeapp.constants import SPECIAL_COMMENT
 from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntity,
@@ -56,6 +57,7 @@ def _version_create(
     force: bool,
     interactive: bool,
     skip_git_check: bool,
+    label: str | None = None,
 ):
     dm = DefinitionManager()
     pd = dm.project_definition
@@ -71,6 +73,7 @@ def _version_create(
         action_ctx=mock.Mock(spec=ActionContext),
         version=version,
         patch=patch,
+        label=label,
         force=force,
         interactive=interactive,
         skip_git_check=skip_git_check,
@@ -279,7 +282,7 @@ def test_add_new_patch_custom(
 )
 @mock.patch(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
-    return_value=(None, None),
+    return_value=VersionInfo(None, None, None),
 )
 @pytest.mark.parametrize("force", [True, False])
 @pytest.mark.parametrize("interactive", [True, False])
@@ -377,7 +380,7 @@ def test_process_no_version_exists_throws_bad_option_exception_two(
 # Test version create when there are no release directives matching the version AND no version exists for app pkg
 @mock.patch(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
-    return_value=("manifest_version", None),
+    return_value=VersionInfo("manifest_version", None, None),
 )
 @mock.patch.object(
     ApplicationPackageEntity, "check_index_changes_in_git_repo", return_value=None

--- a/tests/nativeapp/test_version_drop.py
+++ b/tests/nativeapp/test_version_drop.py
@@ -18,6 +18,7 @@ from unittest import mock
 import pytest
 import typer
 from click import ClickException
+from snowflake.cli._plugins.nativeapp.artifacts import VersionInfo
 from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntity,
     ApplicationPackageEntityModel,
@@ -104,7 +105,7 @@ def test_process_has_no_existing_app_pkg(
 )
 @mock.patch(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
-    return_value=(None, None),
+    return_value=VersionInfo(None, None, None),
 )
 @pytest.mark.parametrize("force", [True, False])
 @pytest.mark.parametrize("interactive", [True, False])
@@ -146,7 +147,7 @@ def test_process_no_version_from_user_no_version_in_manifest(
 )
 @mock.patch(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
-    return_value=("manifest_version", None),
+    return_value=VersionInfo("manifest_version", None, None),
 )
 @mock.patch(
     f"snowflake.cli._plugins.nativeapp.policy.{TYPER_CONFIRM}", return_value=False
@@ -196,7 +197,7 @@ def test_process_drop_cannot_complete(
 )
 @mock.patch(
     f"{APPLICATION_PACKAGE_ENTITY_MODULE}.find_version_info_in_manifest_file",
-    return_value=("manifest_version", None),
+    return_value=VersionInfo("manifest_version", None, None),
 )
 @mock.patch(SQL_EXECUTOR_EXECUTE)
 @mock.patch(

--- a/tests_integration/nativeapp/__snapshots__/test_version.ambr
+++ b/tests_integration/nativeapp/__snapshots__/test_version.ambr
@@ -4,7 +4,7 @@
     dict({
       'comment': None,
       'dropped_on': None,
-      'label': None,
+      'label': '',
       'log_level': 'OFF',
       'patch': 0,
       'review_status': 'NOT_REVIEWED',
@@ -15,7 +15,7 @@
     dict({
       'comment': None,
       'dropped_on': None,
-      'label': None,
+      'label': '',
       'log_level': 'OFF',
       'patch': 1,
       'review_status': 'NOT_REVIEWED',


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added `--label` option to `snow app version create`. version label in `manifest.yml` will be ignored if this option is provided. 
    
Other changes:
- `--patch` can be provided to the cli even if there is no version name specified in the cli. `manifest.yml will be checked for the version name. if there is a conflicting patch in the manifest, the user will have to confirm to use the cli-provided patch.   

- If a version name is provided through the cli, all version info from manifest (version name, patch, and label) are ignored. 
 
