### PR TITLE
Make manifest optional in application package pdfV2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,7 +17,7 @@
 ## Backward incompatibility
 
 ## Deprecations
-
+* `manifest` field of `application package` entity is now optional. This field does not have any functionality.
 ## New additions
 * Added `--retain-comments` option to `snow sql` command to allow passing comments to Snowflake.
 * Added `--replace` and `--if-not-exists` options to `snow object create` command.

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -112,9 +112,7 @@ class ApplicationPackageEntityModel(EntityModelBase):
         title="Distribution of the application package created by the Snowflake CLI",
         default="internal",
     )
-    manifest: str = Field(
-        title="Path to manifest.yml",
-    )
+    manifest: Optional[str] = Field(title="Path to manifest.yml", default="")
 
     @field_validator("identifier")
     @classmethod

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -112,7 +112,9 @@ class ApplicationPackageEntityModel(EntityModelBase):
         title="Distribution of the application package created by the Snowflake CLI",
         default="internal",
     )
-    manifest: Optional[str] = Field(title="Path to manifest.yml", default="")
+    manifest: Optional[str] = Field(
+        title="Unused field. Path to manifest.yml", default=""
+    )
 
     @field_validator("identifier")
     @classmethod

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -113,7 +113,8 @@ class ApplicationPackageEntityModel(EntityModelBase):
         default="internal",
     )
     manifest: Optional[str] = Field(
-        title="Unused field. Path to manifest.yml", default=""
+        title="Path to manifest.yml. Unused and deprecated starting with Snowflake CLI 3.2",
+        default="",
     )
 
     @field_validator("identifier")

--- a/tests/helpers/__snapshots__/test_v1_to_v2.ambr
+++ b/tests/helpers/__snapshots__/test_v1_to_v2.ambr
@@ -168,6 +168,127 @@
   
   '''
 # ---
+# name: test_migration_native_app_no_artifacts
+  '''
+  definition_version: '2'
+  entities:
+    procedureName:
+      imports: []
+      external_access_integrations: []
+      secrets: {}
+      meta:
+        use_mixins:
+        - snowpark_shared
+      identifier:
+        name: procedureName
+      handler: hello
+      returns: string
+      signature:
+      - name: name
+        type: string
+      stage: dev_deployment
+      artifacts:
+      - src: app
+        dest: my_snowpark_project
+      type: procedure
+      execute_as_caller: false
+    func1:
+      imports: []
+      external_access_integrations: []
+      secrets: {}
+      meta:
+        use_mixins:
+        - snowpark_shared
+      identifier:
+        name: func1
+      handler: app.func1_handler
+      returns: string
+      signature:
+      - name: a
+        type: string
+        default: default value
+      - name: b
+        type: variant
+      runtime: '3.1'
+      stage: dev_deployment
+      artifacts:
+      - src: app
+        dest: my_snowpark_project
+      type: function
+    test_streamlit:
+      identifier:
+        name: test_streamlit
+      type: streamlit
+      title: My Fancy Streamlit
+      query_warehouse: test_warehouse
+      main_file: streamlit_app.py
+      pages_dir: None
+      stage: streamlit
+      artifacts:
+      - streamlit_app.py
+      - environment.yml
+      - pages
+    pkg:
+      meta:
+        role: pkg_role
+      identifier: <% fn.concat_ids('myapp', '_pkg_', fn.sanitize_id(fn.get_username('unknown_user')) | lower) %>
+      type: application package
+      artifacts: []
+    app:
+      identifier: myapp_app
+      type: application
+      from:
+        target: pkg
+  mixins:
+    snowpark_shared:
+      stage: dev_deployment
+      artifacts:
+      - src: app/
+        dest: my_snowpark_project
+  
+  '''
+# ---
+# name: test_migration_native_app_no_artifacts.1
+  '''
+  definition_version: 1
+  native_app:
+    application:
+      name: myapp_app
+    artifacts: []
+    name: myapp
+    package:
+      role: pkg_role
+  snowpark:
+    functions:
+    - handler: app.func1_handler
+      name: func1
+      returns: string
+      runtime: 3.1
+      signature:
+      - default: default value
+        name: a
+        type: string
+      - name: b
+        type: variant
+    procedures:
+    - handler: hello
+      name: procedureName
+      returns: string
+      signature:
+      - name: name
+        type: string
+    project_name: my_snowpark_project
+    src: app/
+    stage_name: dev_deployment
+  streamlit:
+    main_file: streamlit_app.py
+    name: test_streamlit
+    query_warehouse: test_warehouse
+    stage: streamlit
+    title: My Fancy Streamlit
+  
+  '''
+# ---
 # name: test_migrations_with_all_app_entities
   '''
   definition_version: '2'
@@ -196,7 +317,6 @@
       stage: app_src.my_stage
       scratch_stage: app_src.my_scratch
       distribution: external
-      manifest: app/manifest.yml
     app:
       meta:
         warehouse: app_wh
@@ -316,7 +436,6 @@
       artifacts:
       - src: app/*
         dest: ./
-      manifest: app/manifest.yml
     app:
       identifier: myapp_app
       type: application

--- a/tests/project/test_project_definition_v2.py
+++ b/tests/project/test_project_definition_v2.py
@@ -57,7 +57,6 @@ from tests.nativeapp.factories import ProjectV11Factory
             {"entities": {"pkg": {"type": "application package"}}},
             [
                 "missing the following field: 'entities.pkg.application package.artifacts'",
-                "missing the following field: 'entities.pkg.application package.manifest'",
             ],
         ],
         [


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* make manifest field optional in pdfV2 definition of application package
* don't generate manifest field in v1-to-v2 conversions

Change to snowflake-cli-templates to exclude the field when cli version >= 3.2.0
https://github.com/snowflakedb/snowflake-cli-templates/pull/15
