### PR TITLE
Snow 1789099: SnowCLI integrates with spcs previous logs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,7 +27,7 @@
 * `snow helpers v1-to-v2` now converts v1 template references to v2 in Native App artifacts that use the `templates` processor.
 * Added `--label` option to `snow app version create` command to allow adding labels to versions and patches.
 * Enhanced `snow spcs service logs` command with new parameters for improved log retrieval and monitoring.
-  * * `--previous-logs (-p)`: Retrieve logs from the last terminated container.
+  * `--previous-logs (-p)`: Retrieve logs from the last terminated container.
   * `--since`: Start log retrieval from a specified UTC timestamp.
   * `--include-timestamps`: Include timestamps in log entries for log streaming.
   * `--follow (-f)`: Stream logs in real-time.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,6 +27,7 @@
 * `snow helpers v1-to-v2` now converts v1 template references to v2 in Native App artifacts that use the `templates` processor.
 * Added `--label` option to `snow app version create` command to allow adding labels to versions and patches.
 * Enhanced `snow spcs service logs` command with new parameters for improved log retrieval and monitoring.
+  * * `--previous-logs (-p)`: Retrieve logs from the last terminated container.
   * `--since`: Start log retrieval from a specified UTC timestamp.
   * `--include-timestamps`: Include timestamps in log entries for log streaming.
   * `--follow (-f)`: Stream logs in real-time.

--- a/src/snowflake/cli/_plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/services/commands.py
@@ -223,19 +223,26 @@ def logs(
     num_lines: int = typer.Option(
         500, "--num-lines", help="Number of lines to retrieve."
     ),
+    previous_logs: bool = typer.Option(
+        False,
+        "--previous-logs",
+        "-p",
+        help="Retrieve logs from the last terminated container",
+        is_flag=True,
+    ),
     since_timestamp: Optional[str] = typer.Option(
-        "", "--since", help="Timestamp to retrieve logs from"
+        "", "--since", help="Start log retrieval from a specified UTC timestamp"
     ),
     include_timestamps: bool = typer.Option(
         False, "--include-timestamps", help="Include timestamps in logs", is_flag=True
     ),
     follow: bool = typer.Option(
-        False, "--follow", "-f", help="Continue polling for logs.", is_flag=True
+        False, "--follow", "-f", help="Stream logs in real-time", is_flag=True
     ),
     follow_interval: int = typer.Option(
         2,
         "--follow-interval",
-        help="Polling interval in seconds when using the --follow flag",
+        help="Set custom polling intervals during log streaming.",
     ),
     **options,
 ):
@@ -245,6 +252,8 @@ def logs(
     if follow:
         if num_lines != 500:
             raise IncompatibleParametersError(["--follow", "--num-lines"])
+        if previous_logs:
+            raise IncompatibleParametersError(["--follow", "--previous-logs"])
 
     manager = ServiceManager()
 
@@ -270,6 +279,7 @@ def logs(
                 container_name=container_name,
                 instance_id=instance_id,
                 num_lines=num_lines,
+                previous_logs=previous_logs,
                 since_timestamp=since_timestamp,
                 include_timestamps=include_timestamps,
             )

--- a/src/snowflake/cli/_plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/services/commands.py
@@ -79,6 +79,7 @@ SpecPathOption = typer.Option(
     exists=True,
     show_default=False,
 )
+DEFAULT_NUM_LINES = 500
 
 _MIN_INSTANCES_HELP = "Minimum number of service instances to run."
 MinInstancesOption = OverrideableOption(
@@ -221,7 +222,7 @@ def logs(
         show_default=False,
     ),
     num_lines: int = typer.Option(
-        500, "--num-lines", help="Number of lines to retrieve."
+        DEFAULT_NUM_LINES, "--num-lines", help="Number of lines to retrieve."
     ),
     previous_logs: bool = typer.Option(
         False,
@@ -250,7 +251,7 @@ def logs(
     Retrieves local logs from a service container.
     """
     if follow:
-        if num_lines != 500:
+        if num_lines != DEFAULT_NUM_LINES:
             raise IncompatibleParametersError(["--follow", "--num-lines"])
         if previous_logs:
             raise IncompatibleParametersError(["--follow", "--previous-logs"])

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -141,12 +141,13 @@ class ServiceManager(SqlExecutionMixin):
         instance_id: str,
         container_name: str,
         num_lines: int,
+        previous_logs: bool = False,
         since_timestamp: str = "",
         include_timestamps: bool = False,
     ):
         cursor = self.execute_query(
             f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', "
-            f"{num_lines}, False, '{since_timestamp}', {include_timestamps});"
+            f"{num_lines}, {previous_logs}, '{since_timestamp}', {include_timestamps});"
         )
 
         for log in cursor.fetchall():

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7300,12 +7300,14 @@
   |                                           [required]                         |
   |    --num-lines                   INTEGER  Number of lines to retrieve.       |
   |                                           [default: 500]                     |
-  |    --previous-logs       -p               Retrieve previous logs             |
-  |    --since                       TEXT     Timestamp to retrieve logs from    |
+  |    --previous-logs       -p               Retrieve logs from the last        |
+  |                                           terminated container               |
+  |    --since                       TEXT     Start log retrieval from a         |
+  |                                           specified UTC timestamp            |
   |    --include-timestamps                   Include timestamps in logs         |
-  |    --follow              -f               Continue polling for logs.         |
-  |    --follow-interval             INTEGER  Polling interval in seconds when   |
-  |                                           using the --follow flag            |
+  |    --follow              -f               Stream logs in real-time           |
+  |    --follow-interval             INTEGER  Set custom polling intervals       |
+  |                                           during log streaming.              |
   |                                           [default: 2]                       |
   |    --help                -h               Show this message and exit.        |
   +------------------------------------------------------------------------------+

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7300,6 +7300,7 @@
   |                                           [required]                         |
   |    --num-lines                   INTEGER  Number of lines to retrieve.       |
   |                                           [default: 500]                     |
+  |    --previous-logs       -p               Retrieve previous logs             |
   |    --since                       TEXT     Timestamp to retrieve logs from    |
   |    --include-timestamps                   Include timestamps in logs         |
   |    --follow              -f               Continue polling for logs.         |


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
**Enhanced `snow spcs service logs` Command with New Parameters**

This pull request introduces improvements to the `snow spcs service logs` command by adding new parameters, allowing for more flexible and efficient log retrieval and monitoring:

- **New Parameter: `--previous-logs (-p)`**  
  - Allows users to retrieve logs from the last terminated container instance, improving accessibility to historical logs and enhancing debugging visibility.

### Example Usage
```shell
snow spcs service logs log_pre --container-name log-restart --instance-id 0 -p
```

- This command retrieves logs from the previously terminated container if it exists. Error handling has been added to notify users if no previous container instance is available or if incompatible flags are used.


