### PR TITLE
Fix for connections.toml with empty config.toml

### DIFF
--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -351,7 +351,10 @@ def _dump_config(config_and_connections: Dict):
         _update_connections_toml(config_and_connections.get("connections") or {})
         # to config.toml save only connections from config.toml
         connections_to_save_in_config_toml = _read_config_file_toml().get("connections")
-        config_toml_dict["connections"] = connections_to_save_in_config_toml
+        if connections_to_save_in_config_toml:
+            config_toml_dict["connections"] = connections_to_save_in_config_toml
+        else:
+            config_toml_dict.pop("connections", None)
 
     with SecurePath(CONFIG_MANAGER.file_path).open("w+") as fh:
         dump(config_toml_dict, fh)

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -277,6 +277,13 @@ def test_snowcli_config():
         yield p
 
 
+@pytest.fixture(scope="function")
+def empty_snowcli_config():
+    with _named_temporary_file(suffix=".toml") as p:
+        p.chmod(0o600)  # Make config file private
+        yield p
+
+
 @pytest.fixture(scope="session")
 def test_root_path():
     return TEST_DIR


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix for fix from #1791 , which was failing in case we had all connections in `connections.toml` and `config.toml` was empty.
