### PR TITLE
Fix for default visible in connection add

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,7 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
-
+* Fixed default argument shown in `snow connection add`
 
 # v3.2.0
 
@@ -53,6 +53,7 @@
 * The privilege to create a schema or stage is no longer required to run `snow app version create` if the schema and stage already exist.
 * Fix Windows permissions error on files created by CLI when owner is a part of custom group with granted
   default permissions.
+
 
 # v3.1.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,7 +21,6 @@
 ## New additions
 
 ## Fixes and improvements
-* Fixed default argument shown in `snow connection add`
 
 # v3.2.0
 
@@ -53,7 +52,7 @@
 * The privilege to create a schema or stage is no longer required to run `snow app version create` if the schema and stage already exist.
 * Fix Windows permissions error on files created by CLI when owner is a part of custom group with granted
   default permissions.
-
+* Fixed default argument shown in `snow connection add`
 
 # v3.1.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -52,7 +52,6 @@
 * The privilege to create a schema or stage is no longer required to run `snow app version create` if the schema and stage already exist.
 * Fix Windows permissions error on files created by CLI when owner is a part of custom group with granted
   default permissions.
-* Fixed default argument shown in `snow connection add`
 
 # v3.1.0
 

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -258,6 +258,7 @@ def add(
                     default="",
                     value_proc=lambda x: None if not x else x,
                     hide_input=option == "password",
+                    show_default=False,
                 )
             if isinstance(connection_options[option], str):
                 connection_options[option] = strip_if_value_present(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Default value `[]` was visible in prompts for `snow connection add`.
