### PR TITLE
Fix error message for mis-formatted version field in manifest.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ gen_docs/
 .env
 .vscode
 tmp/
-py11venv/
 ^app.zip
 ^snowflake.yml

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ gen_docs/
 .env
 .vscode
 tmp/
-
+py11venv/
 ^app.zip
 ^snowflake.yml

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ gen_docs/
 .env
 .vscode
 tmp/
+
 ^app.zip
 ^snowflake.yml

--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -782,11 +782,11 @@ def find_version_info_in_manifest_file(
             raise ClickException(
                 "Error occurred while reading manifest.yml. Received unexpected version format."
             )
-        if name_field in version_info and version_info[name_field] is not None:
+        if version_info.get(name_field) is not None:
             version_name = to_identifier(str(version_info[name_field]))
-        if patch_field in version_info and version_info[patch_field] is not None:
+        if version_info.get(patch_field) is not None:
             patch_number = int(version_info[patch_field])
-        if label_field in version_info and version_info[label_field] is not None:
+        if version_info.get(label_field) is not None:
             label = str(version_info[label_field])
 
     return VersionInfo(version_name, patch_number, label)

--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -778,6 +778,10 @@ def find_version_info_in_manifest_file(
 
     version_info = manifest_content.get("version", None)
     if version_info:
+        if not isinstance(version_info, dict):
+            raise ClickException(
+                "Error occurred while reading manifest.yml. Received unexpected version format."
+            )
         if name_field in version_info:
             version_name = to_identifier(str(version_info[name_field]))
         if patch_field in version_info:

--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -777,7 +777,7 @@ def find_version_info_in_manifest_file(
     label: Optional[str] = None
 
     version_info = manifest_content.get("version", None)
-    if version_info:
+    if version_info is not None:
         if not isinstance(version_info, dict):
             raise ClickException(
                 "Error occurred while reading manifest.yml. Received unexpected version format."

--- a/src/snowflake/cli/_plugins/nativeapp/artifacts.py
+++ b/src/snowflake/cli/_plugins/nativeapp/artifacts.py
@@ -782,11 +782,11 @@ def find_version_info_in_manifest_file(
             raise ClickException(
                 "Error occurred while reading manifest.yml. Received unexpected version format."
             )
-        if name_field in version_info:
+        if name_field in version_info and version_info[name_field] is not None:
             version_name = to_identifier(str(version_info[name_field]))
-        if patch_field in version_info:
+        if patch_field in version_info and version_info[patch_field] is not None:
             patch_number = int(version_info[patch_field])
-        if label_field in version_info:
+        if label_field in version_info and version_info[label_field] is not None:
             label = str(version_info[label_field])
 
     return VersionInfo(version_name, patch_number, label)

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -29,6 +29,7 @@ from snowflake.cli._plugins.nativeapp.artifacts import (
     NotInDeployRootError,
     SourceNotFoundError,
     TooManyFilesError,
+    VersionInfo,
     build_bundle,
     find_events_definitions_in_manifest_file,
     find_version_info_in_manifest_file,
@@ -1439,6 +1440,32 @@ def test_bad_version_info_in_manifest_file_throws_error(version_info):
         assert (
             err.value.message
             == "Error occurred while reading manifest.yml. Received unexpected version format."
+        )
+
+
+def test_read_empty_version_info_in_manifest_file():
+    manifest_contents = ManifestFactory(
+        version={"name": None, "patch": None, "label": None}
+    )
+
+    deploy_root_structure = {"manifest.yml": manifest_contents}
+    with temp_local_dir(deploy_root_structure) as deploy_root:
+
+        version_info = find_version_info_in_manifest_file(deploy_root=deploy_root)
+        assert version_info == VersionInfo(
+            version_name=None, patch_number=None, label=None
+        )
+
+
+def test_read_empty_version_in_manifest_file():
+    manifest_contents = ManifestFactory(version=None)
+
+    deploy_root_structure = {"manifest.yml": manifest_contents}
+    with temp_local_dir(deploy_root_structure) as deploy_root:
+
+        version_info = find_version_info_in_manifest_file(deploy_root=deploy_root)
+        assert version_info == VersionInfo(
+            version_name=None, patch_number=None, label=None
         )
 
 

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Union
 
 import pytest
+from click import ClickException
 from snowflake.cli._plugins.nativeapp.artifacts import (
     ArtifactError,
     ArtifactPredicate,
@@ -39,6 +40,7 @@ from snowflake.cli.api.project.schemas.v1.native_app.path_mapping import PathMap
 from snowflake.cli.api.project.util import to_identifier
 from yaml import safe_dump
 
+from tests.nativeapp.factories import ManifestFactory
 from tests.nativeapp.utils import (
     assert_dir_snapshot,
     touch,
@@ -1424,6 +1426,20 @@ def test_find_version_info_in_manifest_file(version_name, patch_name, label):
             assert l is None
         else:
             assert l == label
+
+
+@pytest.mark.parametrize("version_info", ["some_name", ["li1", "li2"], "", 4])
+def test_bad_version_info_in_manifest_file_throws_error(version_info):
+    manifest_contents = ManifestFactory(version=version_info)
+
+    deploy_root_structure = {"manifest.yml": manifest_contents}
+    with temp_local_dir(deploy_root_structure) as deploy_root:
+        with pytest.raises(ClickException) as err:
+            find_version_info_in_manifest_file(deploy_root=deploy_root)
+        assert (
+            err.value.message
+            == "Error occurred while reading manifest.yml. Received unexpected version format."
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Having a mis-formatted version field in the manifest.yml throws the wrong error: 
`Error: Manifest.yml file does not contain a value for the version field.`

This PR fixes this to throw the appropriate error. 