### PR TITLE
Make version test resilient to new fields

### DIFF
--- a/tests_integration/nativeapp/__snapshots__/test_version.ambr
+++ b/tests_integration/nativeapp/__snapshots__/test_version.ambr
@@ -3,24 +3,18 @@
   list([
     dict({
       'comment': None,
-      'dropped_on': None,
       'label': '',
-      'log_level': 'OFF',
       'patch': 0,
       'review_status': 'NOT_REVIEWED',
       'state': 'READY',
-      'trace_level': 'OFF',
       'version': 'V1',
     }),
     dict({
       'comment': None,
-      'dropped_on': None,
       'label': '',
-      'log_level': 'OFF',
       'patch': 1,
       'review_status': 'NOT_REVIEWED',
       'state': 'READY',
-      'trace_level': 'OFF',
       'version': 'V1',
     }),
   ])

--- a/tests_integration/nativeapp/test_version.py
+++ b/tests_integration/nativeapp/test_version.py
@@ -31,6 +31,17 @@ from tests.project.fixtures import *
 from tests_integration.test_utils import contains_row_with, row_from_snowflake_session
 
 
+# A minimal set of fields to compare when checking version output
+VERSION_FIELDS_TO_OUTPUT = [
+    "comment",
+    "label",
+    "patch",
+    "review_status",
+    "state",
+    "version",
+]
+
+
 def set_version_in_app_manifest(manifest_path: Path, version: Any, patch: Any = None):
     with open(manifest_path, "r") as f:
         manifest = safe_load(f)
@@ -373,10 +384,10 @@ def test_nativeapp_version_create_package_no_magic_comment(
         # app package contains version v1 with 2 patches
         actual = runner.invoke_with_connection_json(split(list_command))
         for row in actual.json:
-            # Remove date field
-            row.pop("created_on", None)
-            # Remove metric_level field
-            row.pop("metric_level", None)
+            keys_to_remove = row.keys() - VERSION_FIELDS_TO_OUTPUT
+            for key in keys_to_remove:
+                del row[key]
+
         assert actual.json == snapshot
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * (N/A) I've added or updated automated unit tests to verify correctness of my new code.
   * [X] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * (N/A) I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description

There is a version integ test that is brittle in the face of new columns. This change makes it resilient to columns being added, without weakening the current assertions.
