### PR TITLE
Move domain logic to individual processors

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/codegen/compiler.py
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/compiler.py
@@ -176,9 +176,5 @@ class NativeAppCompiler:
 
         # if the processor class defines a static method named "is_enabled", then
         # call it. Otherwise, it's considered enabled by default.
-        is_enabled_fn = getattr(processor_cls, "is_enabled", None)
-        if is_enabled_fn is None:
-            # No custom static method provided, enabled by default
-            return True
-
+        is_enabled_fn = getattr(processor_cls, "is_enabled", lambda: True)
         return is_enabled_fn()

--- a/src/snowflake/cli/_plugins/nativeapp/codegen/compiler.py
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/compiler.py
@@ -62,11 +62,11 @@ class NativeAppCompiler:
         # dictionary of all processors created and shared between different artifact objects.
         self.cached_processors: Dict[str, ArtifactProcessor] = {}
 
-        self._register(SnowparkAnnotationProcessor)
-        self._register(NativeAppSetupProcessor)
-        self._register(TemplatesProcessor)
+        self.register(SnowparkAnnotationProcessor)
+        self.register(NativeAppSetupProcessor)
+        self.register(TemplatesProcessor)
 
-    def _register(self, processor_cls: ProcessorClassType):
+    def register(self, processor_cls: ProcessorClassType):
         """
         Registers a processor class to enable.
         """

--- a/src/snowflake/cli/_plugins/nativeapp/codegen/setup/native_app_setup_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/setup/native_app_setup_processor.py
@@ -36,6 +36,7 @@ from snowflake.cli._plugins.nativeapp.codegen.sandbox import (
     SandboxEnvBuilder,
     execute_script_in_sandbox,
 )
+from snowflake.cli._plugins.nativeapp.feature_flags import FeatureFlag
 from snowflake.cli._plugins.stage.diff import to_stage_path
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.project.schemas.v1.native_app.path_mapping import (
@@ -74,8 +75,14 @@ def safe_set(d: dict, *keys: str, **kwargs) -> None:
 
 
 class NativeAppSetupProcessor(ArtifactProcessor):
+    NAME = "native app setup"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def is_enabled() -> bool:
+        return FeatureFlag.ENABLE_NATIVE_APP_PYTHON_SETUP.is_enabled()
 
     def process(
         self,

--- a/src/snowflake/cli/_plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -164,6 +164,8 @@ class SnowparkAnnotationProcessor(ArtifactProcessor):
     and generate SQL code for creation of extension functions based on those discovered objects.
     """
 
+    NAME = "snowpark"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/src/snowflake/cli/_plugins/nativeapp/codegen/templates/templates_processor.py
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/templates/templates_processor.py
@@ -49,6 +49,8 @@ class TemplatesProcessor(ArtifactProcessor):
     Processor class to perform template expansion on all relevant artifacts (specified in the project definition file).
     """
 
+    NAME = "templates"
+
     def expand_templates_in_file(
         self, src: Path, dest: Path, template_context: dict[str, Any] | None = None
     ) -> None:

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -13,7 +13,6 @@ from snowflake.cli._plugins.nativeapp.artifacts import (
     bundle_artifacts,
 )
 from snowflake.cli._plugins.nativeapp.bundle_context import BundleContext
-from snowflake.cli._plugins.nativeapp.codegen.compiler import TEMPLATES_PROCESSOR
 from snowflake.cli._plugins.nativeapp.codegen.templates.templates_processor import (
     TemplatesProcessor,
 )
@@ -457,7 +456,7 @@ def _convert_templates_in_files(
             artifact
             for artifact in pkg_model.artifacts
             for processor in artifact.processors
-            if processor.name == TEMPLATES_PROCESSOR
+            if processor.name.lower() == TemplatesProcessor.NAME
         ]
         if not in_memory and artifacts_to_template:
             metrics.set_counter(CLICounterField.TEMPLATES_PROCESSOR, 1)

--- a/tests_integration/helpers/test_v1_to_v2.py
+++ b/tests_integration/helpers/test_v1_to_v2.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 import pytest
 
-from snowflake.cli._plugins.nativeapp.codegen.compiler import TEMPLATES_PROCESSOR
+from snowflake.cli._plugins.nativeapp.codegen.templates.templates_processor import (
+    TemplatesProcessor,
+)
 from tests.nativeapp.factories import ProjectV11Factory
 
 
@@ -44,10 +46,10 @@ def test_v1_to_v2_converts_templates_in_files(temp_dir, runner):
         pdf__native_app__package__name="my_pkg",
         pdf__native_app__application__name="my_app",
         pdf__native_app__artifacts=[
-            dict(src="templated.txt", processors=[TEMPLATES_PROCESSOR]),
+            dict(src="templated.txt", processors=[TemplatesProcessor.NAME]),
             dict(src="untemplated.txt"),
-            dict(src="app/*", processors=[TEMPLATES_PROCESSOR]),
-            dict(src="nested/*", processors=[TEMPLATES_PROCESSOR]),
+            dict(src="app/*", processors=[TemplatesProcessor.NAME]),
+            dict(src="nested/*", processors=[TemplatesProcessor.NAME]),
         ],
         files={
             filename: source_contents


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * (N/A) I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * (N/A) I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

This change is part 1 of a series of refactorings aiming to enable the templates processor in domains other than native apps. This change specifically aims to move domain logic out of the compiler and into individual processors. This will facilitate moving the common portion of the processors to a shared location (under the `artifacts` module in the CLI's API). Attempting to do so now would leave a significant number of references to native apps in common code, which I would prefer to avoid.
