### PR TITLE
Downgrade snowpark lib until a fix is identified

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "setuptools==75.6.0",
   'snowflake.core==1.0.2; python_version < "3.12"',
   "snowflake-connector-python[secure-local-storage]==3.12.3",
-  'snowflake-snowpark-python>=1.15.0;python_version < "3.12"',
+  'snowflake-snowpark-python>=1.15.0,<1.26.0;python_version < "3.12"',
   "tomlkit==0.13.2",
   "typer==0.12.5",
   "urllib3>=1.24.3,<2.3",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -8,7 +8,7 @@ requirements-parser==0.11.0
 setuptools==75.6.0
 snowflake.core==1.0.2; python_version < "3.12"
 snowflake-connector-python[secure-local-storage]==3.12.3
-snowflake-snowpark-python>=1.15.0;python_version < "3.12"
+snowflake-snowpark-python>=1.15.0,<1.26.0;python_version < "3.12"
 tomlkit==0.13.2
 typer==0.12.5
 urllib3>=1.24.3,<2.3

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -140,7 +140,7 @@ def _install_snowcli_with_external_plugin(
     )
 
     # Required by snowpark example tests
-    _pip_install(python, "snowflake-snowpark-python")
+    _pip_install(python, "snowflake-snowpark-python[pandas]==1.25.0")
 
 
 def _python_path(venv_path: Path) -> Path:


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description

Snowpark 1.26.0 breaks native app's snowpark integration. It looks like a new piece of logic was introduced that incorrectly assumes that Snowpark has a valid session, which is not the case when we execute Snowpark in the CLI sandbox. NADE will need to work with the Snowpark team on the fix or workaround, until then we shouldn't use the buggy library.
