### PR TITLE
Add with grant option flag to streamlit share

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,7 @@
   * Add ability to list release channels through `snow app release-channel list` command
   * Add ability to add and remove accounts from release channels through `snow app release-channel add-accounts` and snow app release-channel remove-accounts` commands.
   * Add ability to add/remove versions to/from release channels through `snow app release-channel add-version` and `snow app release-channel remove-version` commands.
+* Added `--with-grant-option` to `snow streamlit share` to grant the ability for the role to share the Streamlit app that is being shared.
 
 ## Fixes and improvements
 * Fixed crashes with older x86_64 Intel CPUs.

--- a/src/snowflake/cli/_plugins/streamlit/commands.py
+++ b/src/snowflake/cli/_plugins/streamlit/commands.py
@@ -101,10 +101,11 @@ def streamlit_share(
         help="Role with which to share the Streamlit app.",
         show_default=False,
     ),
-    with_grant_option: bool = typer.Argument(
-        default=False,
+    with_grant_option: bool = typer.Option(
+        False,
+        "--with-grant-option",
         help="Share the Streamlit app with the grant option, giving the role the ability to also share the Streamlit app.",
-        show_default=True,
+        is_flag=True,
     ),
     **options,
 ) -> CommandResult:

--- a/src/snowflake/cli/_plugins/streamlit/commands.py
+++ b/src/snowflake/cli/_plugins/streamlit/commands.py
@@ -101,12 +101,17 @@ def streamlit_share(
         help="Role with which to share the Streamlit app.",
         show_default=False,
     ),
+    with_grant_option: bool = typer.Argument(
+        default=False,
+        help="Share the Streamlit app with the grant option, giving the role the ability to also share the Streamlit app.",
+        show_default=True,
+    ),
     **options,
 ) -> CommandResult:
     """
     Shares a Streamlit app with another role.
     """
-    cursor = StreamlitManager().share(streamlit_name=name, to_role=to_role)
+    cursor = StreamlitManager().share(streamlit_name=name, to_role=to_role, with_grant_option=with_grant_option)
     return SingleQueryResult(cursor)
 
 

--- a/src/snowflake/cli/_plugins/streamlit/manager.py
+++ b/src/snowflake/cli/_plugins/streamlit/manager.py
@@ -47,10 +47,11 @@ class StreamlitManager(SqlExecutionMixin):
         query = f"EXECUTE STREAMLIT {app_name.sql_identifier}()"
         return self.execute_query(query=query)
 
-    def share(self, streamlit_name: FQN, to_role: str) -> SnowflakeCursor:
-        return self.execute_query(
-            f"grant usage on streamlit {streamlit_name.sql_identifier} to role {to_role}"
-        )
+    def share(self, streamlit_name: FQN, to_role: str, with_grant_option: bool) -> SnowflakeCursor:
+        grant_statement = f"grant usage on streamlit {streamlit_name.sql_identifier} to role {to_role}"
+        if with_grant_option:
+            grant_statement += " with grant option"
+        return self.execute_query(grant_statement)
 
     def _put_streamlit_files(
         self,

--- a/tests/streamlit/test_commands.py
+++ b/tests/streamlit/test_commands.py
@@ -973,6 +973,21 @@ def test_share_streamlit(mock_connector, runner, mock_ctx):
 
 
 @mock.patch("snowflake.connector.connect")
+def test_share_streamlit_wth_grant_option(mock_connector, runner, mock_ctx):
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+    role = "other_role"
+
+    result = runner.invoke(["streamlit", "share", STREAMLIT_NAME, role, "--with-grant-option"])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        ctx.get_query()
+        == f"grant usage on streamlit IDENTIFIER('{STREAMLIT_NAME}') to role {role} with grant option"
+    )
+
+
+@mock.patch("snowflake.connector.connect")
 def test_drop_streamlit(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx

--- a/tests_integration/test_streamlit.py
+++ b/tests_integration/test_streamlit.py
@@ -84,6 +84,14 @@ def test_streamlit_deploy(
             {"status": "Statement executed successfully."},
         )
 
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "share", streamlit_name, _new_streamlit_role, "--with-grant-option"]
+        )
+        assert contains_row_with(
+            result.json,
+            {"status": "Statement executed successfully."},
+        )
+
         result = snowflake_session.execute_string("select current_role()")
         current_role = row_from_snowflake_session(result)[0]["CURRENT_ROLE()"]
         try:
@@ -215,6 +223,15 @@ def test_streamlit_deploy_experimental_twice(
             result.json,
             {"status": "Statement executed successfully."},
         )
+
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "share", streamlit_name, _new_streamlit_role, "--with-grant-option"]
+        )
+        assert contains_row_with(
+            result.json,
+            {"status": "Statement executed successfully."},
+        )
+
         result = snowflake_session.execute_string("select current_role()")
         current_role = row_from_snowflake_session(result)[0]["CURRENT_ROLE()"]
         try:


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * [X] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
I've added a `--with-grant-option` flag to `snow streamlit share` to grant the ability to share the app to the role that the app is being shared to.

I've run the tests locally and have run into two failures, which I _believe_ may not be impactful. The help message failure seems to be just due to whitespace due to the addition of the longer-named flag. I am not familiar with the other failure however.
![image](https://github.com/user-attachments/assets/e74db3e4-bf87-4cf3-a5da-8a4aacbc0719)

I am also unfortunately unable to run this command locally, due to some networking restrictions at my company. I've confirmed the addition of the flag via the `--help` menu. This is a fairly small change, so I don't foresee many issues, but if anyone is able to verify for me, that would be great.

Resolves #1961 
