### PR TITLE
Add --from-stage option to version create

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
   * `snow app release-directive set`
   * `snow app release-directive unset`
 * `snow app version create` now returns version, patch, and label in JSON format.
+* Add `--from-stage` flag to `snow app version create` to allow version creation from the content of the stage without re-syncing to the stage.
 * Add support for release channels:
   * Add support for release channels feature in native app version creation/drop.
   * Add ability to specify release channel when creating application instance from release directive: `snow app run --from-release-directive --channel=<channel>`

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -468,8 +468,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
         # then do not re-deploy the artifacts or touch the stage
         if from_stage:
             # verify package exists:
-            show_obj_row = self.get_existing_app_pkg_info()
-            if not show_obj_row:
+            if not self.get_existing_app_pkg_info():
                 raise ClickException(
                     "Cannot create version from stage because the application package does not exist yet. "
                     "Try removing --from-stage flag or executing `snow app deploy` to deploy the application package first."

--- a/src/snowflake/cli/_plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/commands.py
@@ -72,6 +72,12 @@ def create(
         help="When enabled, the Snowflake CLI skips checking if your project has any untracked or stages files in git. Default: unset.",
         is_flag=True,
     ),
+    from_stage: bool = typer.Option(
+        False,
+        "--from-stage",
+        help="When enabled, the Snowflake CLI creates a version from the current application package stage without syncing to the stage first.",
+        is_flag=True,
+    ),
     interactive: bool = InteractiveOption,
     force: Optional[bool] = ForceOption,
     **options,
@@ -95,6 +101,7 @@ def create(
         force=force,
         interactive=interactive,
         skip_git_check=skip_git_check,
+        from_stage=from_stage,
     )
 
     message = "Version create is now complete."

--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -293,6 +293,7 @@ def version_create(
         skip_git_check=skip_git_check,
         interactive=interactive,
         force=force,
+        from_stage=False,
     )
 
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -2089,6 +2089,13 @@
   |                                                       untracked or stages    |
   |                                                       files in git. Default: |
   |                                                       unset.                 |
+  | --from-stage                                          When enabled, the      |
+  |                                                       Snowflake CLI creates  |
+  |                                                       a version from the     |
+  |                                                       current application    |
+  |                                                       package stage without  |
+  |                                                       syncing to the stage   |
+  |                                                       first.                 |
   | --interactive            --no-interactive             When enabled, this     |
   |                                                       option displays        |
   |                                                       prompts even if the    |


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Add --from-stage option to version create

When `--from-stage` is provided, `snow app version create --from-stage` will create a version from the content of the stage directly without resyncing the local files to the stage.
