### PR TITLE
[SNOW-1874231] Pinning click to 8.1.7 as temporary workaround to unblock tests failing by recent changes in click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
+  "click==8.1.7",
   "jinja2==3.1.4",
   "pluggy==1.5.0",
   "PyYAML==6.0.2",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,3 +1,4 @@
+click==8.1.7
 jinja2==3.1.4
 pluggy==1.5.0
 PyYAML==6.0.2


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Pinning `click` version to 8.1.7 because our integration tests currently fail on 8.1.8. Typer uses `click>=8.0.6` requirement. We'll continue debugging of issues with 8.1.8 and remove the pin later.
