### PR TITLE
[SNOW-1874231] Fixes for click 8.1.8 (custom help option)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
-  "click==8.1.8",
   "jinja2==3.1.5",
   "pluggy==1.5.0",
   "PyYAML==6.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
-  "click==8.1.7",
+  "click==8.1.8",
   "jinja2==3.1.5",
   "pluggy==1.5.0",
   "PyYAML==6.0.2",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,4 +1,4 @@
-click==8.1.7
+click==8.1.8
 jinja2==3.1.5
 pluggy==1.5.0
 PyYAML==6.0.2

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,4 +1,3 @@
-click==8.1.8
 jinja2==3.1.5
 pluggy==1.5.0
 PyYAML==6.0.2

--- a/src/snowflake/cli/_app/cli_app.py
+++ b/src/snowflake/cli/_app/cli_app.py
@@ -112,6 +112,15 @@ def _docs_callback(value: bool):
 
 @_do_not_execute_on_completion
 @_commands_registration.after
+def _help_callback(value: bool):
+    if value:
+        ctx = click.get_current_context()
+        typer.echo(ctx.get_help())
+        _exit_with_cleanup()
+
+
+@_do_not_execute_on_completion
+@_commands_registration.after
 def _commands_structure_callback(value: bool):
     if value:
         ctx = click.get_current_context()
@@ -157,10 +166,19 @@ def app_factory() -> SnowCliMainTyper:
         invoke_without_command=True,
         epilog=new_version_msg,
         result_callback=show_new_version_banner_callback(new_version_msg),
+        add_help_option=False,
         help=f"Snowflake CLI tool for developers [v{__about__.VERSION}]",
     )
     def default(
         ctx: typer.Context,
+        custom_help: bool = typer.Option(
+            None,
+            "--help",
+            "-h",
+            help="Show this message and exit.",
+            callback=_help_callback,
+            is_eager=True,
+        ),
         version: bool = typer.Option(
             None,
             "--version",

--- a/src/snowflake/cli/_app/cli_app.py
+++ b/src/snowflake/cli/_app/cli_app.py
@@ -166,11 +166,15 @@ def app_factory() -> SnowCliMainTyper:
         invoke_without_command=True,
         epilog=new_version_msg,
         result_callback=show_new_version_banner_callback(new_version_msg),
-        add_help_option=False,
+        add_help_option=False,  # custom_help option added below
         help=f"Snowflake CLI tool for developers [v{__about__.VERSION}]",
     )
     def default(
         ctx: typer.Context,
+        # We need a custom help option with _help_callback called after command registration
+        # to have all commands visible in the help.
+        # This is required since click 8.1.8, when the default help option
+        # has started to being executed before our eager options, including command registration.
         custom_help: bool = typer.Option(
             None,
             "--help",

--- a/src/snowflake/cli/_app/commands_registration/commands_registration_with_callbacks.py
+++ b/src/snowflake/cli/_app/commands_registration/commands_registration_with_callbacks.py
@@ -87,6 +87,7 @@ class CommandsRegistrationWithCallbacks:
         def enriched_callback(value):
             self._counter_of_callbacks_invoked_before_registration.increment()
             callback(value)
+            self.register_commands_if_ready_and_not_registered_yet()
 
         self._counter_of_callbacks_required_before_registration.increment()
         return enriched_callback

--- a/src/snowflake/cli/_app/commands_registration/commands_registration_with_callbacks.py
+++ b/src/snowflake/cli/_app/commands_registration/commands_registration_with_callbacks.py
@@ -87,7 +87,6 @@ class CommandsRegistrationWithCallbacks:
         def enriched_callback(value):
             self._counter_of_callbacks_invoked_before_registration.increment()
             callback(value)
-            self.register_commands_if_ready_and_not_registered_yet()
 
         self._counter_of_callbacks_required_before_registration.increment()
         return enriched_callback

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7,6 +7,7 @@
    Snowflake CLI tool for developers [v0.0.0-test_patched]                        
                                                                                   
   +- Options --------------------------------------------------------------------+
+  | --help                -h            Show this message and exit.              |
   | --version                           Shows version of the Snowflake CLI       |
   | --info                              Shows information about the Snowflake    |
   |                                     CLI                                      |
@@ -18,7 +19,6 @@
   | --show-completion                   Show completion for the current shell,   |
   |                                     to copy it or customize the              |
   |                                     installation.                            |
-  | --help                -h            Show this message and exit.              |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |
@@ -10914,6 +10914,7 @@
    Snowflake CLI tool for developers [v0.0.0-test_patched]                        
                                                                                   
   +- Options --------------------------------------------------------------------+
+  | --help                -h            Show this message and exit.              |
   | --version                           Shows version of the Snowflake CLI       |
   | --info                              Shows information about the Snowflake    |
   |                                     CLI                                      |
@@ -10925,7 +10926,6 @@
   | --show-completion                   Show completion for the current shell,   |
   |                                     to copy it or customize the              |
   |                                     installation.                            |
-  | --help                -h            Show this message and exit.              |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -150,16 +150,8 @@ def test_if_there_are_no_option_duplicates(runner):
                 _check(command_info, [*path, command_name])
 
     def check_options_for_duplicates(params: t.List[TyperOption]) -> t.Set[str]:
-        RESERVED_FLAGS = ["--help"]  # noqa: N806
-
         flags = [flag for param in params for flag in param.opts]
-        return set(
-            [
-                flag
-                for flag in flags
-                if (flags.count(flag) > 1 or flag in RESERVED_FLAGS)
-            ]
-        )
+        return set([flag for flag in flags if (flags.count(flag) > 1)])
 
     _check(ctx.command)
 

--- a/tests_e2e/__snapshots__/test_installation.ambr
+++ b/tests_e2e/__snapshots__/test_installation.ambr
@@ -17,6 +17,7 @@
    Snowflake CLI tool for developers [v3.3.0.dev0]                                
                                                                                   
   +- Options --------------------------------------------------------------------+
+  | --help                -h            Show this message and exit.              |
   | --version                           Shows version of the Snowflake CLI       |
   | --info                              Shows information about the Snowflake    |
   |                                     CLI                                      |
@@ -28,7 +29,6 @@
   | --show-completion                   Show completion for the current shell,   |
   |                                     to copy it or customize the              |
   |                                     installation.                            |
-  | --help                -h            Show this message and exit.              |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Click 8.1.8 fixed eagerness of help option but as the result its callback is now evaluated before our eager options. This is problematic for CLI because command registration is based on evaluation of eager options and default help option cannot now present commands registered by our plugins mechanism. To fix it, I added custom help option working almost the same as the default one. The only difference is that it's displayed as the first option, not the last option like the default one.
* Thanks to this change I was able to remove the pin to click 8.1.7 and I did it.
