### PR TITLE
Add support for --create-version in snow app publish

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -22,6 +22,7 @@ from textwrap import dedent
 from typing import Generator, Iterable, List, Optional, cast
 
 import typer
+from snowflake.cli._plugins.nativeapp.artifacts import VersionInfo
 from snowflake.cli._plugins.nativeapp.common_flags import (
     ForceOption,
     InteractiveOption,
@@ -538,13 +539,15 @@ class EventResult(ObjectResult, MessageResult):
 @with_project_definition()
 @force_project_definition_v2()
 def app_publish(
-    version: str = typer.Option(
+    version: Optional[str] = typer.Option(
+        default=None,
         show_default=False,
-        help="The version to publish to the release channel. The version must be created fist using 'snow app version create'.",
+        help="The version to publish to the provided release channel and release directive. Version is required to exist unless `--create-version` flag is used.",
     ),
-    patch: int = typer.Option(
+    patch: Optional[int] = typer.Option(
+        default=None,
         show_default=False,
-        help="The patch number under the given version. The patch number must be created first using 'snow app version create'.",
+        help="The patch number under the given version. This will be used when setting the release directive. Patch is required to exist unless `--create-version` flag is used.",
     ),
     channel: Optional[str] = typer.Option(
         "DEFAULT",
@@ -556,6 +559,23 @@ def app_publish(
     ),
     interactive: bool = InteractiveOption,
     force: Optional[bool] = ForceOption,
+    create_version: bool = typer.Option(
+        False,
+        "--create-version",
+        help="Create a new version or patch based on the provided `--version` and `--patch` values. Fallback to the manifest values if not provided.",
+        is_flag=True,
+    ),
+    from_stage: bool = typer.Option(
+        False,
+        "--from-stage",
+        help="When enabled, the Snowflake CLI creates a version from the current application package stage without syncing to the stage first. Can only be used with `--create-version` flag.",
+        is_flag=True,
+    ),
+    label: Optional[str] = typer.Option(
+        None,
+        "--label",
+        help="A label for the version that is displayed to consumers. Can only be used with `--create-version` flag.",
+    ),
     **options,
 ) -> CommandResult:
     """
@@ -567,7 +587,7 @@ def app_publish(
         project_root=cli_context.project_root,
     )
     package_id = options["package_entity_id"]
-    ws.perform_action(
+    version_info: VersionInfo = ws.perform_action(
         package_id,
         EntityActions.PUBLISH,
         version=version,
@@ -576,7 +596,10 @@ def app_publish(
         release_directive=directive,
         interactive=interactive,
         force=force,
+        create_version=create_version,
+        from_stage=from_stage,
+        label=label,
     )
     return MessageResult(
-        f"Version {version} and patch {patch} published to release directive {directive} of release channel {channel}."
+        f"Version {version_info.version_name} and patch {version_info.patch_number} published to release directive {directive} of release channel {channel}."
     )

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -589,87 +589,105 @@
    the new version and patch.                                                     
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | *  --version                                    TEXT     The version to      |
-  |                                                          publish to the      |
-  |                                                          release channel.    |
-  |                                                          The version must be |
-  |                                                          created fist using  |
-  |                                                          'snow app version   |
-  |                                                          create'.            |
-  |                                                          [required]          |
-  | *  --patch                                      INTEGER  The patch number    |
-  |                                                          under the given     |
-  |                                                          version. The patch  |
-  |                                                          number must be      |
-  |                                                          created first using |
-  |                                                          'snow app version   |
-  |                                                          create'.            |
-  |                                                          [required]          |
-  |    --channel                                    TEXT     The name of the     |
-  |                                                          release channel to  |
-  |                                                          publish to. If not  |
-  |                                                          provided, the       |
-  |                                                          default release     |
-  |                                                          channel is used.    |
-  |                                                          [default: DEFAULT]  |
-  |    --directive                                  TEXT     The name of the     |
-  |                                                          release directive   |
-  |                                                          to update with the  |
-  |                                                          specified version   |
-  |                                                          and patch. If not   |
-  |                                                          provided, the       |
-  |                                                          default release     |
-  |                                                          directive is used.  |
-  |                                                          [default: DEFAULT]  |
-  |    --interactive            --no-interactive             When enabled, this  |
-  |                                                          option displays     |
-  |                                                          prompts even if the |
-  |                                                          standard input and  |
-  |                                                          output are not      |
-  |                                                          terminal devices.   |
-  |                                                          Defaults to True in |
-  |                                                          an interactive      |
-  |                                                          shell environment,  |
-  |                                                          and False           |
-  |                                                          otherwise.          |
-  |    --force                                               When enabled, this  |
-  |                                                          option causes the   |
-  |                                                          command to          |
-  |                                                          implicitly approve  |
-  |                                                          any prompts that    |
-  |                                                          arise. You should   |
-  |                                                          enable this option  |
-  |                                                          if interactive mode |
-  |                                                          is not specified    |
-  |                                                          and if you want     |
-  |                                                          perform potentially |
-  |                                                          destructive         |
-  |                                                          actions. Defaults   |
-  |                                                          to unset.           |
-  |    --package-entity-id                          TEXT     The ID of the       |
-  |                                                          package entity on   |
-  |                                                          which to operate    |
-  |                                                          when                |
-  |                                                          definition_version  |
-  |                                                          is 2 or higher.     |
-  |    --app-entity-id                              TEXT     The ID of the       |
-  |                                                          application entity  |
-  |                                                          on which to operate |
-  |                                                          when                |
-  |                                                          definition_version  |
-  |                                                          is 2 or higher.     |
-  |    --project            -p                      TEXT     Path where          |
-  |                                                          Snowflake project   |
-  |                                                          resides. Defaults   |
-  |                                                          to current working  |
-  |                                                          directory.          |
-  |    --env                                        TEXT     String in format of |
-  |                                                          key=value.          |
-  |                                                          Overrides variables |
-  |                                                          from env section    |
-  |                                                          used for templates. |
-  |    --help               -h                               Show this message   |
-  |                                                          and exit.           |
+  | --version                                    TEXT     The version to publish |
+  |                                                       to the provided        |
+  |                                                       release channel and    |
+  |                                                       release directive.     |
+  |                                                       Version is required to |
+  |                                                       exist unless           |
+  |                                                       --create-version flag  |
+  |                                                       is used.               |
+  | --patch                                      INTEGER  The patch number under |
+  |                                                       the given version.     |
+  |                                                       This will be used when |
+  |                                                       setting the release    |
+  |                                                       directive. Patch is    |
+  |                                                       required to exist      |
+  |                                                       unless                 |
+  |                                                       --create-version flag  |
+  |                                                       is used.               |
+  | --channel                                    TEXT     The name of the        |
+  |                                                       release channel to     |
+  |                                                       publish to. If not     |
+  |                                                       provided, the default  |
+  |                                                       release channel is     |
+  |                                                       used.                  |
+  |                                                       [default: DEFAULT]     |
+  | --directive                                  TEXT     The name of the        |
+  |                                                       release directive to   |
+  |                                                       update with the        |
+  |                                                       specified version and  |
+  |                                                       patch. If not          |
+  |                                                       provided, the default  |
+  |                                                       release directive is   |
+  |                                                       used.                  |
+  |                                                       [default: DEFAULT]     |
+  | --interactive            --no-interactive             When enabled, this     |
+  |                                                       option displays        |
+  |                                                       prompts even if the    |
+  |                                                       standard input and     |
+  |                                                       output are not         |
+  |                                                       terminal devices.      |
+  |                                                       Defaults to True in an |
+  |                                                       interactive shell      |
+  |                                                       environment, and False |
+  |                                                       otherwise.             |
+  | --force                                               When enabled, this     |
+  |                                                       option causes the      |
+  |                                                       command to implicitly  |
+  |                                                       approve any prompts    |
+  |                                                       that arise. You should |
+  |                                                       enable this option if  |
+  |                                                       interactive mode is    |
+  |                                                       not specified and if   |
+  |                                                       you want perform       |
+  |                                                       potentially            |
+  |                                                       destructive actions.   |
+  |                                                       Defaults to unset.     |
+  | --create-version                                      Create a new version   |
+  |                                                       or patch based on the  |
+  |                                                       provided --version and |
+  |                                                       --patch values.        |
+  |                                                       Fallback to the        |
+  |                                                       manifest values if not |
+  |                                                       provided.              |
+  | --from-stage                                          When enabled, the      |
+  |                                                       Snowflake CLI creates  |
+  |                                                       a version from the     |
+  |                                                       current application    |
+  |                                                       package stage without  |
+  |                                                       syncing to the stage   |
+  |                                                       first. Can only be     |
+  |                                                       used with              |
+  |                                                       --create-version flag. |
+  | --label                                      TEXT     A label for the        |
+  |                                                       version that is        |
+  |                                                       displayed to           |
+  |                                                       consumers. Can only be |
+  |                                                       used with              |
+  |                                                       --create-version flag. |
+  |                                                       [default: None]        |
+  | --package-entity-id                          TEXT     The ID of the package  |
+  |                                                       entity on which to     |
+  |                                                       operate when           |
+  |                                                       definition_version is  |
+  |                                                       2 or higher.           |
+  | --app-entity-id                              TEXT     The ID of the          |
+  |                                                       application entity on  |
+  |                                                       which to operate when  |
+  |                                                       definition_version is  |
+  |                                                       2 or higher.           |
+  | --project            -p                      TEXT     Path where Snowflake   |
+  |                                                       project resides.       |
+  |                                                       Defaults to current    |
+  |                                                       working directory.     |
+  | --env                                        TEXT     String in format of    |
+  |                                                       key=value. Overrides   |
+  |                                                       variables from env     |
+  |                                                       section used for       |
+  |                                                       templates.             |
+  | --help               -h                               Show this message and  |
+  |                                                       exit.                  |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |

--- a/tests/nativeapp/test_application_package_entity.py
+++ b/tests/nativeapp/test_application_package_entity.py
@@ -22,6 +22,7 @@ import pytz
 import yaml
 from click import ClickException, UsageError
 from snowflake.cli._plugins.connection.util import UIParameter
+from snowflake.cli._plugins.nativeapp.artifacts import VersionInfo
 from snowflake.cli._plugins.nativeapp.constants import (
     LOOSE_FILES_MAGIC_VERSION,
     SPECIAL_COMMENT,
@@ -1902,3 +1903,228 @@ def test_given_only_one_version_referenced_by_existing_release_directive_when_pu
     remove_version_from_release_channel.assert_not_called()
     add_version_to_release_channel.assert_not_called()
     set_release_directive.assert_not_called()
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES)
+@mock.patch(SQL_FACADE_SHOW_VERSIONS)
+@mock.patch(SQL_FACADE_REMOVE_VERSION_FROM_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_ADD_VERSION_TO_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
+@mock.patch(f"{APP_PACKAGE_ENTITY}.action_version_create")
+def test_given_release_channel_and_version_when_publish_with_create_version_then_success(
+    action_version_create,
+    set_release_directive,
+    add_version_to_release_channel,
+    remove_version_from_release_channel,
+    show_versions,
+    show_release_directives,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    action_version_create.return_value = VersionInfo(
+        version_name="1.0", patch_number=1, label=None
+    )
+
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL", "versions": []}]
+    show_release_directives.return_value = [{"name": "TEST_DIRECTIVE"}]
+    show_versions.return_value = [{"version": "1.0", "patch": 1}]
+
+    application_package_entity.action_publish(
+        action_ctx=action_context,
+        release_channel="test_channel",
+        release_directive="test_directive",
+        version="x",
+        patch=33,
+        interactive=False,
+        force=False,
+        create_version=True,
+    )
+
+    action_version_create.assert_called_once_with(
+        action_ctx=action_context,
+        version="x",
+        patch=33,
+        label=None,
+        skip_git_check=True,
+        interactive=False,
+        force=False,
+        from_stage=False,
+    )
+
+    show_release_channels.assert_called_once_with(
+        pkg_model.fqn.name, pkg_model.meta.role
+    )
+    show_release_directives.assert_not_called()
+    show_versions.assert_called_once_with(pkg_model.fqn.name, pkg_model.meta.role)
+    add_version_to_release_channel.assert_called_once_with(
+        package_name=pkg_model.fqn.name,
+        role=pkg_model.meta.role,
+        release_channel="test_channel",
+        version="1.0",
+    )
+    remove_version_from_release_channel.assert_not_called()
+    set_release_directive.assert_called_once_with(
+        package_name=pkg_model.fqn.name,
+        role=pkg_model.meta.role,
+        version="1.0",
+        patch=1,
+        release_channel="test_channel",
+        release_directive="test_directive",
+        target_accounts=None,
+    )
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES)
+@mock.patch(SQL_FACADE_SHOW_VERSIONS)
+@mock.patch(SQL_FACADE_REMOVE_VERSION_FROM_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_ADD_VERSION_TO_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
+@mock.patch(f"{APP_PACKAGE_ENTITY}.action_version_create")
+def test_given_release_channel_and_no_version_when_publish_with_create_version_then_success(
+    action_version_create,
+    set_release_directive,
+    add_version_to_release_channel,
+    remove_version_from_release_channel,
+    show_versions,
+    show_release_directives,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    action_version_create.return_value = VersionInfo(
+        version_name="1.0", patch_number=1, label=None
+    )
+
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL", "versions": []}]
+    show_release_directives.return_value = [{"name": "TEST_DIRECTIVE"}]
+    show_versions.return_value = [{"version": "1.0", "patch": 1}]
+    application_package_entity.action_publish(
+        action_ctx=action_context,
+        release_channel="test_channel",
+        release_directive="test_directive",
+        version=None,
+        patch=None,
+        interactive=False,
+        force=False,
+        create_version=True,
+        from_stage=True,
+        label="some_label",
+    )
+
+    action_version_create.assert_called_once_with(
+        action_ctx=action_context,
+        version=None,
+        patch=None,
+        label="some_label",
+        skip_git_check=True,
+        interactive=False,
+        force=False,
+        from_stage=True,
+    )
+
+    show_release_channels.assert_called_once_with(
+        pkg_model.fqn.name, pkg_model.meta.role
+    )
+    show_release_directives.assert_not_called()
+    show_versions.assert_called_once_with(pkg_model.fqn.name, pkg_model.meta.role)
+    add_version_to_release_channel.assert_called_once_with(
+        package_name=pkg_model.fqn.name,
+        role=pkg_model.meta.role,
+        release_channel="test_channel",
+        version="1.0",
+    )
+    remove_version_from_release_channel.assert_not_called()
+    set_release_directive.assert_called_once_with(
+        package_name=pkg_model.fqn.name,
+        role=pkg_model.meta.role,
+        version="1.0",
+        patch=1,
+        release_channel="test_channel",
+        release_directive="test_directive",
+        target_accounts=None,
+    )
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES)
+@mock.patch(SQL_FACADE_SHOW_VERSIONS)
+@mock.patch(SQL_FACADE_REMOVE_VERSION_FROM_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_ADD_VERSION_TO_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
+@mock.patch(f"{APP_PACKAGE_ENTITY}.action_version_create")
+def test_given_release_channel_and_from_stage_without_create_version_when_publish_then_error(
+    action_version_create,
+    set_release_directive,
+    add_version_to_release_channel,
+    remove_version_from_release_channel,
+    show_versions,
+    show_release_directives,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    with pytest.raises(UsageError) as e:
+        application_package_entity.action_publish(
+            action_ctx=action_context,
+            release_channel="test_channel",
+            release_directive="test_directive",
+            version=None,
+            patch=None,
+            interactive=False,
+            force=False,
+            create_version=False,
+            from_stage=True,
+        )
+
+    assert (
+        str(e.value) == "--from-stage flag can only be used with --create-version flag."
+    )
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES)
+@mock.patch(SQL_FACADE_SHOW_VERSIONS)
+@mock.patch(SQL_FACADE_REMOVE_VERSION_FROM_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_ADD_VERSION_TO_RELEASE_CHANNEL)
+@mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
+@mock.patch(f"{APP_PACKAGE_ENTITY}.action_version_create")
+def test_given_release_channel_and_label_without_create_version_when_publish_then_error(
+    action_version_create,
+    set_release_directive,
+    add_version_to_release_channel,
+    remove_version_from_release_channel,
+    show_versions,
+    show_release_directives,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    with pytest.raises(UsageError) as e:
+        application_package_entity.action_publish(
+            action_ctx=action_context,
+            release_channel="test_channel",
+            release_directive="test_directive",
+            version=None,
+            patch=None,
+            interactive=False,
+            force=False,
+            create_version=False,
+            label="label",
+        )
+
+    assert str(e.value) == "--label can only be used with --create-version flag."

--- a/tests/nativeapp/test_version_create.py
+++ b/tests/nativeapp/test_version_create.py
@@ -195,7 +195,7 @@ def test_add_new_patch_auto(
                     dedent(
                         f"""\
                         alter application package app_pkg
-                            add patch  for version {version_identifier}
+                            add patch for version {version_identifier}
                             using @app_pkg.app_src.stage
                     """
                     ),


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Allow --create-version in `snow app publish` command.

If user wants us to create the version and patch that they provided, they need to pass `--create-version` flag. This will delegate to the version create command to handle the version creation and then continue with the regular publish workflow.

The same logic of falling back to the manifest will also apply in that case, which makes version and patch optional.
