### PR TITLE
Bug fixes and improvements to release directives and channels commands

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -333,7 +333,8 @@ class SnowflakeSQLFacade:
                     if err.errno == MAX_UNBOUND_VERSIONS_REACHED:
                         raise UserInputError(
                             f"Maximum unbound versions reached for application package {package_name}. "
-                            "Please drop the other unbound version first, or add it to a release channel."
+                            "Please drop other unbound versions first, or add them to a release channel. "
+                            "Use `snow app version list` to view all versions.",
                         ) from err
                     if err.errno == APPLICATION_PACKAGE_MAX_VERSIONS_HIT:
                         raise UserInputError(
@@ -414,6 +415,8 @@ class SnowflakeSQLFacade:
         )
 
         patch_query = f" {patch}" if patch is not None else ""
+
+        # No space between patch and patch{patch_query} to avoid extra space when patch is None
         add_patch_query = dedent(
             f"""\
                  alter application package {package_name}
@@ -669,6 +672,10 @@ class SnowflakeSQLFacade:
                         raise InsufficientPrivilegesError(
                             f"Insufficient privileges to show release directives for application package {package_name}",
                             role=role,
+                        ) from err
+                    if err.errno == DOES_NOT_EXIST_OR_NOT_AUTHORIZED:
+                        raise UserInputError(
+                            f"Application package {package_name} does not exist or you are not authorized to access it."
                         ) from err
                 handle_unclassified_error(
                     err,
@@ -1027,29 +1034,26 @@ class SnowflakeSQLFacade:
         @param [Optional] role: Role to switch to while running this script. Current role will be used if no role is passed in.
         """
 
-        if same_identifiers(release_directive, DEFAULT_DIRECTIVE) and target_accounts:
-            raise UserInputError(
-                "Default release directive does not support target accounts."
-            )
-
-        if (
-            not same_identifiers(release_directive, DEFAULT_DIRECTIVE)
-            and not target_accounts
-        ):
-            raise UserInputError(
-                "Non-default release directives require target accounts to be specified."
-            )
-
         package_name = to_identifier(package_name)
         release_channel = to_identifier(release_channel) if release_channel else None
         release_directive = to_identifier(release_directive)
         version = to_identifier(version)
 
-        release_directive_statement = (
-            "set default release directive"
-            if same_identifiers(release_directive, DEFAULT_DIRECTIVE)
-            else f"set release directive {release_directive}"
-        )
+        if same_identifiers(release_directive, DEFAULT_DIRECTIVE):
+            if target_accounts:
+                raise UserInputError(
+                    "Default release directive does not support target accounts."
+                )
+            release_directive_statement = "set default release directive"
+        else:
+            if target_accounts:
+                release_directive_statement = (
+                    f"set release directive {release_directive}"
+                )
+            else:
+                release_directive_statement = (
+                    f"modify release directive {release_directive}"
+                )
 
         release_channel_statement = (
             f"modify release channel {release_channel}" if release_channel else ""
@@ -1083,74 +1087,9 @@ class SnowflakeSQLFacade:
                         raise UserInputError(
                             f"Invalid account passed in.\n{str(err.msg)}"
                         ) from err
-                    _handle_release_directive_version_error(
-                        err,
-                        package_name=package_name,
-                        release_channel=release_channel,
-                        version=version,
-                        patch=patch,
-                    )
-                handle_unclassified_error(
-                    err,
-                    f"Failed to set release directive {release_directive} for application package {package_name}.",
-                )
-
-    def modify_release_directive(
-        self,
-        package_name: str,
-        release_directive: str,
-        release_channel: str | None,
-        version: str,
-        patch: int,
-        role: str | None = None,
-    ):
-        """
-        Modifies a release directive for an application package.
-        Release directive must already exist in the application package.
-        Accepts both default and non-default release directives.
-
-        @param package_name: Name of the application package to alter.
-        @param release_directive: Name of the release directive to modify.
-        @param release_channel: Name of the release channel to modify the release directive for.
-        @param version: Version to modify the release directive for.
-        @param patch: Patch number to modify the release directive for.
-        @param [Optional] role: Role to switch to while running this script. Current role will be used if no role is passed in.
-        """
-
-        package_name = to_identifier(package_name)
-        release_channel = to_identifier(release_channel) if release_channel else None
-        release_directive = to_identifier(release_directive)
-        version = to_identifier(version)
-
-        release_directive_statement = (
-            "modify default release directive"
-            if same_identifiers(release_directive, DEFAULT_DIRECTIVE)
-            else f"modify release directive {release_directive}"
-        )
-
-        release_channel_statement = (
-            f"modify release channel {release_channel}" if release_channel else ""
-        )
-
-        full_query = dedent(
-            _strip_empty_lines(
-                f"""\
-                    alter application package {package_name}
-                        {release_channel_statement}
-                        {release_directive_statement}
-                        version = {version} patch = {patch}
-                """
-            )
-        )
-
-        with self._use_role_optional(role):
-            try:
-                self._sql_executor.execute_query(full_query)
-            except Exception as err:
-                if isinstance(err, ProgrammingError):
                     if err.errno == RELEASE_DIRECTIVE_DOES_NOT_EXIST:
                         raise UserInputError(
-                            f"Release directive {release_directive} does not exist in application package {package_name}. Please create it first by specifying the target accounts."
+                            f"Release directive {release_directive} does not exist in application package {package_name}. Please create it first by specifying --target-accounts with the `snow app release-directive set` command."
                         ) from err
                     _handle_release_directive_version_error(
                         err,
@@ -1161,7 +1100,7 @@ class SnowflakeSQLFacade:
                     )
                 handle_unclassified_error(
                     err,
-                    f"Failed to modify release directive {release_directive} for application package {package_name}.",
+                    f"Failed to set release directive {release_directive} for application package {package_name}.",
                 )
 
     def unset_release_directive(

--- a/tests/nativeapp/__snapshots__/test_application_package_entity.ambr
+++ b/tests/nativeapp/__snapshots__/test_application_package_entity.ambr
@@ -7,7 +7,7 @@
 # ---
 # name: test_given_release_channel_with_no_target_account_or_version_then_show_all_accounts_in_snapshot
   '''
-  channel1
+  CHANNEL1
     Description: desc
     Versions: ()
     Created on: 2024-12-03 00:00:00.000000 UTC
@@ -18,7 +18,7 @@
 # ---
 # name: test_given_release_channels_with_a_selected_channel_to_filter_when_list_release_channels_then_returned_selected_channel
   '''
-  channel1
+  CHANNEL1
     Description: desc
     Versions: (v1, v2)
     Created on: 2024-12-03 00:00:00.000000 UTC
@@ -29,13 +29,13 @@
 # ---
 # name: test_given_release_channels_with_proper_values_when_list_release_channels_then_success
   '''
-  channel1
+  CHANNEL1
     Description: desc
     Versions: (v1, v2)
     Created on: 2024-12-03 00:00:00.000000 UTC
     Updated on: 2024-12-05 00:00:00.000000 UTC
     Target accounts: (org1.acc1, org2.acc2)
-  channel2
+  CHANNEL2
     Description: desc2
     Versions: (v3)
     Created on: 2024-12-03 00:00:00.000000 UTC

--- a/tests/nativeapp/test_application_package_entity.py
+++ b/tests/nativeapp/test_application_package_entity.py
@@ -42,7 +42,6 @@ from tests.nativeapp.utils import (
     SQL_FACADE_ADD_ACCOUNTS_TO_RELEASE_CHANNEL,
     SQL_FACADE_ADD_VERSION_TO_RELEASE_CHANNEL,
     SQL_FACADE_GET_UI_PARAMETER,
-    SQL_FACADE_MODIFY_RELEASE_DIRECTIVE,
     SQL_FACADE_REMOVE_ACCOUNTS_FROM_RELEASE_CHANNEL,
     SQL_FACADE_REMOVE_VERSION_FROM_RELEASE_CHANNEL,
     SQL_FACADE_SET_RELEASE_DIRECTIVE,
@@ -234,7 +233,7 @@ def test_given_channels_disabled_and_no_directives_when_release_directive_list_t
 
 
 @mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[])
-@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "my_directive"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "MY_DIRECTIVE"}])
 def test_given_channels_disabled_and_directives_present_when_release_directive_list_then_success(
     show_release_directives,
     show_release_channels,
@@ -249,7 +248,7 @@ def test_given_channels_disabled_and_directives_present_when_release_directive_l
         action_ctx=action_context, release_channel=None, like="%%"
     )
 
-    assert result == [{"name": "my_directive"}]
+    assert result == [{"name": "MY_DIRECTIVE"}]
 
     show_release_directives.assert_called_once_with(
         package_name=pkg_model.fqn.name,
@@ -286,8 +285,8 @@ def test_given_multiple_directives_and_like_pattern_when_release_directive_list_
     )
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "my_channel"}])
-@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "my_directive"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "MY_CHANNEL"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "MY_DIRECTIVE"}])
 def test_given_channels_enabled_and_no_channel_specified_when_release_directive_list_then_success(
     show_release_directives,
     show_release_channels,
@@ -302,7 +301,7 @@ def test_given_channels_enabled_and_no_channel_specified_when_release_directive_
         action_ctx=action_context, release_channel=None, like="%%"
     )
 
-    assert result == [{"name": "my_directive"}]
+    assert result == [{"name": "MY_DIRECTIVE"}]
 
     show_release_directives.assert_called_once_with(
         package_name=pkg_model.fqn.name,
@@ -368,8 +367,8 @@ def test_given_channels_disabled_and_non_default_channel_selected_when_release_d
     show_release_directives.assert_not_called()
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "my_channel"}])
-@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "my_directive"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "MY_CHANNEL"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "MY_DIRECTIVE"}])
 def test_given_channels_enabled_and_invalid_channel_selected_when_release_directive_list_then_error(
     show_release_directives,
     show_release_channels,
@@ -387,7 +386,7 @@ def test_given_channels_enabled_and_invalid_channel_selected_when_release_direct
 
     assert (
         str(e.value)
-        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (my_channel)."
+        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (MY_CHANNEL)."
     )
     show_release_channels.assert_called_once_with(
         pkg_model.fqn.name, pkg_model.meta.role
@@ -396,8 +395,8 @@ def test_given_channels_enabled_and_invalid_channel_selected_when_release_direct
     show_release_directives.assert_not_called()
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "my_channel"}])
-@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "my_directive"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "MY_CHANNEL"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_DIRECTIVES, return_value=[{"name": "MY_DIRECTIVE"}])
 def test_given_channels_enabled_and_valid_channel_selected_when_release_directive_list_then_success(
     show_release_directives,
     show_release_channels,
@@ -412,7 +411,7 @@ def test_given_channels_enabled_and_valid_channel_selected_when_release_directiv
         action_ctx=action_context, release_channel="my_channel", like="%%"
     )
 
-    assert result == [{"name": "my_directive"}]
+    assert result == [{"name": "MY_DIRECTIVE"}]
 
     show_release_channels.assert_called_once_with(
         pkg_model.fqn.name, pkg_model.meta.role
@@ -425,7 +424,7 @@ def test_given_channels_enabled_and_valid_channel_selected_when_release_directiv
     )
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "test_channel"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "TEST_CHANNEL"}])
 @mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
 def test_given_named_directive_with_accounts_when_release_directive_set_then_success(
     set_release_directive,
@@ -460,7 +459,7 @@ def test_given_named_directive_with_accounts_when_release_directive_set_then_suc
     )
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "test_channel"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "TEST_CHANNEL"}])
 @mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
 def test_given_default_directive_with_no_accounts_when_release_directive_set_then_success(
     set_release_directive,
@@ -563,10 +562,10 @@ def test_given_no_channels_with_non_default_channel_used_when_release_directive_
     set_release_directive.assert_not_called()
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "test_channel"}])
-@mock.patch(SQL_FACADE_MODIFY_RELEASE_DIRECTIVE)
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "TEST_CHANNEL"}])
+@mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
 def test_given_named_directive_with_no_accounts_when_release_directive_set_then_modify_existing_directive(
-    modify_release_directive,
+    set_release_directive,
     show_release_channels,
     application_package_entity,
     action_context,
@@ -587,17 +586,18 @@ def test_given_named_directive_with_no_accounts_when_release_directive_set_then_
         pkg_model.fqn.name, pkg_model.meta.role
     )
 
-    modify_release_directive.assert_called_once_with(
+    set_release_directive.assert_called_once_with(
         package_name=pkg_model.fqn.name,
         role=pkg_model.meta.role,
         version="1.0",
         patch=2,
         release_channel="test_channel",
         release_directive="directive",
+        target_accounts=None,
     )
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "test_channel"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "TEST_CHANNEL"}])
 @mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
 def test_given_default_directive_with_accounts_when_release_directive_set_then_error(
     set_release_directive,
@@ -627,7 +627,7 @@ def test_given_default_directive_with_accounts_when_release_directive_set_then_e
 
 
 # test with target_account not in org.account format:
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "test_channel"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "TEST_CHANNEL"}])
 @mock.patch(SQL_FACADE_SET_RELEASE_DIRECTIVE)
 @pytest.mark.parametrize(
     "account_name", ["org1", "org1.", ".account1", "org1.acc.ount1"]
@@ -663,7 +663,7 @@ def test_given_invalid_account_names_when_release_directive_set_then_error(
 
 @mock.patch(
     SQL_FACADE_SHOW_RELEASE_CHANNELS,
-    return_value=[{"name": "my_channel"}, {"name": "default"}],
+    return_value=[{"name": "MY_CHANNEL"}, {"name": "DEFAULT"}],
 )
 @mock.patch(SQL_FACADE_UNSET_RELEASE_DIRECTIVE)
 def test_given_channels_enabled_and_default_channel_selected_when_release_directive_unset_then_success(
@@ -693,7 +693,7 @@ def test_given_channels_enabled_and_default_channel_selected_when_release_direct
     )
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "my_channel"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "MY_CHANNEL"}])
 @mock.patch(SQL_FACADE_UNSET_RELEASE_DIRECTIVE)
 def test_given_channels_enabled_and_non_default_channel_selected_when_release_directive_unset_then_success(
     unset_release_directive,
@@ -781,7 +781,7 @@ def test_given_channels_disabled_and_non_default_channel_selected_when_release_d
     unset_release_directive.assert_not_called()
 
 
-@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "my_channel"}])
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS, return_value=[{"name": "MY_CHANNEL"}])
 @mock.patch(SQL_FACADE_UNSET_RELEASE_DIRECTIVE)
 def test_given_channels_enabled_and_non_existing_channel_selected_when_release_directive_unset_then_error(
     unset_release_directive,
@@ -801,7 +801,7 @@ def test_given_channels_enabled_and_non_existing_channel_selected_when_release_d
 
     assert (
         str(e.value)
-        == f"Release channel non_existing is not available in application package {pkg_model.fqn.name}. Available release channels are: (my_channel)."
+        == f"Release channel non_existing is not available in application package {pkg_model.fqn.name}. Available release channels are: (MY_CHANNEL)."
     )
 
     show_release_channels.assert_called_once_with(
@@ -863,7 +863,7 @@ def test_given_release_channels_with_proper_values_when_list_release_channels_th
 
     release_channels = [
         {
-            "name": "channel1",
+            "name": "CHANNEL1",
             "description": "desc",
             "created_on": created_on_mock,
             "updated_on": updated_on_mock,
@@ -871,7 +871,7 @@ def test_given_release_channels_with_proper_values_when_list_release_channels_th
             "targets": {"accounts": ["org1.acc1", "org2.acc2"]},
         },
         {
-            "name": "channel2",
+            "name": "CHANNEL2",
             "description": "desc2",
             "created_on": created_on_mock,
             "updated_on": updated_on_mock,
@@ -914,7 +914,7 @@ def test_given_release_channel_with_no_target_account_or_version_then_show_all_a
 
     release_channels = [
         {
-            "name": "channel1",
+            "name": "CHANNEL1",
             "description": "desc",
             "created_on": created_on_mock,
             "updated_on": updated_on_mock,
@@ -981,7 +981,7 @@ def test_given_release_channels_with_a_selected_channel_to_filter_when_list_rele
     )
 
     test_channel_1 = {
-        "name": "channel1",
+        "name": "CHANNEL1",
         "description": "desc",
         "created_on": created_on_mock,
         "updated_on": updated_on_mock,
@@ -990,7 +990,7 @@ def test_given_release_channels_with_a_selected_channel_to_filter_when_list_rele
     }
 
     test_channel_2 = {
-        "name": "channel2",
+        "name": "CHANNEL2",
         "description": "desc2",
         "created_on": created_on_mock,
         "updated_on": updated_on_mock,
@@ -1021,7 +1021,7 @@ def test_given_release_channel_and_accounts_when_add_accounts_to_release_channel
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     application_package_entity.action_release_channel_add_accounts(
         action_ctx=action_context,
@@ -1076,7 +1076,7 @@ def test_given_invalid_release_channel_when_add_accounts_to_release_channel_then
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     with pytest.raises(UsageError) as e:
         application_package_entity.action_release_channel_add_accounts(
@@ -1087,7 +1087,7 @@ def test_given_invalid_release_channel_when_add_accounts_to_release_channel_then
 
     assert (
         str(e.value)
-        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (test_channel)."
+        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (TEST_CHANNEL)."
     )
 
     add_accounts_to_release_channel.assert_not_called()
@@ -1108,7 +1108,7 @@ def test_given_invalid_account_names_when_add_accounts_to_release_channel_then_e
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     with pytest.raises(ClickException) as e:
         application_package_entity.action_release_channel_add_accounts(
@@ -1136,7 +1136,7 @@ def test_given_release_channel_and_accounts_when_remove_accounts_from_release_ch
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     application_package_entity.action_release_channel_remove_accounts(
         action_ctx=action_context,
@@ -1191,7 +1191,7 @@ def test_given_invalid_release_channel_when_remove_accounts_from_release_channel
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     with pytest.raises(UsageError) as e:
         application_package_entity.action_release_channel_remove_accounts(
@@ -1202,7 +1202,7 @@ def test_given_invalid_release_channel_when_remove_accounts_from_release_channel
 
     assert (
         str(e.value)
-        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (test_channel)."
+        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (TEST_CHANNEL)."
     )
 
     remove_accounts_from_release_channel.assert_not_called()
@@ -1223,7 +1223,7 @@ def test_given_invalid_account_names_when_remove_accounts_from_release_channel_t
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     with pytest.raises(ClickException) as e:
         application_package_entity.action_release_channel_remove_accounts(
@@ -1251,7 +1251,7 @@ def test_given_release_channel_and_version_when_release_channel_add_version_then
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     application_package_entity.action_release_channel_add_version(
         action_ctx=action_context,
@@ -1310,7 +1310,7 @@ def test_given_invalid_release_channel_when_release_channel_add_version_then_err
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     with pytest.raises(UsageError) as e:
         application_package_entity.action_release_channel_add_version(
@@ -1321,7 +1321,7 @@ def test_given_invalid_release_channel_when_release_channel_add_version_then_err
 
     assert (
         str(e.value)
-        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (test_channel)."
+        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (TEST_CHANNEL)."
     )
 
     add_version_to_release_channel.assert_not_called()
@@ -1338,7 +1338,7 @@ def test_given_release_channel_and_version_when_release_channel_remove_version_t
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     application_package_entity.action_release_channel_remove_version(
         action_ctx=action_context,
@@ -1397,7 +1397,7 @@ def test_given_invalid_release_channel_when_release_channel_remove_version_then_
     pkg_model = application_package_entity._entity_model  # noqa SLF001
     pkg_model.meta.role = "package_role"
 
-    show_release_channels.return_value = [{"name": "test_channel"}]
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
 
     with pytest.raises(UsageError) as e:
         application_package_entity.action_release_channel_remove_version(
@@ -1408,7 +1408,7 @@ def test_given_invalid_release_channel_when_release_channel_remove_version_then_
 
     assert (
         str(e.value)
-        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (test_channel)."
+        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (TEST_CHANNEL)."
     )
 
     remove_version_from_release_channel.assert_not_called()
@@ -1653,7 +1653,7 @@ def test_given_non_existing_version_when_publish_then_error(
 
     assert (
         str(e.value)
-        == f"Version 1.0 does not exist in application package {pkg_model.fqn.name}."
+        == f"Version 1.0 does not exist in application package {pkg_model.fqn.name}. Use --create-version flag to create a new version."
     )
 
     show_versions.assert_called_once_with(pkg_model.fqn.name, pkg_model.meta.role)
@@ -1698,7 +1698,7 @@ def test_given_non_existing_patch_when_publish_then_error(
 
     assert (
         str(e.value)
-        == f"Patch 1 does not exist for version 1.0 in application package {pkg_model.fqn.name}."
+        == f"Patch 1 does not exist for version 1.0 in application package {pkg_model.fqn.name}. Use --create-version flag to add a new patch."
     )
 
     show_versions.assert_called_once_with(pkg_model.fqn.name, pkg_model.meta.role)

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -2253,7 +2253,7 @@ def test_run_app_from_release_directive_with_channel(
         "comment": SPECIAL_COMMENT,
         "owner": "app_role",
     }
-    mock_show_release_channels.return_value = [{"name": "my_channel"}]
+    mock_show_release_channels.return_value = [{"name": "MY_CHANNEL"}]
     side_effects, expected = mock_execute_helper(
         [
             (

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -91,7 +91,6 @@ SQL_FACADE_ALTER_APP_PKG_PROPERTIES = (
 SQL_FACADE_CREATE_APP_PKG = f"{SQL_FACADE}.create_application_package"
 SQL_FACADE_SHOW_RELEASE_DIRECTIVES = f"{SQL_FACADE}.show_release_directives"
 SQL_FACADE_SET_RELEASE_DIRECTIVE = f"{SQL_FACADE}.set_release_directive"
-SQL_FACADE_MODIFY_RELEASE_DIRECTIVE = f"{SQL_FACADE}.modify_release_directive"
 SQL_FACADE_UNSET_RELEASE_DIRECTIVE = f"{SQL_FACADE}.unset_release_directive"
 SQL_FACADE_SHOW_RELEASE_CHANNELS = f"{SQL_FACADE}.show_release_channels"
 SQL_FACADE_DROP_VERSION = f"{SQL_FACADE}.drop_version_from_package"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
- Fix messaging for errors for release channels/directives features.
- same_identifier() replaced with unquote_identifier() check. The reason is that identifiers in SnowCLI are different than what is stored in the backend. The backend never uses quotes in its output. It uses capitalization to indicate that.

For example:
- `abc` locally is the same as `ABC` on the server.
- `"abc"` locally is the same as `abc` on the server but different from `ABC` on the server.
- `a.bc` locally is the same as `a.bc` on the server, because it contains special characters and SnowCLI automatically quotes it.

Instead of `same_identifier(local, remote_identifier)`, the check should change to:
`unquote_identifier(local) == remote_identifier`


