### PR TITLE
Fix incorrect commands registration in test of docs generation

### DIFF
--- a/tests/test_docs_generation_output.py
+++ b/tests/test_docs_generation_output.py
@@ -132,7 +132,7 @@ def test_all_commands_have_generated_files(runner, temp_dir):
     runner.invoke(["--docs"])
 
     # invoke help command to populate app context (plugins registration)
-    runner.invoke(["--help"])
+    runner.invoke([])
 
     ctx = app_context_holder.app_context
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Fixed flaky test of docs generation.
* `app_context_holder.app_context = click.get_current_context()` from `cli_app.py` is not invoked when `snow --help` is used because `--help` is eager option causing CLI exit before the line called. As the result side effects from previous tests were still visible in `app_context_holder.app_context` and caused issues in `test_docs_generation_output` tests. I changed `snow --help` to just `snow`.
* This is only a patch which does not resolve the root cause of issue - command registration state shared by tests. This will be improved in SNOW-1747456.
