### PR TITLE
Fix failure to SQL scripts when there is a comment at the end of the file

### DIFF
--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -92,7 +92,11 @@ class BaseSqlExecutor:
 
     def execute_queries(self, queries: str, **kwargs):
         """Executes multiple SQL queries (passed as one string) and returns the results as a list"""
-        return list(self._execute_string(dedent(queries), **kwargs))
+
+        # Without remove_comments=True, connectors might throw an error if there is a comment at the end of the file
+        return list(
+            self._execute_string(dedent(queries), remove_comments=True, **kwargs)
+        )
 
 
 class SqlExecutor(BaseSqlExecutor):

--- a/tests_integration/test_data/projects/napp_application_post_deploy_v1/scripts/app_post_deploy2.sql
+++ b/tests_integration/test_data/projects/napp_application_post_deploy_v1/scripts/app_post_deploy2.sql
@@ -1,3 +1,4 @@
 -- app post-deploy script (2/2)
 
 INSERT INTO &{ ctx.env.schema }.post_deploy_log VALUES('app-post-deploy-part-2');
+-- comment at the end of the file to make sure no Empty SQL statement error

--- a/tests_integration/test_data/projects/napp_application_post_deploy_v1/scripts/package_post_deploy2.sql
+++ b/tests_integration/test_data/projects/napp_application_post_deploy_v1/scripts/package_post_deploy2.sql
@@ -1,3 +1,4 @@
 -- app post-deploy script (2/2)
 
 INSERT INTO &{ ctx.env.pkg_schema }.post_deploy_log VALUES('package-post-deploy-part-2');
+-- comment at the end of the file to make sure no Empty SQL statement error

--- a/tests_integration/test_data/projects/napp_application_post_deploy_v2/scripts/app_post_deploy2.sql
+++ b/tests_integration/test_data/projects/napp_application_post_deploy_v2/scripts/app_post_deploy2.sql
@@ -1,3 +1,4 @@
 -- app post-deploy script (2/2)
 
 INSERT INTO &{ ctx.env.schema }.post_deploy_log VALUES('app-post-deploy-part-2');
+-- comment at the end of the file to make sure no Empty SQL statement error

--- a/tests_integration/test_data/projects/napp_application_post_deploy_v2/scripts/package_post_deploy2.sql
+++ b/tests_integration/test_data/projects/napp_application_post_deploy_v2/scripts/package_post_deploy2.sql
@@ -1,3 +1,4 @@
 -- app post-deploy script (2/2)
 
 INSERT INTO &{ ctx.env.pkg_schema }.post_deploy_log VALUES('package-post-deploy-part-2');
+-- comment at the end of the file to make sure no Empty SQL statement error


### PR DESCRIPTION

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix failure to SQL scripts when there is a comment at the end of the file.
- Before the fix, any SQL script with comment at the end of the file will result in "Empty SQL Statement" error.
- After the fix, error should disappear

Updated integration tests to cover this usecase.
Error comes from Snowflake backend and is caused by a library, so the only way to cover this usecase is through integration tests (not unit tests)