### PR TITLE
Add commands to set-accounts for release channels (add-accounts/remove-accounts already exist)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,7 @@
 * Added `--replace` flag to `snow spcs compute-pool create` command.
 * Added command `snow app release-directive add-accounts` and `snow app release-directive remove-accounts`
 * Added command `snow spcs compute-pool deploy`.
+* Added `snow app release-channel set-accounts` command to set accounts for release channel.
 * Added support for Mac Os x86_64 architecture.
 * Added image repository model in snowflake.yml.
 * Added `snow spcs service deploy` command.

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -972,6 +972,31 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
             role=self.role,
         )
 
+    def action_release_channel_set_accounts(
+        self,
+        action_ctx: ActionContext,
+        release_channel: str,
+        target_accounts: list[str],
+        *args,
+        **kwargs,
+    ):
+        """
+        Sets target accounts for a release channel.
+        """
+
+        if not target_accounts:
+            raise ClickException("No target accounts provided.")
+
+        self.validate_release_channel(release_channel)
+        self._validate_target_accounts(target_accounts)
+
+        get_snowflake_facade().set_accounts_for_release_channel(
+            package_name=self.name,
+            release_channel=release_channel,
+            target_accounts=target_accounts,
+            role=self.role,
+        )
+
     def action_release_channel_add_version(
         self,
         action_ctx: ActionContext,

--- a/src/snowflake/cli/_plugins/nativeapp/release_channel/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/release_channel/commands.py
@@ -140,6 +140,40 @@ def release_channel_remove_accounts(
     return MessageResult("Successfully removed accounts from the release channel.")
 
 
+@with_project_definition()
+@app.command("set-accounts", requires_connection=True)
+@force_project_definition_v2()
+def release_channel_set_accounts(
+    channel: str = typer.Argument(
+        show_default=False,
+        help="The release channel to set accounts for.",
+    ),
+    target_accounts: str = typer.Option(
+        show_default=False,
+        help="The accounts to set for the release channel. Format has to be `org1.account1,org2.account2`.",
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Sets accounts for a release channel.
+    """
+
+    cli_context = get_cli_context()
+    ws = WorkspaceManager(
+        project_definition=cli_context.project_definition,
+        project_root=cli_context.project_root,
+    )
+    package_id = options["package_entity_id"]
+    ws.perform_action(
+        package_id,
+        EntityActions.RELEASE_CHANNEL_SET_ACCOUNTS,
+        release_channel=channel,
+        target_accounts=target_accounts.split(","),
+    )
+
+    return MessageResult("Successfully set accounts for the release channel.")
+
+
 @app.command("add-version", requires_connection=True)
 @with_project_definition()
 @force_project_definition_v2()

--- a/src/snowflake/cli/api/entities/common.py
+++ b/src/snowflake/cli/api/entities/common.py
@@ -32,6 +32,7 @@ class EntityActions(str, Enum):
     RELEASE_CHANNEL_LIST = "action_release_channel_list"
     RELEASE_CHANNEL_ADD_ACCOUNTS = "action_release_channel_add_accounts"
     RELEASE_CHANNEL_REMOVE_ACCOUNTS = "action_release_channel_remove_accounts"
+    RELEASE_CHANNEL_SET_ACCOUNTS = "action_release_channel_set_accounts"
     RELEASE_CHANNEL_ADD_VERSION = "action_release_channel_add_version"
     RELEASE_CHANNEL_REMOVE_VERSION = "action_release_channel_remove_version"
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -1278,6 +1278,105 @@
   
   '''
 # ---
+# name: test_help_messages[app.release-channel.set-accounts]
+  '''
+                                                                                  
+   Usage: default app release-channel set-accounts [OPTIONS] CHANNEL              
+                                                                                  
+   Sets accounts for a release channel.                                           
+                                                                                  
+  +- Arguments ------------------------------------------------------------------+
+  | *    channel      TEXT  The release channel to set accounts for.             |
+  |                         [required]                                           |
+  +------------------------------------------------------------------------------+
+  +- Options --------------------------------------------------------------------+
+  | *  --target-accounts            TEXT  The accounts to set for the release    |
+  |                                       channel. Format has to be              |
+  |                                       org1.account1,org2.account2.           |
+  |                                       [required]                             |
+  |    --package-entity-id          TEXT  The ID of the package entity on which  |
+  |                                       to operate when definition_version is  |
+  |                                       2 or higher.                           |
+  |    --app-entity-id              TEXT  The ID of the application entity on    |
+  |                                       which to operate when                  |
+  |                                       definition_version is 2 or higher.     |
+  |    --help               -h            Show this message and exit.            |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment     -c      TEXT     Name of the connection, as   |
+  |                                                 defined in your config.toml  |
+  |                                                 file. Default: default.      |
+  | --host                                 TEXT     Host address for the         |
+  |                                                 connection. Overrides the    |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --port                                 INTEGER  Port for the connection.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --account,--accountname                TEXT     Name assigned to your        |
+  |                                                 Snowflake account. Overrides |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --user,--username                      TEXT     Username to connect to       |
+  |                                                 Snowflake. Overrides the     |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --password                             TEXT     Snowflake password.          |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --authenticator                        TEXT     Snowflake authenticator.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --private-key-file,--private…          TEXT     Snowflake private key file   |
+  |                                                 path. Overrides the value    |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --token-file-path                      TEXT     Path to file with an OAuth   |
+  |                                                 token that should be used    |
+  |                                                 when connecting to Snowflake |
+  | --database,--dbname                    TEXT     Database to use. Overrides   |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --schema,--schemaname                  TEXT     Database schema to use.      |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --role,--rolename                      TEXT     Role to use. Overrides the   |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --warehouse                            TEXT     Warehouse to use. Overrides  |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --temporary-connection         -x               Uses connection defined with |
+  |                                                 command line parameters,     |
+  |                                                 instead of one defined in    |
+  |                                                 config                       |
+  | --mfa-passcode                         TEXT     Token to use for             |
+  |                                                 multi-factor authentication  |
+  |                                                 (MFA)                        |
+  | --enable-diag                                   Run Python connector         |
+  |                                                 diagnostic test              |
+  | --diag-log-path                        TEXT     Diagnostic report path       |
+  | --diag-allowlist-path                  TEXT     Diagnostic report path to    |
+  |                                                 optional allowlist           |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format           [TABLE|JSON]  Specifies the output format.                |
+  |                                  [default: TABLE]                            |
+  | --verbose  -v                    Displays log entries for log levels info    |
+  |                                  and higher.                                 |
+  | --debug                          Displays log entries for log levels debug   |
+  |                                  and higher; debug logs contain additional   |
+  |                                  information.                                |
+  | --silent                         Turns off intermediate output to console.   |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[app.release-channel]
   '''
                                                                                   
@@ -1295,6 +1394,7 @@
   |                   package.                                                   |
   | remove-accounts   Removes accounts from a release channel.                   |
   | remove-version    Removes a version from a release channel.                  |
+  | set-accounts      Sets accounts for a release channel.                       |
   +------------------------------------------------------------------------------+
   
   
@@ -11269,6 +11369,7 @@
   |                   package.                                                   |
   | remove-accounts   Removes accounts from a release channel.                   |
   | remove-version    Removes a version from a release channel.                  |
+  | set-accounts      Sets accounts for a release channel.                       |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/nativeapp/test_application_package_entity.py
+++ b/tests/nativeapp/test_application_package_entity.py
@@ -52,6 +52,7 @@ from tests.nativeapp.utils import (
     SQL_FACADE_REMOVE_ACCOUNTS_FROM_RELEASE_CHANNEL,
     SQL_FACADE_REMOVE_ACCOUNTS_FROM_RELEASE_DIRECTIVE,
     SQL_FACADE_REMOVE_VERSION_FROM_RELEASE_CHANNEL,
+    SQL_FACADE_SET_ACCOUNTS_FOR_RELEASE_CHANNEL,
     SQL_FACADE_SET_RELEASE_DIRECTIVE,
     SQL_FACADE_SHOW_RELEASE_CHANNELS,
     SQL_FACADE_SHOW_RELEASE_DIRECTIVES,
@@ -1579,6 +1580,121 @@ def test_given_invalid_account_names_when_remove_accounts_from_release_channel_t
     )
 
     remove_accounts_from_release_channel.assert_not_called()
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SET_ACCOUNTS_FOR_RELEASE_CHANNEL)
+def test_given_release_channel_and_accounts_when_set_accounts_for_release_channel_then_success(
+    set_accounts_for_release_channel,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
+
+    application_package_entity.action_release_channel_set_accounts(
+        action_ctx=action_context,
+        release_channel="test_channel",
+        target_accounts=["org1.acc1", "org2.acc2"],
+    )
+
+    set_accounts_for_release_channel.assert_called_once_with(
+        package_name=pkg_model.fqn.name,
+        role=pkg_model.meta.role,
+        release_channel="test_channel",
+        target_accounts=["org1.acc1", "org2.acc2"],
+    )
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SET_ACCOUNTS_FOR_RELEASE_CHANNEL)
+def test_given_release_channels_disabled_when_set_accounts_for_release_channel_then_error(
+    set_accounts_for_release_channel,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    show_release_channels.return_value = []
+
+    with pytest.raises(UsageError) as e:
+        application_package_entity.action_release_channel_set_accounts(
+            action_ctx=action_context,
+            release_channel="invalid_channel",
+            target_accounts=["org1.acc1", "org2.acc2"],
+        )
+
+    assert (
+        str(e.value)
+        == f"Release channels are not enabled for application package {pkg_model.fqn.name}."
+    )
+
+    set_accounts_for_release_channel.assert_not_called()
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SET_ACCOUNTS_FOR_RELEASE_CHANNEL)
+def test_given_invalid_release_channel_when_set_accounts_for_release_channel_then_error(
+    set_accounts_for_release_channel,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
+
+    with pytest.raises(UsageError) as e:
+        application_package_entity.action_release_channel_set_accounts(
+            action_ctx=action_context,
+            release_channel="invalid_channel",
+            target_accounts=["org1.acc1", "org2.acc2"],
+        )
+
+    assert (
+        str(e.value)
+        == f"Release channel invalid_channel is not available in application package {pkg_model.fqn.name}. Available release channels are: (TEST_CHANNEL)."
+    )
+
+    set_accounts_for_release_channel.assert_not_called()
+
+
+@mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)
+@mock.patch(SQL_FACADE_SET_ACCOUNTS_FOR_RELEASE_CHANNEL)
+@pytest.mark.parametrize(
+    "account_name", ["org1", "org1.", ".account1", "org1.acc.ount1"]
+)
+def test_given_invalid_account_names_when_set_accounts_for_release_channel_then_error(
+    set_accounts_for_release_channel,
+    show_release_channels,
+    application_package_entity,
+    action_context,
+    account_name,
+):
+    pkg_model = application_package_entity._entity_model  # noqa SLF001
+    pkg_model.meta.role = "package_role"
+
+    show_release_channels.return_value = [{"name": "TEST_CHANNEL"}]
+
+    with pytest.raises(ClickException) as e:
+        application_package_entity.action_release_channel_set_accounts(
+            action_ctx=action_context,
+            release_channel="test_channel",
+            target_accounts=[account_name],
+        )
+
+    assert (
+        str(e.value)
+        == f"Target account {account_name} is not in a valid format. Make sure you provide the target account in the format 'org.account'."
+    )
+
+    set_accounts_for_release_channel.assert_not_called()
 
 
 @mock.patch(SQL_FACADE_SHOW_RELEASE_CHANNELS)

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -108,6 +108,9 @@ SQL_FACADE_ADD_ACCOUNTS_TO_RELEASE_CHANNEL = (
 SQL_FACADE_REMOVE_ACCOUNTS_FROM_RELEASE_CHANNEL = (
     f"{SQL_FACADE}.remove_accounts_from_release_channel"
 )
+SQL_FACADE_SET_ACCOUNTS_FOR_RELEASE_CHANNEL = (
+    f"{SQL_FACADE}.set_accounts_for_release_channel"
+)
 SQL_FACADE_ADD_VERSION_TO_RELEASE_CHANNEL = (
     f"{SQL_FACADE}.add_version_to_release_channel"
 )

--- a/tests_integration/nativeapp/test_release_channels.py
+++ b/tests_integration/nativeapp/test_release_channels.py
@@ -80,7 +80,7 @@ def test_release_channels_disabled_to_enabled_switch(
     return_value=True,
 )
 @pytest.mark.integration
-def test_add_accounts_and_remove_accounts_from_release_channels(
+def test_add_accounts_and_remove_accounts_and_set_accounts_from_release_channels(
     get_value_mock, runner, nativeapp_teardown, nativeapp_basic_pdf
 ):
 
@@ -140,6 +140,29 @@ def test_add_accounts_and_remove_accounts_from_release_channels(
         assert result.exit_code == 0
         alpha_channel = result.json[0]
         assert alpha_channel["targets"].get("accounts") == []
+
+        # set accounts for the release channel
+        result = runner.invoke_with_connection(
+            [
+                "app",
+                "release-channel",
+                "set-accounts",
+                "ALPHA",
+                "--target-accounts",
+                ",".join(target_accounts),
+            ]
+        )
+        assert result.exit_code == 0
+
+        # verify accounts are in the release channel
+        result = runner.invoke_with_connection_json(
+            ["app", "release-channel", "list", "ALPHA"]
+        )
+        assert result.exit_code == 0
+        alpha_channel = result.json[0]
+        assert sorted(alpha_channel["targets"].get("accounts")) == sorted(
+            unique_accounts
+        )
 
 
 @mock.patch(


### PR DESCRIPTION

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Add `snow app release-channel set-accounts` command.
We already have `snow app release-channel add-accounts` and `remove-accounts` commands. This one provides another option to set accounts by replacing the whole list of accounts instead of adding or removing.

