### PR TITLE
Fix date handling in sql cmd when using json

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Fix handling of date types in `snow sql` command when using JSON for output format
 
 
 # v3.4.0

--- a/src/snowflake/cli/_app/printing.py
+++ b/src/snowflake/cli/_app/printing.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from json import JSONEncoder
 from pathlib import Path
 from textwrap import indent
@@ -57,7 +57,7 @@ class CustomJSONEncoder(JSONEncoder):
             return o.result
         if isinstance(o, (CollectionResult, MultipleResults)):
             return list(o.result)
-        if isinstance(o, datetime):
+        if isinstance(o, (date, datetime)):
             return o.isoformat()
         if isinstance(o, Path):
             return str(o)

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1,0 +1,18 @@
+import datetime
+
+from snowflake.cli._app.printing import print_structured
+from snowflake.cli.api.output.types import QueryResult
+
+
+def test_print_structured_output_date(mock_cursor, capsys):
+    cmd_result = QueryResult(
+        cursor=mock_cursor(
+            [(datetime.date.fromisoformat("2025-02-17"),)], ["CURRENT_DATE()"]
+        )
+    )
+    print_structured(cmd_result)
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """[\n    {\n        "CURRENT_DATE()": "2025-02-17"\n    }\n]\n"""
+    )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fixes SQL command output formating. Before:
```
➜ snow sql -q 'select current_date();' --format=JSON
[
    {
        "CURRENT_DATE()": %      
```

and after
```
➜ snow sql -q 'select current_date();' --format=JSON        
[
    {
        "CURRENT_DATE()": "2025-02-17"
    }
]

```
