### PR TITLE
Added snow auth keypair setup/rotate/list/remove commands

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,11 @@
 ## Deprecations
 
 ## New additions
+* Added new `snow auth keypair` commands:
+    * `setup` - generate key pair, set public key for the user in Snowflake and update/create connection.
+    * `rotate` - rotate keys for connection.
+    * `list` - list the public keys for the user.
+    * `remove` - remove the public key for the user.
 
 ## Fixes and improvements
 - Fix for incompatible options in `snow spcs compute-pool` commands didn't raise error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,23 +25,23 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
+  "GitPython==3.1.44",
   "jinja2==3.1.6",
-  "pluggy==1.5.0",
-  "PyYAML==6.0.2",
   "packaging",
-  "rich==13.9.4",
+  "pip",
+  "pluggy==1.5.0",
+  "pydantic==2.10.6",
+  "PyYAML==6.0.2",
   "requests==2.32.3",
   "requirements-parser==0.11.0",
+  "rich==13.9.4",
   "setuptools==75.8.0",
-  'snowflake.core==1.0.2; python_version < "3.12"',
   "snowflake-connector-python[secure-local-storage]==3.14.0",
   'snowflake-snowpark-python>=1.15.0,<1.26.0;python_version < "3.12"',
+  'snowflake.core==1.0.2; python_version < "3.12"',
   "tomlkit==0.13.2",
   "typer==0.15.1",
   "urllib3>=1.24.3,<2.4",
-  "GitPython==3.1.44",
-  "pip",
-  "pydantic==2.10.6",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,20 +1,20 @@
+GitPython==3.1.44
 jinja2==3.1.6
-pluggy==1.5.0
-PyYAML==6.0.2
 packaging
-rich==13.9.4
+pip
+pluggy==1.5.0
+pydantic==2.10.6
+PyYAML==6.0.2
 requests==2.32.3
 requirements-parser==0.11.0
+rich==13.9.4
 setuptools==75.8.0
-snowflake.core==1.0.2; python_version < "3.12"
 snowflake-connector-python[secure-local-storage]==3.14.0
 snowflake-snowpark-python>=1.15.0,<1.26.0;python_version < "3.12"
+snowflake.core==1.0.2; python_version < "3.12"
 tomlkit==0.13.2
 typer==0.15.1
 urllib3>=1.24.3,<2.4
-GitPython==3.1.44
-pip
-pydantic==2.10.6
 coverage==7.6.12
 pre-commit>=3.5.0
 pytest==8.3.4

--- a/src/snowflake/cli/_app/commands_registration/builtin_plugins.py
+++ b/src/snowflake/cli/_app/commands_registration/builtin_plugins.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from snowflake.cli._plugins.auth.keypair import plugin_spec as auth_plugin_spec
 from snowflake.cli._plugins.connection import plugin_spec as connection_plugin_spec
 from snowflake.cli._plugins.cortex import plugin_spec as cortex_plugin_spec
 from snowflake.cli._plugins.git import plugin_spec as git_plugin_spec
@@ -33,6 +34,7 @@ from snowflake.cli._plugins.workspace import plugin_spec as workspace_plugin_spe
 # plugin name to plugin spec
 def get_builtin_plugin_name_to_plugin_spec():
     plugin_specs = {
+        "auth": auth_plugin_spec,
         "connection": connection_plugin_spec,
         "helpers": migrate_plugin_spec,
         "spcs": spcs_plugin_spec,

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -26,7 +26,6 @@ from snowflake.cli._app.constants import (
     INTERNAL_APPLICATION_NAME,
     PARAM_APPLICATION_NAME,
 )
-from snowflake.cli._app.secret import SecretType
 from snowflake.cli._app.telemetry import command_info
 from snowflake.cli.api.config import (
     get_connection_dict,
@@ -38,6 +37,7 @@ from snowflake.cli.api.exceptions import (
     SnowflakeConnectionError,
 )
 from snowflake.cli.api.feature_flags import FeatureFlag
+from snowflake.cli.api.secret import SecretType
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.connector import SnowflakeConnection
 from snowflake.connector.errors import DatabaseError, ForbiddenError

--- a/src/snowflake/cli/_plugins/auth/__init__.py
+++ b/src/snowflake/cli/_plugins/auth/__init__.py
@@ -1,0 +1,9 @@
+from snowflake.cli._plugins.auth.keypair.commands import app as keypair_app
+from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+
+app = SnowTyperFactory(
+    name="auth",
+    help="Manages authentication methods.",
+)
+
+app.add_typer(keypair_app)

--- a/src/snowflake/cli/_plugins/auth/keypair/commands.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/commands.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+
+import typer
+from snowflake.cli._plugins.auth.keypair.manager import AuthManager, PublicKeyProperty
+from snowflake.cli.api.commands.flags import SecretTypeParser
+from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.output.types import (
+    CollectionResult,
+    CommandResult,
+    MessageResult,
+    SingleQueryResult,
+)
+from snowflake.cli.api.secret import SecretType
+from snowflake.cli.api.secure_path import SecurePath
+
+app = SnowTyperFactory(
+    name="keypair",
+    help="Manages authentication.",
+)
+
+
+def _show_connection_name_prompt(ctx: typer.Context, value: str):
+    for param in ctx.command.params:
+        if param.name == "connection_name":
+            if value:
+                param.prompt = "Enter connection name"
+            break
+    return value
+
+
+def _resolve_default_and_convert(value: Path) -> Path:
+    if value:
+        return value
+    return Path.home()
+
+
+_new_connection_option = typer.Option(
+    True,
+    help="Create a new connection.",
+    prompt="Create a new connection?",
+    confirmation_prompt=True,
+    callback=_show_connection_name_prompt,
+    show_default=False,
+    hidden=True,
+)
+
+
+_connection_name_option = typer.Option(
+    None,
+    help="The new connection name.",
+    prompt=False,
+    show_default=False,
+    hidden=True,
+)
+
+
+_key_length_option = typer.Option(
+    2048,
+    "--key-length",
+    help="The RSA key length.",
+    prompt="Enter key length",
+)
+
+
+_output_path_option = typer.Option(
+    "~/.ssh",
+    "--output-path",
+    help="The output path for private and public keys",
+    prompt="Enter output path",
+    callback=_resolve_default_and_convert,
+)
+
+
+_private_key_passphrase_option = typer.Option(
+    "",
+    "--private-key-passphrase",
+    help="The private key passphrase.",
+    click_type=SecretTypeParser(),
+    prompt="Enter private key passphrase",
+    hide_input=True,
+    show_default=False,
+)
+
+
+@app.command("setup", requires_connection=True)
+def setup(
+    new_connection: bool = _new_connection_option,
+    connection_name: str = _connection_name_option,
+    key_length: int = _key_length_option,
+    output_path: Path = _output_path_option,
+    private_key_passphrase: SecretType = _private_key_passphrase_option,
+    **options,
+):
+    """
+    Generates the key pair, sets the public key for the user in Snowflake and creates or updates the connection.
+    """
+    AuthManager().setup(
+        connection_name=connection_name,
+        key_length=key_length,
+        output_path=SecurePath(output_path),
+        private_key_passphrase=private_key_passphrase,
+    )
+    return MessageResult(f"Setup completed.")
+
+
+@app.command("rotate", requires_connection=True)
+def rotate(
+    new_connection: bool = _new_connection_option,
+    connection_name: str = _connection_name_option,
+    key_length: int = _key_length_option,
+    output_path: Path = _output_path_option,
+    private_key_passphrase: SecretType = _private_key_passphrase_option,
+    **options,
+):
+    """
+    Rotates the key for the connection. Generates the key pair, sets the public key for the user in Snowflake and creates or updates the connection.
+    """
+    AuthManager().rotate(
+        connection_name=connection_name,
+        key_length=key_length,
+        output_path=SecurePath(output_path),
+        private_key_passphrase=private_key_passphrase,
+    )
+    return MessageResult(f"Rotate completed.")
+
+
+@app.command("list", requires_connection=True)
+def list_keys(**options) -> CommandResult:
+    """
+    Lists the public keys set for the user.
+    """
+    return CollectionResult(AuthManager().list_keys())
+
+
+@app.command("remove", requires_connection=True)
+def remove(
+    public_key_property: PublicKeyProperty = typer.Option(
+        ...,
+        "--key-id",
+        help=f"local path to template directory or URL to git repository with templates.",
+        show_default=False,
+    ),
+    **options,
+):
+    """
+    Removes the public key for the user.
+    """
+    return SingleQueryResult(
+        AuthManager().remove_public_key(public_key_property=public_key_property)
+    )

--- a/src/snowflake/cli/_plugins/auth/keypair/manager.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/manager.py
@@ -1,0 +1,264 @@
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from click import ClickException
+from snowflake.cli._plugins.object.manager import ObjectManager
+from snowflake.cli.api.cli_global_context import get_cli_context
+from snowflake.cli.api.config import (
+    connection_exists,
+    get_connection_dict,
+    set_config_value,
+)
+from snowflake.cli.api.console import cli_console
+from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
+from snowflake.cli.api.secret import SecretType
+from snowflake.cli.api.secure_path import SecurePath
+from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.connector import DictCursor
+from snowflake.connector.cursor import SnowflakeCursor
+
+
+class PublicKeyProperty(Enum):
+    RSA_PUBLIC_KEY = "RSA_PUBLIC_KEY"
+    RSA_PUBLIC_KEY_2 = "RSA_PUBLIC_KEY_2"
+
+
+class AuthManager(SqlExecutionMixin):
+    def setup(
+        self,
+        connection_name: Optional[str],
+        key_length: int,
+        output_path: SecurePath,
+        private_key_passphrase: SecretType,
+    ):
+        # When the user provide new connection name
+        if connection_name and connection_exists(connection_name):
+            raise ClickException(
+                f"Connection with name {connection_name} already exists."
+            )
+
+        cli_context = get_cli_context()
+        # When the use not provide connection name, so we overwrite the current connection
+        if not connection_name:
+            connection_name = cli_context.connection_context.connection_name
+
+        public_key_exists, public_key_2_exists = self._get_public_keys()
+
+        if public_key_exists or public_key_2_exists:
+            raise ClickException(
+                "The public key is set already. Use the rotate command instead."
+            )
+
+        if not output_path.exists():
+            output_path.mkdir(parents=True)
+
+        public_key = self._generate_keys_and_return_public_key(
+            key_length=key_length,
+            output_path=output_path,
+            key_name=connection_name,  # type: ignore[arg-type]
+            private_key_passphrase=private_key_passphrase,
+        )
+        self.set_public_key(
+            cli_context.connection.user, PublicKeyProperty.RSA_PUBLIC_KEY, public_key
+        )
+
+        self._create_or_update_connection(
+            current_connection=cli_context.connection_context.connection_name,
+            connection_name=connection_name,  # type: ignore[arg-type]
+            private_key_path=self._get_private_key_path(
+                output_path=output_path, key_name=connection_name  # type: ignore[arg-type]
+            ),
+        )
+
+    def rotate(
+        self,
+        connection_name: str,
+        key_length: int,
+        output_path: SecurePath,
+        private_key_passphrase: SecretType,
+    ):
+        # When the user provide new connection name
+        if connection_name and connection_exists(connection_name):
+            raise ClickException(
+                f"Connection with name {connection_name} already exists."
+            )
+
+        cli_context = get_cli_context()
+        # When the use not provide connection name, so we overwrite the current connection
+        if not connection_name:
+            connection_name = cli_context.connection_context.connection_name
+
+        self._check_if_connection_has_private_key(
+            cli_context.connection_context.connection_name
+        )
+
+        public_key, public_key_2 = self._get_public_keys()
+
+        if not public_key and not public_key_2:
+            raise ClickException("No public key found. Use the setup command first.")
+
+        if public_key_2:
+            self.set_public_key(
+                cli_context.connection.user,
+                PublicKeyProperty.RSA_PUBLIC_KEY,
+                public_key_2,
+            )
+
+        public_key = self._generate_keys_and_return_public_key(
+            key_length=key_length,
+            output_path=output_path,
+            key_name=connection_name,
+            private_key_passphrase=private_key_passphrase,
+        )
+        self.set_public_key(
+            cli_context.connection.user, PublicKeyProperty.RSA_PUBLIC_KEY_2, public_key
+        )
+        self._create_or_update_connection(
+            current_connection=cli_context.connection_context.connection_name,
+            connection_name=connection_name,
+            private_key_path=self._get_private_key_path(
+                output_path=output_path, key_name=connection_name
+            ),
+        )
+
+    def list_keys(self) -> List[Dict]:
+        key_properties = [
+            "RSA_PUBLIC_KEY",
+            "RSA_PUBLIC_KEY_FP",
+            "RSA_PUBLIC_KEY_LAST_SET_TIME",
+            "RSA_PUBLIC_KEY_2",
+            "RSA_PUBLIC_KEY_2_FP",
+            "RSA_PUBLIC_KEY_2_LAST_SET_TIME",
+        ]
+        cli_context = get_cli_context()
+        cursor = ObjectManager().describe(
+            object_type=ObjectType.USER.value.sf_name,
+            fqn=FQN.from_string(cli_context.connection.user),
+            cursor_class=DictCursor,
+        )
+        only_public_key_properties = [
+            p for p in cursor.fetchall() if p.get("property") in key_properties
+        ]
+        return only_public_key_properties
+
+    def set_public_key(
+        self, user: str, public_key_property: PublicKeyProperty, public_key: str
+    ) -> SnowflakeCursor:
+        return self.execute_query(
+            f"ALTER USER {user} SET {public_key_property.value}='{public_key}'"
+        )
+
+    def remove_public_key(
+        self, public_key_property: PublicKeyProperty
+    ) -> SnowflakeCursor:
+        cli_context = get_cli_context()
+        return self.execute_query(
+            f"ALTER USER {cli_context.connection.user} UNSET {public_key_property.value}"
+        )
+
+    @staticmethod
+    def _check_if_connection_has_private_key(connection_name: str):
+        connection = get_connection_dict(connection_name)
+        if connection.get("private_key_file") and connection.get("private_key_path"):
+            raise ClickException(
+                f"The private key is not set in {connection_name} connection."
+            )
+
+    def _get_public_keys(self) -> Tuple[str, str]:
+        keys = self.list_keys()
+        public_key = ""
+        public_key_2 = ""
+        for p in keys:
+            if (
+                p.get("property") == PublicKeyProperty.RSA_PUBLIC_KEY.value
+                and p.get("value") != "null"
+            ):
+                public_key = p.get("value")  # type: ignore
+            if (
+                p.get("property") == PublicKeyProperty.RSA_PUBLIC_KEY_2.value
+                and p.get("value") != "null"
+            ):
+                public_key_2 = p.get("value")  # type: ignore
+        return public_key, public_key_2
+
+    @staticmethod
+    def _generate_keys_and_return_public_key(
+        key_length: int,
+        output_path: SecurePath,
+        key_name: str,
+        private_key_passphrase: SecretType,
+    ) -> str:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=key_length,
+        )
+
+        if private_key_passphrase:
+            pem = SecretType(
+                private_key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=serialization.BestAvailableEncryption(
+                        private_key_passphrase.value.encode("utf-8")
+                    ),
+                )
+            )
+            cli_console.message(
+                "Set the `PRIVATE_KEY_PASSPHRASE` environment variable before using the connection."
+            )
+        else:
+            pem = SecretType(
+                private_key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=serialization.NoEncryption(),
+                )
+            )
+
+        with AuthManager._get_private_key_path(output_path, key_name).open(
+            mode="wb"
+        ) as file:
+            file.write(pem.value)
+
+        public_key = private_key.public_key()
+        public_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        with AuthManager._get_public_key_path(output_path, key_name).open(
+            mode="wb"
+        ) as file:
+            file.write(public_pem)
+
+        return public_pem.decode("utf-8")
+
+    @staticmethod
+    def _get_private_key_path(output_path: SecurePath, key_name: str) -> SecurePath:
+        return (output_path / f"{key_name}.p8").resolve()
+
+    @staticmethod
+    def _get_public_key_path(output_path: SecurePath, key_name: str) -> SecurePath:
+        return (output_path / f"{key_name}.pub").resolve()
+
+    @staticmethod
+    def _create_or_update_connection(
+        current_connection: Optional[str],
+        connection_name: str,
+        private_key_path: SecurePath,
+    ):
+        connection = get_connection_dict(current_connection)
+        del connection["password"]
+        connection["authenticator"] = "SNOWFLAKE_JWT"
+        connection["private_key_file"] = str(private_key_path.path)
+
+        set_config_value(["connections", connection_name], value=connection)
+
+    @staticmethod
+    def _find_public_key_2(list_keys: List[Dict[str, str]]):
+        for p in list_keys:
+            if p.get("property") == PublicKeyProperty.RSA_PUBLIC_KEY_2.value:
+                return p.get("value")

--- a/src/snowflake/cli/_plugins/auth/keypair/manager.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/manager.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 from click import ClickException
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from snowflake.cli._plugins.object.manager import ObjectManager
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.config import (
@@ -189,9 +191,6 @@ class AuthManager(SqlExecutionMixin):
         key_name: str,
         private_key_passphrase: SecretType,
     ) -> str:
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
         private_key = rsa.generate_private_key(
             public_exponent=65537,
             key_size=key_length,

--- a/src/snowflake/cli/_plugins/auth/keypair/plugin_spec.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/plugin_spec.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from snowflake.cli._plugins.auth import app
+from snowflake.cli.api.plugins.command import (
+    SNOWCLI_ROOT_COMMAND_PATH,
+    CommandSpec,
+    CommandType,
+    plugin_hook_impl,
+)
+
+
+@plugin_hook_impl
+def command_spec():
+    return CommandSpec(
+        parent_command_path=SNOWCLI_ROOT_COMMAND_PATH,
+        command_type=CommandType.COMMAND_GROUP,
+        typer_instance=app.create_instance(),
+    )

--- a/src/snowflake/cli/_plugins/object/manager.py
+++ b/src/snowflake/cli/_plugins/object/manager.py
@@ -58,14 +58,16 @@ class ObjectManager(SqlExecutionMixin):
         object_name = _get_object_names(object_type).sf_name
         return self.execute_query(f"drop {object_name} {fqn.sql_identifier}")
 
-    def describe(self, *, object_type: str, fqn: FQN):
+    def describe(self, *, object_type: str, fqn: FQN, **kwargs):
         # Image repository is the only supported object that does not have a DESCRIBE command.
         if object_type == "image-repository":
             raise ClickException(
                 f"Describe is currently not supported for object of type image-repository"
             )
         object_name = _get_object_names(object_type).sf_name
-        return self.execute_query(f"describe {object_name} {fqn.sql_identifier}")
+        return self.execute_query(
+            f"describe {object_name} {fqn.sql_identifier}", **kwargs
+        )
 
     def object_exists(self, *, object_type: str, fqn: FQN):
         try:

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -32,6 +32,7 @@ from snowflake.cli.api.connections import ConnectionContext
 from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.formats import OutputFormat
+from snowflake.cli.api.secret import SecretType
 from snowflake.cli.api.stage_path import StagePath
 
 DEFAULT_CONTEXT_SETTINGS = {"help_option_names": ["--help", "-h"]}
@@ -499,6 +500,15 @@ class IdentifierStagePathType(click.ParamType):
 
     def convert(self, value, param, ctx):
         return StagePath.from_stage_str(value)
+
+
+class SecretTypeParser(click.ParamType):
+    name = "TEXT"
+
+    def convert(self, value, param, ctx):
+        if not isinstance(value, SecretType):
+            return SecretType(value)
+        return value
 
 
 def identifier_argument(

--- a/src/snowflake/cli/api/secret.py
+++ b/src/snowflake/cli/api/secret.py
@@ -5,5 +5,8 @@ class SecretType:
     def __repr__(self):
         return "SecretType(***)"
 
-    def __str___(self):
+    def __str__(self):
         return "***"
+
+    def __bool__(self):
+        return self.value is not None and self.value != ""

--- a/src/snowflake/cli/api/secure_path.py
+++ b/src/snowflake/cli/api/secure_path.py
@@ -72,6 +72,12 @@ class SecurePath:
         """
         return SecurePath(self._path.absolute())
 
+    def resolve(self):
+        """
+        Make the path absolute, resolving symlinks
+        """
+        return SecurePath(self._path.resolve())
+
     def iterdir(self):
         """
         When the path points to a directory, yield path objects of the directory contents.

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -22,6 +22,7 @@
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |
+  | auth         Manages authentication methods.                                 |
   | connection   Manages connections to Snowflake.                               |
   | cortex       Provides access to Snowflake Cortex.                            |
   | git          Manages git repositories in Snowflake.                          |
@@ -2938,6 +2939,420 @@
   | validate            Validates a deployed Snowflake Native App's setup        |
   |                     script.                                                  |
   | version             Manages versions defined in an application package       |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[auth.keypair.list]
+  '''
+                                                                                  
+   Usage: root auth keypair list [OPTIONS]                                        
+                                                                                  
+   Lists the public keys set for the user.                                        
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment     -c      TEXT     Name of the connection, as   |
+  |                                                 defined in your config.toml  |
+  |                                                 file. Default: default.      |
+  | --host                                 TEXT     Host address for the         |
+  |                                                 connection. Overrides the    |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --port                                 INTEGER  Port for the connection.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --account,--accountname                TEXT     Name assigned to your        |
+  |                                                 Snowflake account. Overrides |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --user,--username                      TEXT     Username to connect to       |
+  |                                                 Snowflake. Overrides the     |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --password                             TEXT     Snowflake password.          |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --authenticator                        TEXT     Snowflake authenticator.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --private-key-file,--private…          TEXT     Snowflake private key file   |
+  |                                                 path. Overrides the value    |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --token-file-path                      TEXT     Path to file with an OAuth   |
+  |                                                 token that should be used    |
+  |                                                 when connecting to Snowflake |
+  | --database,--dbname                    TEXT     Database to use. Overrides   |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --schema,--schemaname                  TEXT     Database schema to use.      |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --role,--rolename                      TEXT     Role to use. Overrides the   |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --warehouse                            TEXT     Warehouse to use. Overrides  |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --temporary-connection         -x               Uses a connection defined    |
+  |                                                 with command line            |
+  |                                                 parameters, instead of one   |
+  |                                                 defined in config            |
+  | --mfa-passcode                         TEXT     Token to use for             |
+  |                                                 multi-factor authentication  |
+  |                                                 (MFA)                        |
+  | --enable-diag                                   Whether to generate a        |
+  |                                                 connection diagnostic        |
+  |                                                 report.                      |
+  | --diag-log-path                        TEXT     Path for the generated       |
+  |                                                 report. Defaults to system   |
+  |                                                 temporary directory.         |
+  | --diag-allowlist-path                  TEXT     Path to a JSON file          |
+  |                                                 containing allowlist         |
+  |                                                 parameters.                  |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format           [TABLE|JSON]  Specifies the output format.                |
+  |                                  [default: TABLE]                            |
+  | --verbose  -v                    Displays log entries for log levels info    |
+  |                                  and higher.                                 |
+  | --debug                          Displays log entries for log levels debug   |
+  |                                  and higher; debug logs contain additional   |
+  |                                  information.                                |
+  | --silent                         Turns off intermediate output to console.   |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[auth.keypair.remove]
+  '''
+                                                                                  
+   Usage: root auth keypair remove [OPTIONS]                                      
+                                                                                  
+   Removes the public key for the user.                                           
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | *  --key-id          [RSA_PUBLIC_KEY|RSA_PUBLIC  local path to template      |
+  |                      _KEY_2]                     directory or URL to git     |
+  |                                                  repository with templates.  |
+  |                                                  [required]                  |
+  |    --help    -h                                  Show this message and exit. |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment     -c      TEXT     Name of the connection, as   |
+  |                                                 defined in your config.toml  |
+  |                                                 file. Default: default.      |
+  | --host                                 TEXT     Host address for the         |
+  |                                                 connection. Overrides the    |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --port                                 INTEGER  Port for the connection.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --account,--accountname                TEXT     Name assigned to your        |
+  |                                                 Snowflake account. Overrides |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --user,--username                      TEXT     Username to connect to       |
+  |                                                 Snowflake. Overrides the     |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --password                             TEXT     Snowflake password.          |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --authenticator                        TEXT     Snowflake authenticator.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --private-key-file,--private…          TEXT     Snowflake private key file   |
+  |                                                 path. Overrides the value    |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --token-file-path                      TEXT     Path to file with an OAuth   |
+  |                                                 token that should be used    |
+  |                                                 when connecting to Snowflake |
+  | --database,--dbname                    TEXT     Database to use. Overrides   |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --schema,--schemaname                  TEXT     Database schema to use.      |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --role,--rolename                      TEXT     Role to use. Overrides the   |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --warehouse                            TEXT     Warehouse to use. Overrides  |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --temporary-connection         -x               Uses a connection defined    |
+  |                                                 with command line            |
+  |                                                 parameters, instead of one   |
+  |                                                 defined in config            |
+  | --mfa-passcode                         TEXT     Token to use for             |
+  |                                                 multi-factor authentication  |
+  |                                                 (MFA)                        |
+  | --enable-diag                                   Whether to generate a        |
+  |                                                 connection diagnostic        |
+  |                                                 report.                      |
+  | --diag-log-path                        TEXT     Path for the generated       |
+  |                                                 report. Defaults to system   |
+  |                                                 temporary directory.         |
+  | --diag-allowlist-path                  TEXT     Path to a JSON file          |
+  |                                                 containing allowlist         |
+  |                                                 parameters.                  |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format           [TABLE|JSON]  Specifies the output format.                |
+  |                                  [default: TABLE]                            |
+  | --verbose  -v                    Displays log entries for log levels info    |
+  |                                  and higher.                                 |
+  | --debug                          Displays log entries for log levels debug   |
+  |                                  and higher; debug logs contain additional   |
+  |                                  information.                                |
+  | --silent                         Turns off intermediate output to console.   |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[auth.keypair.rotate]
+  '''
+                                                                                  
+   Usage: root auth keypair rotate [OPTIONS]                                      
+                                                                                  
+   Rotates the key for the connection. Generates the key pair, sets the public    
+   key for the user in Snowflake and creates or updates the connection.           
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --key-length                      INTEGER  The RSA key length.               |
+  |                                            [default: 2048]                   |
+  | --output-path                     PATH     The output path for private and   |
+  |                                            public keys                       |
+  |                                            [default: ~/.ssh]                 |
+  | --private-key-passphrase          TEXT     The private key passphrase.       |
+  | --help                    -h               Show this message and exit.       |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment     -c      TEXT     Name of the connection, as   |
+  |                                                 defined in your config.toml  |
+  |                                                 file. Default: default.      |
+  | --host                                 TEXT     Host address for the         |
+  |                                                 connection. Overrides the    |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --port                                 INTEGER  Port for the connection.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --account,--accountname                TEXT     Name assigned to your        |
+  |                                                 Snowflake account. Overrides |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --user,--username                      TEXT     Username to connect to       |
+  |                                                 Snowflake. Overrides the     |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --password                             TEXT     Snowflake password.          |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --authenticator                        TEXT     Snowflake authenticator.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --private-key-file,--private…          TEXT     Snowflake private key file   |
+  |                                                 path. Overrides the value    |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --token-file-path                      TEXT     Path to file with an OAuth   |
+  |                                                 token that should be used    |
+  |                                                 when connecting to Snowflake |
+  | --database,--dbname                    TEXT     Database to use. Overrides   |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --schema,--schemaname                  TEXT     Database schema to use.      |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --role,--rolename                      TEXT     Role to use. Overrides the   |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --warehouse                            TEXT     Warehouse to use. Overrides  |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --temporary-connection         -x               Uses a connection defined    |
+  |                                                 with command line            |
+  |                                                 parameters, instead of one   |
+  |                                                 defined in config            |
+  | --mfa-passcode                         TEXT     Token to use for             |
+  |                                                 multi-factor authentication  |
+  |                                                 (MFA)                        |
+  | --enable-diag                                   Whether to generate a        |
+  |                                                 connection diagnostic        |
+  |                                                 report.                      |
+  | --diag-log-path                        TEXT     Path for the generated       |
+  |                                                 report. Defaults to system   |
+  |                                                 temporary directory.         |
+  | --diag-allowlist-path                  TEXT     Path to a JSON file          |
+  |                                                 containing allowlist         |
+  |                                                 parameters.                  |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format           [TABLE|JSON]  Specifies the output format.                |
+  |                                  [default: TABLE]                            |
+  | --verbose  -v                    Displays log entries for log levels info    |
+  |                                  and higher.                                 |
+  | --debug                          Displays log entries for log levels debug   |
+  |                                  and higher; debug logs contain additional   |
+  |                                  information.                                |
+  | --silent                         Turns off intermediate output to console.   |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[auth.keypair.setup]
+  '''
+                                                                                  
+   Usage: root auth keypair setup [OPTIONS]                                       
+                                                                                  
+   Generates the key pair, sets the public key for the user in Snowflake and      
+   creates or updates the connection.                                             
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --key-length                      INTEGER  The RSA key length.               |
+  |                                            [default: 2048]                   |
+  | --output-path                     PATH     The output path for private and   |
+  |                                            public keys                       |
+  |                                            [default: ~/.ssh]                 |
+  | --private-key-passphrase          TEXT     The private key passphrase.       |
+  | --help                    -h               Show this message and exit.       |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment     -c      TEXT     Name of the connection, as   |
+  |                                                 defined in your config.toml  |
+  |                                                 file. Default: default.      |
+  | --host                                 TEXT     Host address for the         |
+  |                                                 connection. Overrides the    |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --port                                 INTEGER  Port for the connection.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --account,--accountname                TEXT     Name assigned to your        |
+  |                                                 Snowflake account. Overrides |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --user,--username                      TEXT     Username to connect to       |
+  |                                                 Snowflake. Overrides the     |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --password                             TEXT     Snowflake password.          |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --authenticator                        TEXT     Snowflake authenticator.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --private-key-file,--private…          TEXT     Snowflake private key file   |
+  |                                                 path. Overrides the value    |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --token-file-path                      TEXT     Path to file with an OAuth   |
+  |                                                 token that should be used    |
+  |                                                 when connecting to Snowflake |
+  | --database,--dbname                    TEXT     Database to use. Overrides   |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --schema,--schemaname                  TEXT     Database schema to use.      |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --role,--rolename                      TEXT     Role to use. Overrides the   |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --warehouse                            TEXT     Warehouse to use. Overrides  |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --temporary-connection         -x               Uses a connection defined    |
+  |                                                 with command line            |
+  |                                                 parameters, instead of one   |
+  |                                                 defined in config            |
+  | --mfa-passcode                         TEXT     Token to use for             |
+  |                                                 multi-factor authentication  |
+  |                                                 (MFA)                        |
+  | --enable-diag                                   Whether to generate a        |
+  |                                                 connection diagnostic        |
+  |                                                 report.                      |
+  | --diag-log-path                        TEXT     Path for the generated       |
+  |                                                 report. Defaults to system   |
+  |                                                 temporary directory.         |
+  | --diag-allowlist-path                  TEXT     Path to a JSON file          |
+  |                                                 containing allowlist         |
+  |                                                 parameters.                  |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format           [TABLE|JSON]  Specifies the output format.                |
+  |                                  [default: TABLE]                            |
+  | --verbose  -v                    Displays log entries for log levels info    |
+  |                                  and higher.                                 |
+  | --debug                          Displays log entries for log levels debug   |
+  |                                  and higher; debug logs contain additional   |
+  |                                  information.                                |
+  | --silent                         Turns off intermediate output to console.   |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[auth.keypair]
+  '''
+                                                                                  
+   Usage: root auth keypair [OPTIONS] COMMAND [ARGS]...                           
+                                                                                  
+   Manages authentication.                                                        
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Commands -------------------------------------------------------------------+
+  | list     Lists the public keys set for the user.                             |
+  | remove   Removes the public key for the user.                                |
+  | rotate   Rotates the key for the connection. Generates the key pair, sets    |
+  |          the public key for the user in Snowflake and creates or updates the |
+  |          connection.                                                         |
+  | setup    Generates the key pair, sets the public key for the user in         |
+  |          Snowflake and creates or updates the connection.                    |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[auth]
+  '''
+                                                                                  
+   Usage: root auth [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                  
+   Manages authentication methods.                                                
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Commands -------------------------------------------------------------------+
+  | keypair   Manages authentication.                                            |
   +------------------------------------------------------------------------------+
   
   
@@ -12617,6 +13032,7 @@
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |
+  | auth         Manages authentication methods.                                 |
   | connection   Manages connections to Snowflake.                               |
   | cortex       Provides access to Snowflake Cortex.                            |
   | git          Manages git repositories in Snowflake.                          |
@@ -12740,6 +13156,46 @@
   | validate            Validates a deployed Snowflake Native App's setup        |
   |                     script.                                                  |
   | version             Manages versions defined in an application package       |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages_no_help_flag[auth.keypair]
+  '''
+                                                                                  
+   Usage: root auth keypair [OPTIONS] COMMAND [ARGS]...                           
+                                                                                  
+   Manages authentication.                                                        
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Commands -------------------------------------------------------------------+
+  | list     Lists the public keys set for the user.                             |
+  | remove   Removes the public key for the user.                                |
+  | rotate   Rotates the key for the connection. Generates the key pair, sets    |
+  |          the public key for the user in Snowflake and creates or updates the |
+  |          connection.                                                         |
+  | setup    Generates the key pair, sets the public key for the user in         |
+  |          Snowflake and creates or updates the connection.                    |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages_no_help_flag[auth]
+  '''
+                                                                                  
+   Usage: root auth [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                  
+   Manages authentication methods.                                                
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Commands -------------------------------------------------------------------+
+  | keypair   Manages authentication.                                            |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/auth/__snapshots__/test_auth.ambr
+++ b/tests/auth/__snapshots__/test_auth.ambr
@@ -1,0 +1,214 @@
+# serializer version: 1
+# name: test_list
+  '''
+  +------------------------------------------------------------------------------+
+  | property             | value                | default | description          |
+  |----------------------+----------------------+---------+----------------------|
+  | RSA_PUBLIC_KEY       | -----BEGIN PUBLIC    | None    | RSA public key of    |
+  |                      | KEY-----             |         | the user             |
+  | RSA_PUBLIC_KEY_FP    | SHA256               | None    | Fingerprint of       |
+  |                      |                      |         | user's RSA public    |
+  |                      |                      |         | key.                 |
+  | RSA_PUBLIC_KEY_LAST_ | 2025-02-17           | None    | The timestamp        |
+  | SET_TIME             | 12:53:51.212         |         |                      |
+  | RSA_PUBLIC_KEY_2     | None                 | None    | Second RSA public    |
+  |                      |                      |         | key of the user      |
+  | RSA_PUBLIC_KEY_2_FP  | None                 | None    | Fingerprint of       |
+  |                      |                      |         | user's second RSA    |
+  |                      |                      |         | public key.          |
+  | RSA_PUBLIC_KEY_2_LAS | None                 | None    | The timestamp        |
+  | T_SET_TIME           |                      |         |                      |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_remove[RSA_PUBLIC_KEY]
+  '''
+  +-------------------------------------------+
+  | key    | value                            |
+  |--------+----------------------------------|
+  | status | Statement executed successfully. |
+  +-------------------------------------------+
+  
+  '''
+# ---
+# name: test_remove[RSA_PUBLIC_KEY_2]
+  '''
+  +-------------------------------------------+
+  | key    | value                            |
+  |--------+----------------------------------|
+  | status | Statement executed successfully. |
+  +-------------------------------------------+
+  
+  '''
+# ---
+# name: test_rotate_connection_already_exists
+  '''
+  Create a new connection? [Y/n]: 
+  Enter connection name: default
+  Enter key length [2048]: 
+  Enter private key passphrase []: 
+  +- Error ----------------------------------------------------------------------+
+  | Connection with name default already exists.                                 |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_rotate_no_prompts
+  '''
+  Create a new connection? [Y/n]: 
+  Enter connection name: keypairconnection
+  Set the `PRIVATE_KEY_PASSPHRASE` environment variable before using the connection.
+  Rotate completed.
+  
+  '''
+# ---
+# name: test_rotate_no_public_key_set
+  '''
+  Create a new connection? [Y/n]: 
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 
+  Enter private key passphrase []: 
+  +- Error ----------------------------------------------------------------------+
+  | Connection with name keypairconnection already exists.                       |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_rotate_only_public_key_set
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Rotate completed.
+  
+  '''
+# ---
+# name: test_rotate_other_public_key_set_options[KEY-KEY]
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Rotate completed.
+  
+  '''
+# ---
+# name: test_rotate_other_public_key_set_options[None-KEY]
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Rotate completed.
+  
+  '''
+# ---
+# name: test_rotate_overwrite_connection
+  '''
+  Create a new connection? [Y/n]: n
+  Enter key length [2048]: 
+  Enter private key passphrase []: 
+  Rotate completed.
+  
+  '''
+# ---
+# name: test_rotate_with_password
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Set the `PRIVATE_KEY_PASSPHRASE` environment variable before using the connection.
+  Rotate completed.
+  
+  '''
+# ---
+# name: test_setup_connection_already_exists
+  '''
+  Create a new connection? [Y/n]: 
+  Enter connection name: default
+  Enter key length [2048]: 
+  Enter private key passphrase []: 
+  +- Error ----------------------------------------------------------------------+
+  | Connection with name default already exists.                                 |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_setup_create_output_directory_with_proper_privileges
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Setup completed.
+  
+  '''
+# ---
+# name: test_setup_error_if_any_public_key_is_set[KEY-KEY]
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  +- Error ----------------------------------------------------------------------+
+  | The public key is set already. Use the rotate command instead.               |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_setup_error_if_any_public_key_is_set[KEY-None]
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  +- Error ----------------------------------------------------------------------+
+  | The public key is set already. Use the rotate command instead.               |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_setup_error_if_any_public_key_is_set[None-KEY]
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  +- Error ----------------------------------------------------------------------+
+  | The public key is set already. Use the rotate command instead.               |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_setup_no_prompts
+  '''
+  Create a new connection? [Y/n]: 
+  Enter connection name: keypairconnection
+  Set the `PRIVATE_KEY_PASSPHRASE` environment variable before using the connection.
+  Setup completed.
+  
+  '''
+# ---
+# name: test_setup_overwrite_connection
+  '''
+  Create a new connection? [Y/n]: n
+  Enter key length [2048]: 
+  Enter private key passphrase []: 
+  Setup completed.
+  
+  '''
+# ---
+# name: test_setup_with_password
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Set the `PRIVATE_KEY_PASSPHRASE` environment variable before using the connection.
+  Setup completed.
+  
+  '''
+# ---

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -1,0 +1,690 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from unittest import mock
+
+import pytest
+from snowflake.cli.api.config import get_connection_dict
+from snowflake.cli.api.secure_utils import file_permissions_are_strict
+
+EXECUTE_QUERY = "snowflake.cli._plugins.auth.keypair.manager.AuthManager.execute_query"
+OBJECT_EXECUTE_QUERY = (
+    "snowflake.cli._plugins.object.manager.ObjectManager.execute_query"
+)
+CONNECTION = "snowflake.cli._plugins.auth.keypair.manager.AuthManager._conn"
+CONNECT = "snowflake.connector.connect"
+
+new_connection = "keypairconnection"
+user_name = "test_user"
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            ["auth", "keypair", "setup", "--format", "JSON"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == dedent(
+            f"""\
+            Create a new connection? [Y/n]: Y
+            Enter connection name: {new_connection}
+            Enter key length [2048]: 4096
+            Enter output path [~/.ssh]: {tmp_path.absolute()}
+            Enter private key passphrase []: 
+            {{
+                "message": "Setup completed."
+            }}
+            """
+        )
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path)
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY="
+        )
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup_with_password(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            ["auth", "keypair", "setup", "--output-path", tmp_dir],
+            input=f"Y\n{new_connection}\n4096\n123\n",
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert "BEGIN ENCRYPTED PRIVATE KEY" in private_key_path.read_text()
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path)
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY="
+        )
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup_no_prompts(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            [
+                "auth",
+                "keypair",
+                "setup",
+                "--key-length",
+                "4096",
+                "--output-path",
+                tmp_dir,
+                "--private-key-passphrase",
+                "123",
+            ],
+            input=f"\n{new_connection}\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup_connection_already_exists(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            ["auth", "keypair", "setup", "--output-path", tmp_dir], input="\ndefault\n"
+        )
+
+        assert result.exit_code == 1, result.output
+        assert result.output == os_agnostic_snapshot
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup_create_output_directory_with_proper_privileges(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "some" / "subdirectory" / "location"
+        result = runner.invoke(
+            ["auth", "keypair", "setup", "--output-path", tmp_path],
+            input=f"Y\n{new_connection}\n4096\n\n",
+        )
+
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        assert file_permissions_are_strict(tmp_path)
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path.resolve())
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY="
+        )
+
+
+@pytest.mark.parametrize(
+    "key_value, key_2_value",
+    [
+        ("KEY", None),
+        (None, "KEY"),
+        ("KEY", "KEY"),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup_error_if_any_public_key_is_set(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+    key_value,
+    key_2_value,
+):
+    mock_connect.return_value.user = user_name
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": key_value},
+            {"property": "RSA_PUBLIC_KEY_2", "value": key_2_value},
+        ],
+        columns=[],
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "some" / "subdirectory" / "location"
+        result = runner.invoke(
+            ["auth", "keypair", "setup", "--output-path", tmp_path],
+            input=f"Y\n{new_connection}\n4096\n\n",
+        )
+
+        assert result.exit_code == 1, result.output
+        assert result.output == os_agnostic_snapshot
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_setup_overwrite_connection(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    test_snowcli_config,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            ["auth", "keypair", "setup", "--output-path", tmp_dir], input="n\n\n\n"
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / "default.p8"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        connection_config = get_connection_dict("default")
+        assert connection_config["authenticator"] == "SNOWFLAKE_JWT"
+        assert connection_config["private_key_file"] == str(private_key_path.resolve())
+        assert "password" not in connection_config.keys()
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_public_key(mock_connect, mock_object_execute_query, mock_cursor)
+
+    with TemporaryDirectory() as tmp_dir:
+        runner.invoke(
+            ["auth", "keypair", "setup"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--format", "JSON"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == dedent(
+            f"""\
+            Create a new connection? [Y/n]: Y
+            Enter connection name: {new_connection}
+            Enter key length [2048]: 4096
+            Enter output path [~/.ssh]: {tmp_path.absolute()}
+            Enter private key passphrase []: 
+            {{
+                "message": "Rotate completed."
+            }}
+            """
+        )
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path)
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY_2="
+        )
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_with_password(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_public_key(mock_connect, mock_object_execute_query, mock_cursor)
+
+    with TemporaryDirectory() as tmp_dir:
+        runner.invoke(
+            ["auth", "keypair", "setup"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--output-path", tmp_dir],
+            input=f"Y\n{new_connection}\n4096\n123\n",
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert "BEGIN ENCRYPTED PRIVATE KEY" in private_key_path.read_text()
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path)
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY_2="
+        )
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_no_prompts(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_public_key(mock_connect, mock_object_execute_query, mock_cursor)
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            [
+                "auth",
+                "keypair",
+                "rotate",
+                "--key-length",
+                "4096",
+                "--output-path",
+                tmp_dir,
+                "--private-key-passphrase",
+                "123",
+            ],
+            input=f"\n{new_connection}\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_connection_already_exists(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_public_key(mock_connect, mock_object_execute_query, mock_cursor)
+
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--output-path", tmp_dir], input="\ndefault\n"
+        )
+
+        assert result.exit_code == 1, result.output
+        assert result.output == os_agnostic_snapshot
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_no_public_key_set(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_empty_public_keys(
+        mock_connect, mock_object_execute_query, mock_cursor
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        runner.invoke(
+            ["auth", "keypair", "setup"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--output-path", tmp_dir],
+            input=f"\n{new_connection}\n",
+        )
+
+        assert result.exit_code == 1, result.output
+        assert result.output == os_agnostic_snapshot
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_only_public_key_set(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+):
+    mock_connect.return_value.user = user_name
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": "KEY"},
+            {"property": "RSA_PUBLIC_KEY_2", "value": None},
+        ],
+        columns=[],
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        runner.invoke(
+            ["auth", "keypair", "setup"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--output-path", tmp_dir],
+            input=f"Y\n{new_connection}\n4096\n\n",
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path)
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY_2="
+        )
+
+
+@pytest.mark.parametrize(
+    "key_value, key_2_value",
+    [
+        (None, "KEY"),
+        ("KEY", "KEY"),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_other_public_key_set_options(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    os_agnostic_snapshot,
+    key_value,
+    key_2_value,
+):
+    mock_connect.return_value.user = user_name
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": key_value},
+            {"property": "RSA_PUBLIC_KEY_2", "value": key_2_value},
+        ],
+        columns=[],
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        runner.invoke(
+            ["auth", "keypair", "setup"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--output-path", tmp_dir],
+            input=f"Y\n{new_connection}\n4096\n\n",
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / f"{new_connection}.p8"
+        public_key_path = tmp_path / f"{new_connection}.pub"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        assert private_key_path.exists()
+        assert file_permissions_are_strict(private_key_path)
+        assert public_key_path.exists()
+        assert file_permissions_are_strict(public_key_path)
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY="
+        )
+        assert _call_contains(
+            mock_execute_query, f"ALTER USER {user_name} SET RSA_PUBLIC_KEY_2="
+        )
+
+
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_rotate_overwrite_connection(
+    mock_connect,
+    mock_object_execute_query,
+    mock_execute_query,
+    runner,
+    mock_cursor,
+    test_snowcli_config,
+    os_agnostic_snapshot,
+):
+    _mock_user_and_public_key(mock_connect, mock_object_execute_query, mock_cursor)
+
+    with TemporaryDirectory() as tmp_dir:
+        runner.invoke(
+            ["auth", "keypair", "setup"],
+            input=f"Y\n{new_connection}\n4096\n{tmp_dir}\n\n",
+        )
+
+        result = runner.invoke(
+            ["auth", "keypair", "rotate", "--output-path", tmp_dir], input="n\n\n\n"
+        )
+
+        tmp_path = Path(tmp_dir)
+        private_key_path = tmp_path / "default.p8"
+        assert result.exit_code == 0, result.output
+        assert result.output == os_agnostic_snapshot
+        connection_config = get_connection_dict("default")
+        assert connection_config["authenticator"] == "SNOWFLAKE_JWT"
+        assert connection_config["private_key_file"] == str(private_key_path.resolve())
+        assert "password" not in connection_config.keys()
+
+
+@mock.patch(OBJECT_EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_list(
+    mock_connect, mock_execute_query, runner, mock_cursor, os_agnostic_snapshot
+):
+    mock_connect.return_value.user = user_name
+    mock_execute_query.return_value = mock_cursor(
+        rows=[
+            {
+                "property": "NAME",
+                "value": "test_user",
+                "default": None,
+                "description": "Name",
+            },
+            {
+                "property": "RSA_PUBLIC_KEY",
+                "value": "-----BEGIN PUBLIC KEY-----",
+                "default": None,
+                "description": "RSA public key of the user",
+            },
+            {
+                "property": "RSA_PUBLIC_KEY_FP",
+                "value": "SHA256",
+                "default": None,
+                "description": "Fingerprint of user's RSA public key.",
+            },
+            {
+                "property": "RSA_PUBLIC_KEY_LAST_SET_TIME",
+                "value": "2025-02-17 12:53:51.212",
+                "default": None,
+                "description": "The timestamp",
+            },
+            {
+                "property": "RSA_PUBLIC_KEY_2",
+                "value": None,
+                "default": None,
+                "description": "Second RSA public key of the user",
+            },
+            {
+                "property": "RSA_PUBLIC_KEY_2_FP",
+                "value": None,
+                "default": None,
+                "description": "Fingerprint of user's second RSA public key.",
+            },
+            {
+                "property": "RSA_PUBLIC_KEY_2_LAST_SET_TIME",
+                "value": None,
+                "default": None,
+                "description": "The timestamp",
+            },
+            {
+                "property": "COMMENT",
+                "value": None,
+                "default": None,
+                "description": "user comment",
+            },
+        ],
+        columns=[],
+    )
+
+    result = runner.invoke(["auth", "keypair", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == os_agnostic_snapshot
+
+
+@pytest.mark.parametrize("key", ["RSA_PUBLIC_KEY", "RSA_PUBLIC_KEY_2"])
+@mock.patch(EXECUTE_QUERY)
+@mock.patch(CONNECT)
+def test_remove(
+    mock_connect, mock_execute_query, runner, mock_cursor, os_agnostic_snapshot, key
+):
+    mock_connect.return_value.user = user_name
+    mock_execute_query.return_value = mock_cursor(
+        rows=[["Statement executed successfully."]], columns=["status"]
+    )
+    result = runner.invoke(["auth", "keypair", "remove", "--key-id", key])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == os_agnostic_snapshot
+    mock_execute_query.assert_called_once_with(f"ALTER USER test_user UNSET {key}")
+
+
+def _mock_user_and_empty_public_keys(
+    mock_connect, mock_object_execute_query, mock_cursor
+):
+    mock_connect.return_value.user = user_name
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": None},
+            {"property": "RSA_PUBLIC_KEY_2", "value": None},
+        ],
+        columns=[],
+    )
+
+
+def _mock_user_and_public_key(mock_connect, mock_object_execute_query, mock_cursor):
+    mock_connect.return_value.user = user_name
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": "KEY"},
+            {"property": "RSA_PUBLIC_KEY_2", "value": None},
+        ],
+        columns=[],
+    )
+
+
+def _call_contains(mock, search_string: str) -> bool:
+    for call in mock.mock_calls:
+        if search_string in str(call):
+            return True
+    return False

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -21,9 +21,9 @@ from unittest import mock
 
 import pytest
 import tomlkit
-from snowflake.cli._app.secret import SecretType
 from snowflake.cli.api.config import ConnectionConfig
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.secret import SecretType
 
 from tests.testing_utils.files_and_dirs import pushd
 from tests_common import IS_WINDOWS

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -16,7 +16,7 @@ import os
 from unittest import mock
 
 import pytest
-from snowflake.cli._app.secret import SecretType
+from snowflake.cli.api.secret import SecretType
 
 
 # Used as a solution to syrupy having some problems with comparing multilines string

--- a/tests_e2e/__snapshots__/test_installation.ambr
+++ b/tests_e2e/__snapshots__/test_installation.ambr
@@ -32,6 +32,7 @@
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app                  Manages a Snowflake Native App                          |
+  | auth                 Manages authentication methods.                         |
   | connection           Manages connections to Snowflake.                       |
   | cortex               Provides access to Snowflake Cortex.                    |
   | git                  Manages git repositories in Snowflake.                  |
@@ -100,6 +101,7 @@
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |
+  | auth         Manages authentication methods.                                 |
   | connection   Manages connections to Snowflake.                               |
   | cortex       Provides access to Snowflake Cortex.                            |
   | git          Manages git repositories in Snowflake.                          |
@@ -147,6 +149,7 @@
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app                  Manages a Snowflake Native App                          |
+  | auth                 Manages authentication methods.                         |
   | connection           Manages connections to Snowflake.                       |
   | cortex               Provides access to Snowflake Cortex.                    |
   | git                  Manages git repositories in Snowflake.                  |
@@ -231,6 +234,7 @@
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
   | app          Manages a Snowflake Native App                                  |
+  | auth         Manages authentication methods.                                 |
   | connection   Manages connections to Snowflake.                               |
   | cortex       Provides access to Snowflake Cortex.                            |
   | git          Manages git repositories in Snowflake.                          |

--- a/tests_integration/snowflake_connector.py
+++ b/tests_integration/snowflake_connector.py
@@ -22,7 +22,6 @@ from unittest import mock
 
 import pytest
 from snowflake import connector
-from snowflake.cli._app.secret import SecretType
 from snowflake.cli.api.exceptions import EnvironmentVariableNotFoundError
 from snowflake.cli._app.snow_connector import update_connection_details_with_private_key
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Added new `snow auth keypair` commands:
  * `setup` - generate key pair, set public key for the user in Snowflake and create/update the connection.
  * `rotate` - rotate keys for connection.
  * `list` - list the public keys for the user.
  * `remove` - remove the public key for the user.