### PR TITLE
Added auth keypair status command and extended connection add

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,8 @@
     * `rotate` - rotate keys for connection.
     * `list` - list the public keys for the user.
     * `remove` - remove the public key for the user.
+    * `status` - verifies the key pair configuration and tests the connection.
+* The `snow connection add` command has been enhanced to include key pair authentication when a password is provided.
 
 ## Fixes and improvements
 * Fix for incompatible options in `snow spcs compute-pool` commands didn't raise error.

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -21,7 +21,7 @@ from typing import Dict, Optional
 
 import snowflake.connector
 from click.exceptions import ClickException
-from snowflake.cli.__about__ import VERSION
+from snowflake.cli import __about__
 from snowflake.cli._app.constants import (
     INTERNAL_APPLICATION_NAME,
     PARAM_APPLICATION_NAME,
@@ -247,7 +247,7 @@ def _update_internal_application_info(connection_parameters: Dict):
     """Update internal application data if ENABLE_SEPARATE_AUTHENTICATION_POLICY_ID is enabled."""
     if FeatureFlag.ENABLE_SEPARATE_AUTHENTICATION_POLICY_ID.is_enabled():
         connection_parameters["internal_application_name"] = INTERNAL_APPLICATION_NAME
-        connection_parameters["internal_application_version"] = VERSION
+        connection_parameters["internal_application_version"] = __about__.VERSION
 
 
 def _load_pem_from_file(private_key_file: str) -> SecretType:

--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Union
 
 import click
 import typer
-from snowflake.cli.__about__ import VERSION
+from snowflake.cli import __about__
 from snowflake.cli._app.constants import PARAM_APPLICATION_NAME
 from snowflake.cli.api.cli_global_context import (
     _CliGlobalContextAccess,
@@ -215,7 +215,7 @@ class CLITelemetryClient:
         data = {
             CLITelemetryField.SOURCE: PARAM_APPLICATION_NAME,
             CLITelemetryField.INSTALLATION_SOURCE: _get_installation_source().value,
-            CLITelemetryField.VERSION_CLI: VERSION,
+            CLITelemetryField.VERSION_CLI: __about__.VERSION,
             CLITelemetryField.VERSION_OS: platform.platform(),
             CLITelemetryField.VERSION_PYTHON: python_version(),
             CLITelemetryField.COMMAND_CI_ENVIRONMENT: _get_ci_environment_type(),

--- a/src/snowflake/cli/_plugins/auth/keypair/commands.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/commands.py
@@ -31,12 +31,6 @@ def _show_connection_name_prompt(ctx: typer.Context, value: str):
     return value
 
 
-def _resolve_default_and_convert(value: Path) -> Path:
-    if value:
-        return value
-    return Path.home()
-
-
 _new_connection_option = typer.Option(
     True,
     help="Create a new connection.",
@@ -69,7 +63,6 @@ _output_path_option = typer.Option(
     "--output-path",
     help="The output path for private and public keys",
     prompt="Enter output path",
-    callback=_resolve_default_and_convert,
 )
 
 

--- a/src/snowflake/cli/_plugins/auth/keypair/commands.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/commands.py
@@ -19,6 +19,9 @@ app = SnowTyperFactory(
 )
 
 
+KEY_PAIR_DEFAULT_PATH = "~/.ssh"
+
+
 def _show_connection_name_prompt(ctx: typer.Context, value: str):
     for param in ctx.command.params:
         if param.name == "connection_name":
@@ -38,7 +41,6 @@ _new_connection_option = typer.Option(
     True,
     help="Create a new connection.",
     prompt="Create a new connection?",
-    confirmation_prompt=True,
     callback=_show_connection_name_prompt,
     show_default=False,
     hidden=True,
@@ -63,7 +65,7 @@ _key_length_option = typer.Option(
 
 
 _output_path_option = typer.Option(
-    "~/.ssh",
+    KEY_PAIR_DEFAULT_PATH,
     "--output-path",
     help="The output path for private and public keys",
     prompt="Enter output path",
@@ -148,3 +150,12 @@ def remove(
     return SingleQueryResult(
         AuthManager().remove_public_key(public_key_property=public_key_property)
     )
+
+
+@app.command("status", requires_connection=True)
+def status(**options):
+    """
+    Verifies the key pair configuration and tests the connection.
+    """
+    AuthManager().status()
+    return MessageResult("Status check completed.")

--- a/src/snowflake/cli/_plugins/auth/keypair/manager.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/manager.py
@@ -82,7 +82,7 @@ class AuthManager(SqlExecutionMixin):
         if not connection_name:
             connection_name = cli_context.connection_context.connection_name
 
-        self._check_if_connection_has_private_key(
+        self._ensure_connection_has_private_key(
             cli_context.connection_context.connection_name
         )
 
@@ -177,7 +177,7 @@ class AuthManager(SqlExecutionMixin):
 
     def status(self):
         cli_context = get_cli_context()
-        self._check_if_connection_has_private_key(
+        self._ensure_connection_has_private_key(
             cli_context.connection_context.connection_name
         )
         cli_console.step("Private key set for connection - OK")
@@ -212,7 +212,7 @@ class AuthManager(SqlExecutionMixin):
         return connection_options
 
     @staticmethod
-    def _check_if_connection_has_private_key(connection_name: str) -> None:
+    def _ensure_connection_has_private_key(connection_name: str) -> None:
         connection = get_connection_dict(connection_name)
         if not connection.get("private_key_file") and not connection.get(
             "private_key_path"

--- a/src/snowflake/cli/_plugins/auth/keypair/manager.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/manager.py
@@ -308,8 +308,7 @@ class AuthManager(SqlExecutionMixin):
         private_key_path: SecurePath,
     ):
         connection = get_connection_dict(current_connection)
-        if connection.get("password"):
-            del connection["password"]
+        connection.pop("password", None)
         connection["authenticator"] = "SNOWFLAKE_JWT"
         connection["private_key_file"] = str(private_key_path.path)
 

--- a/src/snowflake/cli/_plugins/auth/keypair/manager.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/manager.py
@@ -5,7 +5,10 @@ from click import ClickException
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from snowflake.cli._plugins.object.manager import ObjectManager
-from snowflake.cli.api.cli_global_context import get_cli_context
+from snowflake.cli.api.cli_global_context import (
+    _CliGlobalContextAccess,
+    get_cli_context,
+)
 from snowflake.cli.api.config import (
     connection_exists,
     get_connection_dict,
@@ -45,24 +48,12 @@ class AuthManager(SqlExecutionMixin):
         if not connection_name:
             connection_name = cli_context.connection_context.connection_name
 
-        public_key_exists, public_key_2_exists = self._get_public_keys()
-
-        if public_key_exists or public_key_2_exists:
-            raise ClickException(
-                "The public key is set already. Use the rotate command instead."
-            )
-
-        if not output_path.exists():
-            output_path.mkdir(parents=True)
-
-        public_key = self._generate_keys_and_return_public_key(
+        self._generate_key_pair_and_set_public_key(
+            user=cli_context.connection.user,
             key_length=key_length,
             output_path=output_path,
-            key_name=connection_name,  # type: ignore[arg-type]
+            connection_name=connection_name,  # type: ignore[arg-type]
             private_key_passphrase=private_key_passphrase,
-        )
-        self.set_public_key(
-            cli_context.connection.user, PublicKeyProperty.RSA_PUBLIC_KEY, public_key
         )
 
         self._create_or_update_connection(
@@ -124,6 +115,32 @@ class AuthManager(SqlExecutionMixin):
             ),
         )
 
+    def _generate_key_pair_and_set_public_key(
+        self,
+        user: str,
+        key_length: int,
+        output_path: SecurePath,
+        connection_name: str,
+        private_key_passphrase: SecretType,
+    ):
+        public_key_exists, public_key_2_exists = self._get_public_keys()
+
+        if public_key_exists or public_key_2_exists:
+            raise ClickException(
+                "The public key is set already. Use the rotate command instead."
+            )
+
+        if not output_path.exists():
+            output_path.mkdir(parents=True)
+
+        public_key = self._generate_keys_and_return_public_key(
+            key_length=key_length,
+            output_path=output_path,
+            key_name=connection_name,  # type: ignore[arg-type]
+            private_key_passphrase=private_key_passphrase,
+        )
+        self.set_public_key(user, PublicKeyProperty.RSA_PUBLIC_KEY, public_key)
+
     def list_keys(self) -> List[Dict]:
         key_properties = [
             "RSA_PUBLIC_KEY",
@@ -133,10 +150,9 @@ class AuthManager(SqlExecutionMixin):
             "RSA_PUBLIC_KEY_2_FP",
             "RSA_PUBLIC_KEY_2_LAST_SET_TIME",
         ]
-        cli_context = get_cli_context()
-        cursor = ObjectManager().describe(
+        cursor = ObjectManager(connection=self._conn).describe(
             object_type=ObjectType.USER.value.sf_name,
-            fqn=FQN.from_string(cli_context.connection.user),
+            fqn=FQN.from_string(self._conn.user),
             cursor_class=DictCursor,
         )
         only_public_key_properties = [
@@ -159,13 +175,55 @@ class AuthManager(SqlExecutionMixin):
             f"ALTER USER {cli_context.connection.user} UNSET {public_key_property.value}"
         )
 
+    def status(self):
+        cli_context = get_cli_context()
+        self._check_if_connection_has_private_key(
+            cli_context.connection_context.connection_name
+        )
+        cli_console.step("Private key set for connection - OK")
+        self._check_connection(cli_context)
+        cli_console.step("Test connection - OK")
+
+    def extend_connection_add(
+        self,
+        connection_name: str,
+        connection_options: Dict,
+        key_length: int,
+        output_path: SecurePath,
+        private_key_passphrase: SecretType,
+    ) -> Dict:
+        self._generate_key_pair_and_set_public_key(
+            user=connection_options["user"],
+            key_length=key_length,
+            output_path=output_path,
+            connection_name=connection_name,
+            private_key_passphrase=private_key_passphrase,
+        )
+
+        connection_options["authenticator"] = "SNOWFLAKE_JWT"
+        connection_options["private_key_file"] = str(
+            self._get_private_key_path(
+                output_path=output_path, key_name=connection_name
+            ).path
+        )
+        if connection_options.get("password"):
+            del connection_options["password"]
+
+        return connection_options
+
     @staticmethod
-    def _check_if_connection_has_private_key(connection_name: str):
+    def _check_if_connection_has_private_key(connection_name: str) -> None:
         connection = get_connection_dict(connection_name)
-        if connection.get("private_key_file") and connection.get("private_key_path"):
+        if not connection.get("private_key_file") and not connection.get(
+            "private_key_path"
+        ):
             raise ClickException(
                 f"The private key is not set in {connection_name} connection."
             )
+
+    @staticmethod
+    def _check_connection(cli_context: _CliGlobalContextAccess) -> None:
+        cli_context.connection
 
     def _get_public_keys(self) -> Tuple[str, str]:
         keys = self.list_keys()
@@ -250,14 +308,9 @@ class AuthManager(SqlExecutionMixin):
         private_key_path: SecurePath,
     ):
         connection = get_connection_dict(current_connection)
-        del connection["password"]
+        if connection.get("password"):
+            del connection["password"]
         connection["authenticator"] = "SNOWFLAKE_JWT"
         connection["private_key_file"] = str(private_key_path.path)
 
         set_config_value(["connections", connection_name], value=connection)
-
-    @staticmethod
-    def _find_public_key_2(list_keys: List[Dict[str, str]]):
-        for p in list_keys:
-            if p.get("property") == PublicKeyProperty.RSA_PUBLIC_KEY_2.value:
-                return p.get("value")

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -429,16 +429,11 @@ def _extend_add_with_key_pair(connection_name: str, connection_options: Dict):
                 show_default=True,
             )
 
-            def output_path_parser(value: str) -> SecurePath:
-                if value == KEY_PAIR_DEFAULT_PATH:
-                    return SecurePath(Path.home())
-                return SecurePath(value)
-
             output_path = typer.prompt(
                 "Output path",
                 default=KEY_PAIR_DEFAULT_PATH,
                 show_default=True,
-                value_proc=output_path_parser,
+                value_proc=lambda value: SecurePath(value),
             )
             private_key_passphrase = typer.prompt(
                 "Private key passphrase",

--- a/src/snowflake/cli/api/secure_path.py
+++ b/src/snowflake/cli/api/secure_path.py
@@ -38,7 +38,7 @@ UNLIMITED = -1
 
 class SecurePath:
     def __init__(self, path: Union[Path, str]):
-        self._path = Path(path)
+        self._path = Path(os.path.expanduser(path))
 
     def __repr__(self):
         return f'SecurePath("{self._path}")'

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -3318,6 +3318,95 @@
   
   '''
 # ---
+# name: test_help_messages[auth.keypair.status]
+  '''
+                                                                                  
+   Usage: root auth keypair status [OPTIONS]                                      
+                                                                                  
+   Verifies the key pair configuration and tests the connection.                  
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment     -c      TEXT     Name of the connection, as   |
+  |                                                 defined in your config.toml  |
+  |                                                 file. Default: default.      |
+  | --host                                 TEXT     Host address for the         |
+  |                                                 connection. Overrides the    |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --port                                 INTEGER  Port for the connection.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --account,--accountname                TEXT     Name assigned to your        |
+  |                                                 Snowflake account. Overrides |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --user,--username                      TEXT     Username to connect to       |
+  |                                                 Snowflake. Overrides the     |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --password                             TEXT     Snowflake password.          |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --authenticator                        TEXT     Snowflake authenticator.     |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --private-key-file,--private…          TEXT     Snowflake private key file   |
+  |                                                 path. Overrides the value    |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --token-file-path                      TEXT     Path to file with an OAuth   |
+  |                                                 token that should be used    |
+  |                                                 when connecting to Snowflake |
+  | --database,--dbname                    TEXT     Database to use. Overrides   |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --schema,--schemaname                  TEXT     Database schema to use.      |
+  |                                                 Overrides the value          |
+  |                                                 specified for the            |
+  |                                                 connection.                  |
+  | --role,--rolename                      TEXT     Role to use. Overrides the   |
+  |                                                 value specified for the      |
+  |                                                 connection.                  |
+  | --warehouse                            TEXT     Warehouse to use. Overrides  |
+  |                                                 the value specified for the  |
+  |                                                 connection.                  |
+  | --temporary-connection         -x               Uses a connection defined    |
+  |                                                 with command line            |
+  |                                                 parameters, instead of one   |
+  |                                                 defined in config            |
+  | --mfa-passcode                         TEXT     Token to use for             |
+  |                                                 multi-factor authentication  |
+  |                                                 (MFA)                        |
+  | --enable-diag                                   Whether to generate a        |
+  |                                                 connection diagnostic        |
+  |                                                 report.                      |
+  | --diag-log-path                        TEXT     Path for the generated       |
+  |                                                 report. Defaults to system   |
+  |                                                 temporary directory.         |
+  | --diag-allowlist-path                  TEXT     Path to a JSON file          |
+  |                                                 containing allowlist         |
+  |                                                 parameters.                  |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format           [TABLE|JSON]  Specifies the output format.                |
+  |                                  [default: TABLE]                            |
+  | --verbose  -v                    Displays log entries for log levels info    |
+  |                                  and higher.                                 |
+  | --debug                          Displays log entries for log levels debug   |
+  |                                  and higher; debug logs contain additional   |
+  |                                  information.                                |
+  | --silent                         Turns off intermediate output to console.   |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[auth.keypair]
   '''
                                                                                   
@@ -3336,6 +3425,7 @@
   |          connection.                                                         |
   | setup    Generates the key pair, sets the public key for the user in         |
   |          Snowflake and creates or updates the connection.                    |
+  | status   Verifies the key pair configuration and tests the connection.       |
   +------------------------------------------------------------------------------+
   
   
@@ -13279,6 +13369,7 @@
   |          connection.                                                         |
   | setup    Generates the key pair, sets the public key for the user in         |
   |          Snowflake and creates or updates the connection.                    |
+  | status   Verifies the key pair configuration and tests the connection.       |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/auth/__snapshots__/test_auth.ambr
+++ b/tests/auth/__snapshots__/test_auth.ambr
@@ -54,6 +54,16 @@
   
   '''
 # ---
+# name: test_rotate_create_output_directory_with_proper_privileges
+  '''
+  Create a new connection? [Y/n]: Y
+  Enter connection name: keypairconnection
+  Enter key length [2048]: 4096
+  Enter private key passphrase []: 
+  Rotate completed.
+  
+  '''
+# ---
 # name: test_rotate_no_prompts
   '''
   Create a new connection? [Y/n]: 

--- a/tests/auth/__snapshots__/test_auth.ambr
+++ b/tests/auth/__snapshots__/test_auth.ambr
@@ -212,3 +212,28 @@
   
   '''
 # ---
+# name: test_status
+  '''
+  Private key set for connection - OK
+  Test connection - OK
+  Status check completed.
+  
+  '''
+# ---
+# name: test_status_no_authenticator
+  '''
+  Private key set for connection - OK
+  +- Error ----------------------------------------------------------------------+
+  | Private Key authentication requires authenticator set to SNOWFLAKE_JWT       |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
+# name: test_status_no_private_key_in_connection
+  '''
+  +- Error ----------------------------------------------------------------------+
+  | The private key is not set in default connection.                            |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
@@ -7,8 +6,6 @@ from unittest import mock
 import pytest
 from snowflake.cli.api.config import get_connection_dict
 from snowflake.cli.api.secure_utils import file_permissions_are_strict
-
-from tests.testing_utils.fixtures import _named_temporary_file
 
 EXECUTE_QUERY = "snowflake.cli._plugins.auth.keypair.manager.AuthManager.execute_query"
 OBJECT_EXECUTE_QUERY = (
@@ -794,18 +791,6 @@ def test_remove(
     assert result.exit_code == 0, result.output
     assert result.output == os_agnostic_snapshot
     mock_execute_query.assert_called_once_with(f"ALTER USER test_user UNSET {key}")
-
-
-@pytest.fixture
-def config_file():
-    @contextmanager
-    def _config_file(content: str):
-        with _named_temporary_file(suffix=".toml") as p:
-            p.write_text(content)
-            p.chmod(0o600)  # Make config file private
-            yield p
-
-    return _config_file
 
 
 def _mock_user_and_empty_public_keys(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1531,9 +1531,6 @@ def test_connection_add_no_key_pair_setup_if_private_key_provided(
 def test_connection_add_no_key_pair_setup_if_no_interactive(
     runner, tmp_path, test_snowcli_config
 ):
-    key = tmp_path / "key.p8"
-    key.touch()
-
     result = runner.invoke(
         [
             "connection",
@@ -1546,20 +1543,6 @@ def test_connection_add_no_key_pair_setup_if_no_interactive(
             "account",
             "--no-interactive",
         ],
-        input="conn\n"  # connection name: zz
-        "test\n"  # account:
-        "user\n"  # user:
-        "\n"  # password:
-        "\n"  # role:
-        "\n"  # warehouse:
-        "\n"  # database:
-        "\n"  # schema:
-        "\n"  # host:
-        "\n"  # port:
-        "\n"  # region:
-        "\n"  # authenticator:
-        f"{key}\n"  # private key file:
-        "\n",  # token file path:
     )
     assert result.exit_code == 0, result.output
     assert (

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -24,6 +24,7 @@ import tomlkit
 from snowflake.cli.api.config import ConnectionConfig
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.secret import SecretType
+from snowflake.cli.api.secure_utils import file_permissions_are_strict
 
 from tests.testing_utils.files_and_dirs import pushd
 from tests_common import IS_WINDOWS
@@ -1237,7 +1238,7 @@ def test_generate_jwt_with_passphrase(
     )
 
 
-@mock.patch.dict(os.environ, {"PRIVATE_KEY_PASSPHRASE": "123"})
+@mock.patch.dict(os.environ, {"PRIVATE_KEY_PASSPHRASE": "123"}, clear=True)
 @mock.patch(
     "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
 )
@@ -1396,4 +1397,171 @@ def test_connection_add_no_interactive(mock_add, runner):
             token_file_path=None,
             _other_settings={},
         ),
+    )
+
+
+@mock.patch("snowflake.cli._plugins.auth.keypair.manager.AuthManager.execute_query")
+@mock.patch("snowflake.cli._plugins.object.manager.ObjectManager.execute_query")
+@mock.patch("snowflake.connector.connect")
+def test_connection_add_with_key_pair(
+    mock_connect,
+    mock_object_execute_query,
+    mock_auth_execute_query,
+    runner,
+    tmp_path,
+    mock_cursor,
+    test_snowcli_config,
+):
+    mock_connect.return_value.user = "user"
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": None},
+            {"property": "RSA_PUBLIC_KEY_2", "value": None},
+        ],
+        columns=[],
+    )
+
+    result = runner.invoke(
+        [
+            "connection",
+            "add",
+        ],
+        input="conn\n"  # connection name: zz
+        "test\n"  # account:
+        "user\n"  # user:
+        "123\n"  # password:
+        "\n"  # role:
+        "\n"  # warehouse:
+        "\n"  # database:
+        "\n"  # schema:
+        "\n"  # host:
+        "\n"  # port:
+        "\n"  # region:
+        "\n"  # authenticator:
+        "\n"  # private key file:
+        "\n"  # token file path:
+        "y\n"  #
+        "4096\n"  # key_length
+        f"{tmp_path}\n"  # output_path
+        "123\n",  # passphrase
+    )
+
+    private_key_path = tmp_path / "conn.p8"
+    public_key_path = tmp_path / "conn.pub"
+    assert result.exit_code == 0, result.output
+    assert result.output == dedent(
+        f"""\
+        Enter connection name: conn
+        Enter account: test
+        Enter user: user
+        Enter password: 
+        Enter role: 
+        Enter warehouse: 
+        Enter database: 
+        Enter schema: 
+        Enter host: 
+        Enter port: 
+        Enter region: 
+        Enter authenticator: 
+        Enter private key file: 
+        Enter token file path: 
+        Do you want to configure key pair authentication? [y/N]: y
+        Key length [2048]: 4096
+        Output path [~/.ssh]: {tmp_path}
+        Private key passphrase: 
+        Set the `PRIVATE_KEY_PASSPHRASE` environment variable before using the connection.
+        Wrote new connection conn to {test_snowcli_config}
+        """
+    )
+    assert private_key_path.exists()
+    assert "BEGIN ENCRYPTED PRIVATE KEY" in private_key_path.read_text()
+    assert file_permissions_are_strict(private_key_path)
+    assert public_key_path.exists()
+    assert file_permissions_are_strict(public_key_path)
+
+
+def test_connection_add_no_key_pair_setup_if_private_key_provided(
+    runner, test_snowcli_config, tmp_path
+):
+    key = tmp_path / "key.p8"
+    key.touch()
+
+    result = runner.invoke(
+        [
+            "connection",
+            "add",
+        ],
+        input="conn\n"  # connection name: zz
+        "test\n"  # account:
+        "user\n"  # user:
+        "\n"  # password:
+        "\n"  # role:
+        "\n"  # warehouse:
+        "\n"  # database:
+        "\n"  # schema:
+        "\n"  # host:
+        "\n"  # port:
+        "\n"  # region:
+        "\n"  # authenticator:
+        f"{key}\n"  # private key file:
+        "\n",  # token file path:
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == dedent(
+        f"""\
+        Enter connection name: conn
+        Enter account: test
+        Enter user: user
+        Enter password: 
+        Enter role: 
+        Enter warehouse: 
+        Enter database: 
+        Enter schema: 
+        Enter host: 
+        Enter port: 
+        Enter region: 
+        Enter authenticator: 
+        Enter private key file: {key.resolve()}
+        Enter token file path: 
+        Wrote new connection conn to {test_snowcli_config}
+        """
+    )
+
+
+def test_connection_add_no_key_pair_setup_if_no_interactive(
+    runner, tmp_path, test_snowcli_config
+):
+    key = tmp_path / "key.p8"
+    key.touch()
+
+    result = runner.invoke(
+        [
+            "connection",
+            "add",
+            "--connection-name",
+            "conn",
+            "--user",
+            "user",
+            "--account",
+            "account",
+            "--no-interactive",
+        ],
+        input="conn\n"  # connection name: zz
+        "test\n"  # account:
+        "user\n"  # user:
+        "\n"  # password:
+        "\n"  # role:
+        "\n"  # warehouse:
+        "\n"  # database:
+        "\n"  # schema:
+        "\n"  # host:
+        "\n"  # port:
+        "\n"  # region:
+        "\n"  # authenticator:
+        f"{key}\n"  # private key file:
+        "\n",  # token file path:
+    )
+    assert result.exit_code == 0, result.output
+    assert (
+        result.output.strip() == f"Wrote new connection conn to {test_snowcli_config}"
     )

--- a/tests/test_secret_type.py
+++ b/tests/test_secret_type.py
@@ -1,0 +1,11 @@
+from snowflake.cli.api.secret import SecretType
+
+
+def test_secret_type():
+    secret_type = SecretType("secret")
+
+    assert str(secret_type) == "***"
+    assert repr(secret_type) == "SecretType(***)"
+    assert f"{secret_type}" == "***"
+    assert "{}".format(secret_type) == "***"
+    assert "%s" % secret_type == "***"

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -286,6 +286,18 @@ def test_snowcli_config():
         yield p
 
 
+@pytest.fixture
+def config_file():
+    @contextmanager
+    def _config_file(content: str):
+        with _named_temporary_file(suffix=".toml") as p:
+            p.write_text(content)
+            p.chmod(0o600)  # Make config file private
+            yield p
+
+    return _config_file
+
+
 @pytest.fixture(scope="function")
 def empty_snowcli_config():
     with _named_temporary_file(suffix=".toml") as p:


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added `snow auth keypair status` command to verify the key pair configuration and test the connection.
The `snow connection add` command has been enhanced to include key pair authentication when a password is provided.
Added support for ~ in SecurePath