### PR TITLE
feat: [SNOW-1966187] fix recursive copy for unbalanced trees

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
 ## Fixes and improvements
 * Fix for incompatible options in `snow spcs compute-pool` commands didn't raise error.
 * Change binary builds to embed whole Python environment.
+* Fixed recursive copying to stage for unbalanced directory trees
 
 # v3.5.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,7 +28,7 @@
 ## Fixes and improvements
 * Fix for incompatible options in `snow spcs compute-pool` commands didn't raise error.
 * Change binary builds to embed whole Python environment.
-* Fixed recursive copying to stage for unbalanced directory trees
+* Fixed recursive copying to stage for unbalanced directory trees.
 
 # v3.5.0
 

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -439,9 +439,14 @@ class StageManager(SqlExecutionMixin):
                 # We end if we reach the root directory
                 if directory == temp_dir_with_copy:
                     break
-
                 # Add parent directory to the list if it's not already there
-                if directory.parent not in deepest_dirs_list:
+                if directory.parent not in deepest_dirs_list and not any(
+                    (
+                        1
+                        for existing_dir in deepest_dirs_list
+                        if existing_dir.is_relative_to(directory.parent)
+                    )
+                ):
                     deepest_dirs_list.append(directory.parent)
 
                 # Remove the directory so the parent directory will contain only files

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -442,9 +442,8 @@ class StageManager(SqlExecutionMixin):
                 # Add parent directory to the list if it's not already there
                 if directory.parent not in deepest_dirs_list and not any(
                     (
-                        1
+                        existing_dir.is_relative_to(directory.parent)
                         for existing_dir in deepest_dirs_list
-                        if existing_dir.is_relative_to(directory.parent)
                     )
                 ):
                     deepest_dirs_list.append(directory.parent)

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -1339,3 +1339,30 @@ def test_recursive_upload_no_recursive_glob_pattern(temp_dir):
             stage_path=StagePath.from_stage_str("@stageName"),
         ),
     ]
+
+
+NESTED_UNBALANCED_STRUCTURE = {
+    "dir1": {
+        "dir2": {
+            "file2.py": "content2",
+        },
+        "dir3": {
+            "dir4": {
+                "dir5": {
+                    "file5.py": "content5",
+                }
+            },
+        },
+    },
+}
+
+
+def test_recursive_unbalanced_tree(temp_dir):
+    """
+    SNOW-1966187 - with certain directory structure we were deleting nodes
+    before they were processed. This was mostly visible when there was a
+    shallow branch and deep branch starting from the same directory.
+    """
+    tester = RecursiveUploadTester(temp_dir)
+    tester.prepare(structure=NESTED_UNBALANCED_STRUCTURE)
+    tester.execute(local_path=temp_dir + "/")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
https://snowflakecomputing.atlassian.net/browse/SNOW-1966187

Fixes a bug where recursive copying to stage for unbalanced directory trees was not working as expected due to potential deletion of directories before they were processed.
