### PR TITLE
Snow 1999047 fix binaries visible as pypi in telemetry

### DIFF
--- a/scripts/packaging/build_isolated_binary_with_hatch.py
+++ b/scripts/packaging/build_isolated_binary_with_hatch.py
@@ -142,7 +142,6 @@ def pip_install_project(python_exe: str) -> bool:
 def hatch_build_binary(archive_path: Path, python_path: Path) -> Path | None:
     """Use hatch to build the binary."""
     os.environ["PYAPP_SKIP_INSTALL"] = "1"
-    os.environ["PYAPP_SELF_COMMAND"] = "1"
     os.environ["PYAPP_DISTRIBUTION_PATH"] = str(archive_path)
     os.environ["PYAPP_FULL_ISOLATION"] = "1"
     os.environ["PYAPP_DISTRIBUTION_PYTHON_PATH"] = str(python_path)

--- a/scripts/packaging/build_isolated_binary_with_hatch.py
+++ b/scripts/packaging/build_isolated_binary_with_hatch.py
@@ -164,7 +164,7 @@ def main():
     print("-> installed")
 
     print(f"Installing project into Python distribution...")
-    with override_is_installed_from_binary_variable():
+    with override_is_installation_source_variable():
         pip_install_project(str(settings.python_dist_exe))
     print("-> installed")
 

--- a/scripts/packaging/build_isolated_binary_with_hatch.py
+++ b/scripts/packaging/build_isolated_binary_with_hatch.py
@@ -127,7 +127,7 @@ def override_is_installed_from_binary_variable():
         )
     )
     yield
-    subprocess.run(["git", "checkout", str(PROJECT_ROOT)])
+    subprocess.run(["git", "checkout", str(about_file)])
 
 
 def pip_install_project(python_exe: str) -> bool:

--- a/scripts/packaging/build_isolated_binary_with_hatch.py
+++ b/scripts/packaging/build_isolated_binary_with_hatch.py
@@ -22,7 +22,7 @@ import tomlkit
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
-IS_INSTALLED_FROM_BINARY = "IS_INSTALLED_FROM_BINARY"
+INSTALLATION_SOURCE_VARIABLE = "INSTALLATION_SOURCE"
 
 
 @contextlib.contextmanager
@@ -114,16 +114,17 @@ def hatch_install_python(python_tmp_dir: Path, python_version: str) -> bool:
 
 
 @contextlib.contextmanager
-def override_is_installed_from_binary_variable():
+def override_is_installation_source_variable():
     about_file = PROJECT_ROOT / "src" / "snowflake" / "cli" / "__about__.py"
     contents = about_file.read_text()
-    if "IS_INSTALLED_FROM_BINARY" not in contents:
+    if INSTALLATION_SOURCE_VARIABLE not in contents:
         raise RuntimeError(
-            "IS_INSTALLED_FROM_BINARY variable not defined in __about__.py"
+            f"{INSTALLATION_SOURCE_VARIABLE} variable not defined in __about__.py"
         )
     about_file.write_text(
         contents.replace(
-            f"{IS_INSTALLED_FROM_BINARY} = False", f"{IS_INSTALLED_FROM_BINARY} = True"
+            f"{INSTALLATION_SOURCE_VARIABLE} = CLIInstallationSource.PYPI",
+            f"{INSTALLATION_SOURCE_VARIABLE} = CLIInstallationSource.BINARY",
         )
     )
     yield

--- a/src/snowflake/cli/__about__.py
+++ b/src/snowflake/cli/__about__.py
@@ -14,6 +14,16 @@
 
 from __future__ import annotations
 
+from enum import Enum, unique
+
 VERSION = "3.7.0.dev0"
 
-IS_INSTALLED_FROM_BINARY = False
+
+@unique
+class CLIInstallationSource(Enum):
+    BINARY = "binary"
+    PYPI = "pypi"
+
+
+# This variable is changed in binary release script
+INSTALLATION_SOURCE = CLIInstallationSource.PYPI

--- a/src/snowflake/cli/__about__.py
+++ b/src/snowflake/cli/__about__.py
@@ -15,3 +15,5 @@
 from __future__ import annotations
 
 VERSION = "3.7.0.dev0"
+
+IS_INSTALLED_FROM_BINARY = False

--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -41,12 +41,6 @@ from snowflake.connector.time_util import get_time_millis
 
 
 @unique
-class CLIInstallationSource(Enum):
-    BINARY = "binary"
-    PYPI = "pypi"
-
-
-@unique
 class CLITelemetryField(Enum):
     # Basic information
     SOURCE = "source"
@@ -172,14 +166,6 @@ def _get_definition_version() -> str | None:
     return None
 
 
-def _get_installation_source() -> CLIInstallationSource:
-    from snowflake.cli.__about__ import IS_INSTALLED_FROM_BINARY
-
-    if IS_INSTALLED_FROM_BINARY:
-        return CLIInstallationSource.BINARY
-    return CLIInstallationSource.PYPI
-
-
 def _get_ci_environment_type() -> str:
     if "GITHUB_ACTIONS" in os.environ:
         return "GITHUB_ACTIONS"
@@ -216,7 +202,7 @@ class CLITelemetryClient:
     ) -> Dict[str, Any]:
         data = {
             CLITelemetryField.SOURCE: PARAM_APPLICATION_NAME,
-            CLITelemetryField.INSTALLATION_SOURCE: _get_installation_source().value,
+            CLITelemetryField.INSTALLATION_SOURCE: __about__.INSTALLATION_SOURCE.value,
             CLITelemetryField.VERSION_CLI: __about__.VERSION,
             CLITelemetryField.VERSION_OS: platform.platform(),
             CLITelemetryField.VERSION_PYTHON: python_version(),

--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -173,7 +173,9 @@ def _get_definition_version() -> str | None:
 
 
 def _get_installation_source() -> CLIInstallationSource:
-    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+    from snowflake.cli.__about__ import IS_INSTALLED_FROM_BINARY
+
+    if IS_INSTALLED_FROM_BINARY:
         return CLIInstallationSource.BINARY
     return CLIInstallationSource.PYPI
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix binaries introducing themselves as pypi installation in telemetry.
**Changes:**
* Introduce variable `IS_INSTALLED_FROM_BINARY` variable to `__about__.py`, which is overridden by binary building script. The script will fail if the variable is not defined.

**Tests:**
* Branch `pczajka-test-telemtry` contains "debug" commit that adds debug info to "connection list" command.
  * Check pypi version:
  ```
  > pip install git+https://github.com/snowflakedb/snowflake-cli.git@pczajka-test-telemtry
  > snow connection list
  Checking installation source:
    pypi
  ```
  * Check binary version:
  ```
  > python scripts/packaging/build_isolated_binary_with_hatch.py
  > ./dist/binary/snow-3.6.0rc0 connection list
  Checking installation source:
    binary
  ```

