### PR TITLE
Change default model for Snowflake Complete CLI

### DIFF
--- a/src/snowflake/cli/_plugins/cortex/constants.py
+++ b/src/snowflake/cli/_plugins/cortex/constants.py
@@ -14,4 +14,4 @@
 
 from snowflake.cli._plugins.cortex.types import Model
 
-DEFAULT_MODEL: Model = Model("snowflake-arctic")
+DEFAULT_MODEL: Model = Model("snowflake-llama-3.3-70b")


### PR DESCRIPTION
This PR updates the default model for `snow cortex complete` to a newer model