### PR TITLE
feat: [SNOW-2002186] save password based connection if subsequent key…

### DIFF
--- a/src/snowflake/cli/_plugins/auth/keypair/manager.py
+++ b/src/snowflake/cli/_plugins/auth/keypair/manager.py
@@ -50,18 +50,13 @@ class AuthManager(SqlExecutionMixin):
             connection_name = cli_context.connection_context.connection_name
 
         key_name = AuthManager._get_free_key_name(output_path, connection_name)  # type: ignore[arg-type]
-        try:
-            self._generate_key_pair_and_set_public_key(
-                user=cli_context.connection.user,
-                key_length=key_length,
-                output_path=output_path,
-                key_name=key_name,  # type: ignore[arg-type]
-                private_key_passphrase=private_key_passphrase,
-            )
-        except exceptions.CouldNotSetKeyPairError:
-            raise ClickException(
-                "The public key is set already. Use the rotate command instead."
-            )
+        self._generate_key_pair_and_set_public_key(
+            user=cli_context.connection.user,
+            key_length=key_length,
+            output_path=output_path,
+            key_name=key_name,  # type: ignore[arg-type]
+            private_key_passphrase=private_key_passphrase,
+        )
 
         self._create_or_update_connection(
             current_connection=cli_context.connection_context.connection_name,

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -236,3 +236,7 @@ class ShowSpecificObjectMultipleRowsError(RuntimeError):
         super().__init__(
             f"Received multiple rows from result of SQL statement: {show_obj_query}. Usage of 'show_specific_object' may not be properly scoped."
         )
+
+
+class CouldNotSetKeyPairError(Exception):
+    ...

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -238,5 +238,8 @@ class ShowSpecificObjectMultipleRowsError(RuntimeError):
         )
 
 
-class CouldNotSetKeyPairError(Exception):
-    ...
+class CouldNotSetKeyPairError(ClickException):
+    def __init__(self):
+        super().__init__(
+            "The public key is set already. Use the rotate command instead."
+        )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1617,8 +1617,8 @@ def test_connection_add_with_key_pair_saves_password_if_keypair_is_set(
         Key length [2048]: 
         Output path [~/.ssh]: {tmp_path}
         Private key passphrase: 
-        Wrote new password-based connection conn to {test_snowcli_config}, however there were some issues during key pair setup:
-        The public key is set already. Use the rotate command instead.
+        Wrote new password-based connection conn to {test_snowcli_config}, however there were some issues during key pair setup. Review the following error and check 'snow auth keypair' commands to setup key pair authentication:
+         * The public key is set already.
         """
     )
     assert not private_key_path.exists()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1546,3 +1546,83 @@ def test_connection_add_no_key_pair_setup_if_no_interactive(
     assert (
         result.output.strip() == f"Wrote new connection conn to {test_snowcli_config}"
     )
+
+
+@mock.patch("snowflake.cli._plugins.auth.keypair.manager.AuthManager.execute_query")
+@mock.patch("snowflake.cli._plugins.object.manager.ObjectManager.execute_query")
+@mock.patch("snowflake.connector.connect")
+def test_connection_add_with_key_pair_saves_password_if_keypair_is_set(
+    mock_connect,
+    mock_object_execute_query,
+    mock_auth_execute_query,
+    runner,
+    tmp_path,
+    mock_cursor,
+    test_snowcli_config,
+):
+    mock_connect.return_value.user = "user"
+    mock_object_execute_query.return_value = mock_cursor(
+        rows=[
+            {"property": "RSA_PUBLIC_KEY", "value": None},
+            {"property": "RSA_PUBLIC_KEY_2", "value": "public key..."},
+        ],
+        columns=[],
+    )
+
+    result = runner.invoke(
+        [
+            "connection",
+            "add",
+        ],
+        input="conn\n"  # connection name: zz
+        "test\n"  # account:
+        "user\n"  # user:
+        "123\n"  # password:
+        "\n"  # role:
+        "\n"  # warehouse:
+        "\n"  # database:
+        "\n"  # schema:
+        "\n"  # host:
+        "\n"  # port:
+        "\n"  # region:
+        "\n"  # authenticator:
+        "\n"  # private key file:
+        "\n"  # token file path:
+        "y\n"  #
+        "\n"  # key_length
+        f"{tmp_path}\n"  # output_path
+        "123\n",  # passphrase
+    )
+
+    private_key_path = tmp_path / "conn.p8"
+    public_key_path = tmp_path / "conn.pub"
+    assert result.exit_code == 0, result.output
+    assert result.output == dedent(
+        f"""\
+        Enter connection name: conn
+        Enter account: test
+        Enter user: user
+        Enter password: 
+        Enter role: 
+        Enter warehouse: 
+        Enter database: 
+        Enter schema: 
+        Enter host: 
+        Enter port: 
+        Enter region: 
+        Enter authenticator: 
+        Enter private key file: 
+        Enter token file path: 
+        Do you want to configure key pair authentication? [y/N]: y
+        Key length [2048]: 
+        Output path [~/.ssh]: {tmp_path}
+        Private key passphrase: 
+        Wrote new password-based connection conn to {test_snowcli_config}, however there were some issues during key pair setup:
+        The public key is set already. Use the rotate command instead.
+        """
+    )
+    assert not private_key_path.exists()
+    assert not public_key_path.exists()
+    with open(test_snowcli_config, "r") as f:
+        connections = tomlkit.load(f)
+        assert connections["connections"]["conn"]["password"] == "123"


### PR DESCRIPTION
… pair setup fails

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
https://snowflakecomputing.atlassian.net/browse/SNOW-2002186

Given a user that already has key-pair configured
When user adds new connection with just password and decides to actually setup key pair auth
Then the command should save connection based on password and inform about underlying failure and how to fix it
