### PR TITLE
Change git repository used in integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
 test = [
-  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/',
+  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/test_git.py::test_new_git_repo',
 ]
 test-spcs = [
   "pytest -m integration -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
 test = [
-  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/test_git.py',
+  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/',
 ]
 test-spcs = [
   "pytest -m integration -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
 test = [
-  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/test_git.py::test_new_git_repo',
+  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/test_git.py',
 ]
 test-spcs = [
   "pytest -m integration -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs",

--- a/tests_integration/test_git.py
+++ b/tests_integration/test_git.py
@@ -40,6 +40,26 @@ def sf_git_repository(runner, test_database):
 
 
 @pytest.mark.integration
+def test_new_git_repo(runner, test_database):
+    repo_name = "SNOWCLI_TESTING_REPO"
+    integration_name = "SNOWCLI_TESTING_REPO_API_INTEGRATION"
+    communication = "\n".join(
+        [
+            "https://github.com/snowflakedb/homebrew-snowflake-cli.git",
+            "n",
+            integration_name,
+            "",
+        ]
+    )
+    result = runner.invoke_with_connection(
+        ["git", "setup", repo_name], input=communication
+    )
+    assert result.exit_code == 0
+    assert f"Git Repository {repo_name} was successfully created." in result.output
+    # return repo_name
+
+
+@pytest.mark.integration
 def test_object_commands(runner, sf_git_repository):
     # object list
     result = runner.invoke_with_connection_json(["object", "list", "git-repository"])


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Change repository used in most integration tests to a tiny one (https://github.com/snowflakedb/homebrew-snowflake-cli/), as the size of this repository (used until now) causes issues for SnowGit team (copy operation alerts started firing). This repository remains cloned only for execute tests.
