### PR TITLE
feat: [SNOW-2026174] make project's manifest.yml required

### DIFF
--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -21,8 +21,9 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional
 
+from click import ClickException
 from snowflake.cli.api.connections import ConnectionContext, OpenConnectionCache
-from snowflake.cli.api.exceptions import MissingConfigurationError
+from snowflake.cli.api.exceptions import BaseCliError, MissingConfigurationError
 from snowflake.cli.api.metrics import CLIMetrics
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.rendering.jinja import CONTEXT_KEY
@@ -176,7 +177,10 @@ class _CliGlobalContextAccess:
 
     @property
     def project_definition(self) -> ProjectDefinition | None:
-        return self._manager.project_definition
+        try:
+            return self._manager.project_definition
+        except BaseCliError as exc:
+            raise ClickException(exc.message)
 
     @property
     def project_root(self) -> Path | None:

--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -21,9 +21,8 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional
 
-from click import ClickException
 from snowflake.cli.api.connections import ConnectionContext, OpenConnectionCache
-from snowflake.cli.api.exceptions import BaseCliError, MissingConfigurationError
+from snowflake.cli.api.exceptions import MissingConfigurationError
 from snowflake.cli.api.metrics import CLIMetrics
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.rendering.jinja import CONTEXT_KEY
@@ -177,10 +176,7 @@ class _CliGlobalContextAccess:
 
     @property
     def project_definition(self) -> ProjectDefinition | None:
-        try:
-            return self._manager.project_definition
-        except BaseCliError as exc:
-            raise ClickException(exc.message)
+        return self._manager.project_definition
 
     @property
     def project_root(self) -> Path | None:

--- a/tests/dcm_project/test_project_entity_model.py
+++ b/tests/dcm_project/test_project_entity_model.py
@@ -1,0 +1,21 @@
+import pytest
+from click import ClickException
+from snowflake.cli._plugins.project.project_entity_model import MANIFEST_FILE_NAME
+from snowflake.cli.api.cli_global_context import get_cli_context
+from snowflake.cli.api.commands.utils import get_entity_for_operation
+
+
+def test_project_entity_raises_when_manifest_file_does_not_exist(project_directory):
+    with project_directory("dcm_project") as project_root:
+        (project_root / MANIFEST_FILE_NAME).unlink()
+        with pytest.raises(ClickException) as err:
+            cli_context = get_cli_context()
+            get_entity_for_operation(
+                cli_context=cli_context,
+                entity_id="my_project",
+                project_definition=cli_context.project_definition,
+                entity_type="project",
+            )
+        assert f"{MANIFEST_FILE_NAME} was not found in project root directory" == str(
+            err.value
+        )

--- a/tests/test_data/projects/dcm_project/snowflake.yml
+++ b/tests/test_data/projects/dcm_project/snowflake.yml
@@ -4,7 +4,5 @@ entities:
     type: project
     identifier: "my_project"
     stage: "my_project_stage"
-    main_file: manifest.yml
     artifacts:
       - definitions/
-      - manifest.yml

--- a/tests_integration/test_data/projects/dcm_project/snowflake.yml
+++ b/tests_integration/test_data/projects/dcm_project/snowflake.yml
@@ -3,7 +3,5 @@ entities:
   my_project:
     type: project
     stage: "my_project_stage"
-    main_file: manifest.yml
     artifacts:
       - file_a.sql
-      - manifest.yml


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
main file should not be configurable. Neither it's name nor location in project directory. It must be always called manifest.yml and it must be in project root.
Additionally added checks in cli to confirm that the file exists.

Review together with https://github.com/snowflakedb/snowflake-cli-templates/pull/22

When trying to init a project from the updated template it works as expected, and uploads manifest.yml without having to specify it in snowflake.yml:
```
$ snow project create
Creating project 'with_manifest'
  Uploading artifacts
    Creating stage my_project_stage if not exists.
    Performing a diff between the Snowflake stage: my_project_stage and your local deploy_root: /Users/jwilkowski/snowflake/snowflake-cli/data_proj/output/bundle.
    Local changes to be deployed:
      added:    definitions/account_objects.sql -> definitions/account_objects.sql
      added:    definitions/schema_definition.sql -> definitions/schema_definition.sql
      added:    definitions/schema_objects.sql -> definitions/schema_objects.sql
      added:    manifest.yml -> manifest.yml
    Updating the Snowflake stage from your local /Users/jwilkowski/snowflake/snowflake-cli/data_proj/output/bundle directory.
  Creating project version from stage my_project_stage
Project 'with_manifest' successfully created and initial version is added.
```
