### PR TITLE
Change table behaviour in snow logs

### DIFF
--- a/src/snowflake/cli/_plugins/logs/commands.py
+++ b/src/snowflake/cli/_plugins/logs/commands.py
@@ -36,6 +36,11 @@ def get_logs(
         "--refresh",
         help="If set, the logs will be streamed with the given refresh time in seconds",
     ),
+    event_table: str = typer.Option(
+        None,
+        "--table",
+        help="The table to query for logs. If not provided, the default table will be used",
+    ),
     **options,
 ):
     """
@@ -55,6 +60,7 @@ def get_logs(
             object_name=object_name,
             from_time=from_time,
             refresh_time=refresh_time,
+            event_table=event_table,
         )
         logs = itertools.chain(
             (MessageResult(log.log_message) for logs in logs_stream for log in logs)
@@ -65,6 +71,7 @@ def get_logs(
             object_name=object_name,
             from_time=from_time,
             to_time=to_time,
+            event_table=event_table,
         )
         logs = (MessageResult(log.log_message) for log in logs_iterable)  # type: ignore
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5039,6 +5039,9 @@
   | --refresh          INTEGER  If set, the logs will be streamed with the given |
   |                             refresh time in seconds                          |
   |                             [default: None]                                  |
+  | --table            TEXT     The table to query for logs. If not provided,    |
+  |                             the default table will be used                   |
+  |                             [default: None]                                  |
   | --help     -h               Show this message and exit.                      |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/logs/__snapshots__/test_logs.ambr
+++ b/tests/logs/__snapshots__/test_logs.ambr
@@ -1,5 +1,43 @@
 # serializer version: 1
-# name: test_correct_query_is_constructed
+# name: test_correct_query_is_constructed[None]
+  '''
+  SELECT
+                  timestamp,
+                  resource_attributes:"snow.database.name"::string as database_name,
+                  resource_attributes:"snow.schema.name"::string as schema_name,
+                  resource_attributes:"snow.compute_pool.name"::string as object_name,
+                  record:severity_text::string as log_level,
+                  value::string as log_message
+              FROM SNOWFLAKE.TELEMETRY.EVENTS
+              WHERE record_type = 'LOG'
+              AND (record:severity_text = 'INFO' or record:severity_text is NULL )
+              AND object_name = 'bar'
+              AND timestamp >= TO_TIMESTAMP_LTZ('2022-02-02T02:02:02')
+  AND timestamp <= TO_TIMESTAMP_LTZ('2022-02-03T02:02:02')
+  
+              ORDER BY timestamp;
+  '''
+# ---
+# name: test_correct_query_is_constructed[bar]
+  '''
+  SELECT
+                  timestamp,
+                  resource_attributes:"snow.database.name"::string as database_name,
+                  resource_attributes:"snow.schema.name"::string as schema_name,
+                  resource_attributes:"snow.compute_pool.name"::string as object_name,
+                  record:severity_text::string as log_level,
+                  value::string as log_message
+              FROM bar
+              WHERE record_type = 'LOG'
+              AND (record:severity_text = 'INFO' or record:severity_text is NULL )
+              AND object_name = 'bar'
+              AND timestamp >= TO_TIMESTAMP_LTZ('2022-02-02T02:02:02')
+  AND timestamp <= TO_TIMESTAMP_LTZ('2022-02-03T02:02:02')
+  
+              ORDER BY timestamp;
+  '''
+# ---
+# name: test_correct_query_is_constructed[foo]
   '''
   SELECT
                   timestamp,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Small change to `snow logs` behaviour.
Instead of querying for logs table, default table name will be used - as described here https://docs.snowflake.com/en/developer-guide/logging-tracing/event-table-setting-up

User can provide custom event table name, using `--table`
