### PR TITLE
fix: [SNOW-2032682] fix project entity_id vs identifier

### DIFF
--- a/src/snowflake/cli/_plugins/project/commands.py
+++ b/src/snowflake/cli/_plugins/project/commands.py
@@ -187,11 +187,12 @@ def add_version(
 
 @app.command(requires_connection=True)
 def list_versions(
-    entity_id: str = entity_argument("project", required=True), **options
+    identifier: FQN = project_identifier,
+    **options,
 ):
     """
     Lists versions of given project.
     """
     pm = ProjectManager()
-    results = pm.list_versions(project_name=FQN.from_string(entity_id))
+    results = pm.list_versions(project_name=identifier)
     return QueryResult(results)

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -6762,13 +6762,14 @@
 # name: test_help_messages[project.list-versions]
   '''
                                                                                   
-   Usage: root project list-versions [OPTIONS] ENTITY_ID                          
+   Usage: root project list-versions [OPTIONS] IDENTIFIER                         
                                                                                   
    Lists versions of given project.                                               
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    entity_id      TEXT  ID of project entity.                              |
-  |                           [required]                                         |
+  | *    identifier      TEXT  Identifier of the project; for example:           |
+  |                            MY_PROJECT                                        |
+  |                            [required]                                        |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |

--- a/tests_integration/test_data/projects/dcm_project/snowflake.yml
+++ b/tests_integration/test_data/projects/dcm_project/snowflake.yml
@@ -3,5 +3,6 @@ entities:
   my_project:
     type: project
     stage: "my_project_stage"
+    identifier: "project_descriptive_name"
     artifacts:
       - file_a.sql

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -39,12 +39,13 @@ def test_project_deploy(
     test_database,
     project_directory,
 ):
-    project_name = "my_project"
+    project_name = "project_descriptive_name"
+    entity_id = "my_project"
     with project_directory("dcm_project"):
-        result = runner.invoke_with_connection(["project", "create"])
+        result = runner.invoke_with_connection(["project", "create", entity_id])
         assert result.exit_code == 0, result.output
         assert (
-            "Project 'my_project' successfully created and initial version is added."
+            f"Project '{project_name}' successfully created and initial version is added."
             in result.output
         )
         # project should be initialized with a version
@@ -69,7 +70,7 @@ def test_project_deploy(
             [
                 "project",
                 "execute",
-                "my_project",
+                project_name,
                 "-D",
                 f"table_name='{test_database}.PUBLIC.MyTable'",
             ]
@@ -81,13 +82,13 @@ def test_project_deploy(
                 "project",
                 "list",
                 "--like",
-                "MY_PROJECT",
+                project_name,
             ]
         )
         assert result.exit_code == 0, result.output
         assert len(result.json) == 1
         project = result.json[0]
-        assert project["name"].lower() == "my_project".lower()
+        assert project["name"].lower() == project_name.lower()
 
 
 @pytest.mark.integration
@@ -97,7 +98,7 @@ def test_create_corner_cases(
     test_database,
     project_directory,
 ):
-    project_name = "my_project"
+    project_name = "project_descriptive_name"
     stage_name = "my_project_stage"
     with project_directory("dcm_project"):
         # case 1: stage already exists
@@ -132,7 +133,8 @@ def test_project_add_version(
     test_database,
     project_directory,
 ):
-    project_name = "my_project"
+    project_name = "project_descriptive_name"
+    entity_id = "my_project"
     default_stage_name = "my_project_stage"
     other_stage_name = "other_project_stage"
 
@@ -177,7 +179,7 @@ def test_project_add_version(
             [
                 "project",
                 "add-version",
-                project_name,
+                entity_id,
                 "--from",
                 f"@{other_stage_name}",
                 "--alias",


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
There's a confusion between `entity_id` and `identifier` in the project commands. This PR fixes list-versions command (which doesn't use pdf) and makes the difference between identifiers more explicit in integration tests
