### PR TITLE
feat: [SNOW-2057523] make project add-version prune stage by default

### DIFF
--- a/src/snowflake/cli/_plugins/project/commands.py
+++ b/src/snowflake/cli/_plugins/project/commands.py
@@ -154,17 +154,22 @@ def create(
 @with_project_definition()
 def add_version(
     entity_id: str = entity_argument("project"),
-    _from: Optional[str] = from_option(mutually_exclusive=["prune"]),
+    _from: Optional[str] = from_option(),
     _alias: Optional[str] = typer.Option(
         None, "--alias", help="Alias for the version.", show_default=False
     ),
     comment: Optional[str] = typer.Option(
         None, "--comment", help="Version comment.", show_default=False
     ),
-    prune: bool = PruneOption(mutually_exclusive=["_from"]),
+    prune: bool = PruneOption(default=True),
     **options,
 ):
     """Uploads local files to Snowflake and cerates a new project version."""
+    if _from is not None and prune:
+        cli_console.warning(
+            "When `--from` option is used, `--prune` option will be ignored and files from stage will be used as they are."
+        )
+        prune = False
     cli_context = get_cli_context()
     project: ProjectEntityModel = get_entity_for_operation(
         cli_context=cli_context,

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -489,9 +489,9 @@ NoInteractiveOption = typer.Option(False, "--no-interactive", help="Disable prom
 
 PruneOption = OverrideableOption(
     False,
-    "--prune",
+    "--prune/--no-prune",
     help=f"Delete files that exist in the stage, but not in the local filesystem.",
-    show_default=False,
+    show_default=True,
 )
 
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -6156,16 +6156,20 @@
   |                               [default: None]                                |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --replace                Replace notebook object if it already exists. It    |
-  |                          only uploads new and overwrites existing files, but |
-  |                          does not remove any files already on the stage.     |
-  | --prune                  Delete files that exist in the stage, but not in    |
-  |                          the local filesystem.                               |
-  | --project  -p      TEXT  Path where the Snowflake project is stored.         |
-  |                          Defaults to the current working directory.          |
-  | --env              TEXT  String in the format key=value. Overrides variables |
-  |                          from the env section used for templates.            |
-  | --help     -h            Show this message and exit.                         |
+  | --replace                          Replace notebook object if it already     |
+  |                                    exists. It only uploads new and           |
+  |                                    overwrites existing files, but does not   |
+  |                                    remove any files already on the stage.    |
+  | --prune        --no-prune          Delete files that exist in the stage, but |
+  |                                    not in the local filesystem.              |
+  |                                    [default: no-prune]                       |
+  | --project  -p                TEXT  Path where the Snowflake project is       |
+  |                                    stored. Defaults to the current working   |
+  |                                    directory.                                |
+  | --env                        TEXT  String in the format key=value. Overrides |
+  |                                    variables from the env section used for   |
+  |                                    templates.                                |
+  | --help     -h                      Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |
@@ -7333,17 +7337,20 @@
   |                               [default: None]                                |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --from             TEXT  Create a new version using given stage instead of   |
-  |                          uploading local files.                              |
-  | --alias            TEXT  Alias for the version.                              |
-  | --comment          TEXT  Version comment.                                    |
-  | --prune                  Delete files that exist in the stage, but not in    |
-  |                          the local filesystem.                               |
-  | --project  -p      TEXT  Path where the Snowflake project is stored.         |
-  |                          Defaults to the current working directory.          |
-  | --env              TEXT  String in the format key=value. Overrides variables |
-  |                          from the env section used for templates.            |
-  | --help     -h            Show this message and exit.                         |
+  | --from                       TEXT  Create a new version using given stage    |
+  |                                    instead of uploading local files.         |
+  | --alias                      TEXT  Alias for the version.                    |
+  | --comment                    TEXT  Version comment.                          |
+  | --prune        --no-prune          Delete files that exist in the stage, but |
+  |                                    not in the local filesystem.              |
+  |                                    [default: prune]                          |
+  | --project  -p                TEXT  Path where the Snowflake project is       |
+  |                                    stored. Defaults to the current working   |
+  |                                    directory.                                |
+  | --env                        TEXT  String in the format key=value. Overrides |
+  |                                    variables from the env section used for   |
+  |                                    templates.                                |
+  | --help     -h                      Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |
@@ -8363,20 +8370,24 @@
    are deployed once to every stage specified in definitions.                     
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --replace                      Replaces procedure or function if there were  |
-  |                                changes in the definition. It only uploads    |
-  |                                new and overwrites existing files, but does   |
-  |                                not remove any files already on the stage.    |
-  | --force-replace                Replace this object, even if the state didn't |
-  |                                change                                        |
-  | --prune                        Remove contents of the stage before uploading |
-  |                                artifacts.                                    |
-  | --project        -p      TEXT  Path where the Snowflake project is stored.   |
-  |                                Defaults to the current working directory.    |
-  | --env                    TEXT  String in the format key=value. Overrides     |
-  |                                variables from the env section used for       |
-  |                                templates.                                    |
-  | --help           -h            Show this message and exit.                   |
+  | --replace                                Replaces procedure or function if   |
+  |                                          there were changes in the           |
+  |                                          definition. It only uploads new and |
+  |                                          overwrites existing files, but does |
+  |                                          not remove any files already on the |
+  |                                          stage.                              |
+  | --force-replace                          Replace this object, even if the    |
+  |                                          state didn't change                 |
+  | --prune              --no-prune          Remove contents of the stage before |
+  |                                          uploading artifacts.                |
+  |                                          [default: no-prune]                 |
+  | --project        -p                TEXT  Path where the Snowflake project is |
+  |                                          stored. Defaults to the current     |
+  |                                          working directory.                  |
+  | --env                              TEXT  String in the format key=value.     |
+  |                                          Overrides variables from the env    |
+  |                                          section used for templates.         |
+  | --help           -h                      Show this message and exit.         |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |
@@ -15827,17 +15838,22 @@
   |                               [default: None]                                |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --replace                Replaces the Streamlit app if it already exists. It |
-  |                          only uploads new and overwrites existing files, but |
-  |                          does not remove any files already on the stage.     |
-  | --prune                  Delete files that exist in the stage, but not in    |
-  |                          the local filesystem.                               |
-  | --open                   Whether to open the Streamlit app in a browser.     |
-  | --project  -p      TEXT  Path where the Snowflake project is stored.         |
-  |                          Defaults to the current working directory.          |
-  | --env              TEXT  String in the format key=value. Overrides variables |
-  |                          from the env section used for templates.            |
-  | --help     -h            Show this message and exit.                         |
+  | --replace                          Replaces the Streamlit app if it already  |
+  |                                    exists. It only uploads new and           |
+  |                                    overwrites existing files, but does not   |
+  |                                    remove any files already on the stage.    |
+  | --prune        --no-prune          Delete files that exist in the stage, but |
+  |                                    not in the local filesystem.              |
+  |                                    [default: no-prune]                       |
+  | --open                             Whether to open the Streamlit app in a    |
+  |                                    browser.                                  |
+  | --project  -p                TEXT  Path where the Snowflake project is       |
+  |                                    stored. Defaults to the current working   |
+  |                                    directory.                                |
+  | --env                        TEXT  String in the format key=value. Overrides |
+  |                                    variables from the env section used for   |
+  |                                    templates.                                |
+  | --help     -h                      Show this message and exit.               |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment     -c      TEXT     Name of the connection, as   |

--- a/tests/dcm_project/test_commands.py
+++ b/tests/dcm_project/test_commands.py
@@ -29,8 +29,20 @@ def test_create(mock_om, mock_pm, runner, project_directory, no_version):
 
 
 @mock.patch(ProjectManager)
-@pytest.mark.parametrize("prune", [True, False])
-def test_add_version(mock_pm, runner, project_directory, prune):
+@pytest.mark.parametrize(
+    "prune,_from,expected_prune_value",
+    [
+        (True, True, False),
+        (True, False, True),
+        (False, True, False),
+        (False, False, False),
+        (None, True, False),
+        (None, False, True),
+    ],
+)
+def test_add_version(
+    mock_pm, runner, project_directory, prune, _from, expected_prune_value
+):
     with project_directory("dcm_project") as root:
         command = [
             "project",
@@ -43,7 +55,10 @@ def test_add_version(mock_pm, runner, project_directory, prune):
         ]
         if prune:
             command += ["--prune"]
-        else:
+        elif prune is False:
+            command += ["--no-prune"]
+
+        if _from:
             command += ["--from", "@stage"]
         result = runner.invoke(command)
         assert result.exit_code == 0, result.output
@@ -55,8 +70,8 @@ def test_add_version(mock_pm, runner, project_directory, prune):
         "alias": "v1",
         "comment": "fancy",
         "project": kwargs["project"],
-        "prune": prune,
-        "from_stage": None if prune else "@stage",
+        "prune": expected_prune_value,
+        "from_stage": "@stage" if _from else None,
     }
 
     assert expected_kwargs == kwargs

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -203,9 +203,9 @@ def test_project_add_version(
         )
         assert result.exit_code == 0, result.output
 
-        # no "prune" - unexpected file remains
+        # --no-prune - unexpected file remains
         result = runner.invoke_with_connection(
-            ["project", "add-version", "--alias", "v3.1"]
+            ["project", "add-version", "--alias", "v3.1", "--no-prune"]
         )
         assert result.exit_code == 0, result.output
         _assert_project_has_versions(
@@ -225,7 +225,7 @@ def test_project_add_version(
 
         # prune flag - unexpected file should be removed
         result = runner.invoke_with_connection(
-            ["project", "add-version", "--prune", "--alias", "v3.2"]
+            ["project", "add-version", "--alias", "v3.2"]
         )
         assert result.exit_code == 0, result.output
         _assert_project_has_versions(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
https://snowflakecomputing.atlassian.net/browse/SNOW-2057523

For avoidance of doubt: when a file gets deleted from a project, subsequent project execution will "unapply" changes from that deleted file