### PR TITLE
FLOW-2736: Enable filtering show images output using like

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
 test = [
-  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration tests_integration/',
+  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs',
 ]
 test-spcs = [
   "pytest -m integration -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
 test = [
-  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/',
+  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration tests_integration/',
 ]
 test-spcs = [
   "pytest -m integration -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ features = ["development"]
 
 [tool.hatch.envs.integration.scripts]
 test = [
-  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs',
+  'pytest -m "integration and not qa_only" -n6 --dist=worksteal --deflake-test-type=integration --ignore=tests_integration/spcs tests_integration/',
 ]
 test-spcs = [
   "pytest -m integration -n6 --dist=worksteal --deflake-test-type=integration tests_integration/spcs",

--- a/src/snowflake/cli/_plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/commands.py
@@ -75,7 +75,7 @@ add_object_command_aliases(
     object_type=ObjectType.IMAGE_REPOSITORY,
     name_argument=REPO_NAME_ARGUMENT,
     like_option=like_option(
-        help_example='`list --like "my%"` lists all image repositories that begin with “my”.'
+        help_example='`--like "my%"` lists all image repositories that begin with “my”.'
     ),
     scope_option=scope_option(help_example="`list --in database my_db`"),
     ommit_commands=["describe"],
@@ -126,10 +126,8 @@ def deploy(
 @app.command("list-images", requires_connection=True)
 def list_images(
     name: FQN = REPO_NAME_ARGUMENT,
-    like_option: Optional[str] = typer.Option(
-        None,
-        "--like",
-        help='Filters the list of images to those that match the specified pattern. For example, `--like "my%"` lists all images that begin with “my”.',
+    like_option: Optional[str] = like_option(
+        help_example='`--like "my%"` lists all image repositories that begin with “my”.'
     ),
     **options,
 ) -> CollectionResult:

--- a/src/snowflake/cli/_plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/commands.py
@@ -126,10 +126,19 @@ def deploy(
 @app.command("list-images", requires_connection=True)
 def list_images(
     name: FQN = REPO_NAME_ARGUMENT,
+    like_option: Optional[str] = typer.Option(
+        None,
+        "--like",
+        help='Filters the list of images to those that match the specified pattern. For example, `--like "my%"` lists all images that begin with “my”.',
+    ),
     **options,
 ) -> CollectionResult:
     """Lists images in the given repository."""
-    return QueryResult(ImageRepositoryManager().list_images(name.identifier))
+    if like_option is not None:
+        like_option = f"like '{like_option}'"
+    else :
+        like_option = ""
+    return QueryResult(ImageRepositoryManager().list_images(name.identifier, like_option))
 
 
 @app.command("list-tags", requires_connection=True, deprecated=True)

--- a/src/snowflake/cli/_plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/commands.py
@@ -134,11 +134,9 @@ def list_images(
     **options,
 ) -> CollectionResult:
     """Lists images in the given repository."""
-    if like_option is not None:
-        like_option = f"like '{like_option}'"
-    else :
-        like_option = ""
-    return QueryResult(ImageRepositoryManager().list_images(name.identifier, like_option))
+    return QueryResult(
+        ImageRepositoryManager().list_images(name.identifier, like_option)
+    )
 
 
 @app.command("list-tags", requires_connection=True, deprecated=True)

--- a/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
@@ -83,5 +83,5 @@ class ImageRepositoryManager(SqlExecutionMixin):
                 e, ObjectType.IMAGE_REPOSITORY, name, replace_available=True
             )
 
-    def list_images(self, repo_name: str) -> SnowflakeCursor:
-        return self.execute_query(f"show images in image repository {repo_name}")
+    def list_images(self, repo_name: str, like_option: str) -> SnowflakeCursor:
+        return self.execute_query(f"show images {like_option} in image repository {repo_name}")

--- a/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
@@ -84,4 +84,8 @@ class ImageRepositoryManager(SqlExecutionMixin):
             )
 
     def list_images(self, repo_name: str, like_option: str) -> SnowflakeCursor:
-        return self.execute_query(f"show images {like_option} in image repository {repo_name}")
+        if like_option:
+            query = f"show images like '{like_option}' in image repository {repo_name}"
+        else:
+            query = f"show images in image repository {repo_name}"
+        return self.execute_query(query)

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -11880,10 +11880,10 @@
   |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --like          TEXT  Filters the list of images to those that match the     |
-  |                       specified pattern. For example, --like "my%" lists all |
-  |                       images that begin with “my”.                           |
-  |                       [default: None]                                        |
+  | --like  -l      TEXT  SQL LIKE pattern for filtering objects by name. For    |
+  |                       example, --like "my%" lists all image repositories     |
+  |                       that begin with “my”..                                 |
+  |                       [default: %%]                                          |
   | --help  -h            Show this message and exit.                            |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
@@ -12132,9 +12132,8 @@
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --like  -l      TEXT            SQL LIKE pattern for filtering objects by    |
-  |                                 name. For example, list --like "my%" lists   |
-  |                                 all image repositories that begin with       |
-  |                                 “my”..                                       |
+  |                                 name. For example, --like "my%" lists all    |
+  |                                 image repositories that begin with “my”..    |
   |                                 [default: %%]                                |
   | --in            <TEXT TEXT>...                                               |
   |                                                                              |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -11880,7 +11880,11 @@
   |                      [required]                                              |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --help  -h        Show this message and exit.                                |
+  | --like          TEXT  Filters the list of images to those that match the     |
+  |                       specified pattern. For example, --like "my%" lists all |
+  |                       images that begin with “my”.                           |
+  |                       [default: None]                                        |
+  | --help  -h            Show this message and exit.                            |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -344,9 +344,10 @@ def test_list_images_cli_with_like(
 )
 def test_list_images(mock_execute_query):
     repo_name = "test_repo"
+    like_option = None
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
-    result = ImageRepositoryManager().list_images(repo_name, None)
+    result = ImageRepositoryManager().list_images(repo_name, like_option)
     expected_query = f"show images in image repository test_repo"
     mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -344,7 +344,7 @@ def test_list_images_cli_with_like(
 )
 def test_list_images(mock_execute_query):
     repo_name = "test_repo"
-    like_option = None
+    like_option = ""
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
     result = ImageRepositoryManager().list_images(repo_name, like_option)
@@ -358,7 +358,7 @@ def test_list_images(mock_execute_query):
 )
 def test_list_images_with_like(mock_execute_query):
     repo_name = "test_repo"
-    like = "like 'echo_service'"
+    like = "echo_service"
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
     result = ImageRepositoryManager().list_images(repo_name, like)

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -301,14 +301,67 @@ def test_list_images_cli(
 
 
 @patch(
+    "snowflake.cli._plugins.spcs.image_repository.commands.ImageRepositoryManager.list_images"
+)
+def test_list_images_cli_with_like(
+    mock_list_images,
+    runner,
+    mock_cursor,
+):
+    cursor = mock_cursor(
+        rows=[
+            [
+                "2024-10-11 14:23:49-07:00",
+                "echo_service",
+                "latest",
+                "sha256:a8a001fef406fdb3125ce8e8bf9970c35af7084",
+                "/db/schema/repo/echo_service",
+            ]
+        ],
+        columns=["created_on", "image_name", "tags", "digest", "image_path"],
+    )
+    mock_list_images.return_value = cursor
+
+    result = runner.invoke(
+        [
+            "spcs",
+            "image-repository",
+            "list-images",
+            "IMAGES",
+            "--format",
+            "JSON",
+            "--like",
+            "%echo_service%",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "/db/schema/repo/echo_service" in result.output
+
+
+@patch(
     "snowflake.cli._plugins.spcs.image_repository.commands.ImageRepositoryManager.execute_query"
 )
 def test_list_images(mock_execute_query):
     repo_name = "test_repo"
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
-    result = ImageRepositoryManager().list_images(repo_name)
+    result = ImageRepositoryManager().list_images(repo_name, None)
     expected_query = f"show images in image repository test_repo"
+    mock_execute_query.assert_called_once_with(expected_query)
+    assert result == cursor
+
+
+@patch(
+    "snowflake.cli._plugins.spcs.image_repository.commands.ImageRepositoryManager.execute_query"
+)
+def test_list_images_with_like(mock_execute_query):
+    repo_name = "test_repo"
+    like = "like 'echo_service'"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ImageRepositoryManager().list_images(repo_name, like)
+    expected_query = f"show images like 'echo_service' in image repository test_repo"
     mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -112,6 +112,7 @@ def _list_images_with_like_positive_case(runner):
             "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/test_counter:latest".lower(),
         },
     )
+    # get all the images this time to verify the like filter is not applied
     result2 = runner.invoke_with_connection_json(
         [
             "spcs",
@@ -127,7 +128,7 @@ def _list_images_with_like_positive_case(runner):
         ]
     )
     assert isinstance(result2.json, list), result2.output
-    assert len(result2.json) == 2, result2.json
+    assert len(result2.json) == 3, result2.json
     assert contains_row_with(
         result.json,
         {

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -79,7 +79,7 @@ def _list_images_with_like_empty_list(runner):
             INTEGRATION_DATABASE,
             "--schema",
             INTEGRATION_SCHEMA,
-            "--like-option",
+            "--like",
             "openflow%",
         ]
     )
@@ -98,7 +98,7 @@ def _list_images_with_like_positive_case(runner):
             INTEGRATION_DATABASE,
             "--schema",
             INTEGRATION_SCHEMA,
-            "--like-option",
+            "--like",
             "test_counter%",
         ]
     )

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -86,6 +86,7 @@ def _list_images_with_like_empty_list(runner):
     assert isinstance(result.json, list), result.output
     assert len(result.json) == 0, result.json
 
+
 def _list_images_with_like_positive_case(runner):
     result = runner.invoke_with_connection_json(
         [
@@ -111,6 +112,7 @@ def _list_images_with_like_positive_case(runner):
             "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/test_counter:latest".lower(),
         },
     )
+
 
 def _list_tags(runner):
     result = runner.invoke_with_connection_json(

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -39,6 +39,7 @@ INTEGRATION_REPOSITORY = "snowcli_repository"
 def test_list_images_tags(runner):
     # test assumes the testing environment has been set up with /<DATABASE>/PUBLIC/snowcli_repository/snowpark_test_echo:1
     _list_images(runner)
+    _list_images_with_like(runner)
     _list_tags(runner)
 
 
@@ -64,7 +65,31 @@ def _list_images(runner):
             "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo:1".lower(),
         },
     )
-
+    
+def _list_images_with_like(runner):
+    result = runner.invoke_with_connection_json(
+        [
+            "spcs",
+            "image-repository",
+            "list-images",
+            INTEGRATION_REPOSITORY,
+            "--database",
+            INTEGRATION_DATABASE,
+            "--schema",
+            INTEGRATION_SCHEMA,
+            "--like-option",
+            "snowpark_test_echo",
+        ]
+    )
+    assert isinstance(result.json, list), result.output
+    assert contains_row_with(
+        result.json,
+        {
+            "image_name": "snowpark_test_echo",
+            "tags": "1",
+            "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo:1".lower(),
+        },
+    )
 
 def _list_tags(runner):
     result = runner.invoke_with_connection_json(

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -39,7 +39,8 @@ INTEGRATION_REPOSITORY = "snowcli_repository"
 def test_list_images_tags(runner):
     # test assumes the testing environment has been set up with /<DATABASE>/PUBLIC/snowcli_repository/snowpark_test_echo:1
     _list_images(runner)
-    _list_images_with_like(runner)
+    _list_images_with_like_positive_case(runner)
+    _list_images_with_like_empty_list(runner)
     _list_tags(runner)
 
 
@@ -67,7 +68,7 @@ def _list_images(runner):
     )
 
 
-def _list_images_with_like(runner):
+def _list_images_with_like_empty_list(runner):
     result = runner.invoke_with_connection_json(
         [
             "spcs",
@@ -85,6 +86,31 @@ def _list_images_with_like(runner):
     assert isinstance(result.json, list), result.output
     assert len(result.json) == 0, result.json
 
+def _list_images_with_like_positive_case(runner):
+    result = runner.invoke_with_connection_json(
+        [
+            "spcs",
+            "image-repository",
+            "list-images",
+            INTEGRATION_REPOSITORY,
+            "--database",
+            INTEGRATION_DATABASE,
+            "--schema",
+            INTEGRATION_SCHEMA,
+            "--like-option",
+            "test_counter%",
+        ]
+    )
+    assert isinstance(result.json, list), result.output
+    assert len(result.json) == 1, result.json
+    assert contains_row_with(
+        result.json,
+        {
+            "image_name": "test_counter",
+            "tags": "latest",
+            "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/test_counter:latest".lower(),
+        },
+    )
 
 def _list_tags(runner):
     result = runner.invoke_with_connection_json(

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -85,6 +85,8 @@ def _list_images_with_like_empty_list(runner):
     )
     assert isinstance(result.json, list), result.output
     assert len(result.json) == 0, result.json
+    print("result json is:", result.json)
+    print("result output is:", result.output)
 
 
 def _list_images_with_like_positive_case(runner):

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -65,7 +65,8 @@ def _list_images(runner):
             "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo:1".lower(),
         },
     )
-    
+
+
 def _list_images_with_like(runner):
     result = runner.invoke_with_connection_json(
         [
@@ -90,6 +91,7 @@ def _list_images_with_like(runner):
             "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo:1".lower(),
         },
     )
+
 
 def _list_tags(runner):
     result = runner.invoke_with_connection_json(

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -79,18 +79,11 @@ def _list_images_with_like(runner):
             "--schema",
             INTEGRATION_SCHEMA,
             "--like-option",
-            "snowpark_test_echo",
+            "openflow%",
         ]
     )
     assert isinstance(result.json, list), result.output
-    assert contains_row_with(
-        result.json,
-        {
-            "image_name": "snowpark_test_echo",
-            "tags": "1",
-            "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo:1".lower(),
-        },
-    )
+    assert len(result.json) == 0, result.json
 
 
 def _list_tags(runner):

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -84,9 +84,7 @@ def _list_images_with_like_empty_list(runner):
         ]
     )
     assert isinstance(result.json, list), result.output
-    assert len(result.json) == 1, result.json
-    print("result json is:", result.json)
-    print("result output is:", result.output)
+    assert len(result.json) == 0, result.json
 
 
 def _list_images_with_like_positive_case(runner):
@@ -106,6 +104,30 @@ def _list_images_with_like_positive_case(runner):
     )
     assert isinstance(result.json, list), result.output
     assert len(result.json) == 1, result.json
+    assert contains_row_with(
+        result.json,
+        {
+            "image_name": "test_counter",
+            "tags": "latest",
+            "image_path": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/test_counter:latest".lower(),
+        },
+    )
+    result2 = runner.invoke_with_connection_json(
+        [
+            "spcs",
+            "image-repository",
+            "list-images",
+            INTEGRATION_REPOSITORY,
+            "--database",
+            INTEGRATION_DATABASE,
+            "--schema",
+            INTEGRATION_SCHEMA,
+            "--like",
+            "%",
+        ]
+    )
+    assert isinstance(result2.json, list), result2.output
+    assert len(result2.json) == 2, result2.json
     assert contains_row_with(
         result.json,
         {

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -84,7 +84,7 @@ def _list_images_with_like_empty_list(runner):
         ]
     )
     assert isinstance(result.json, list), result.output
-    assert len(result.json) == 0, result.json
+    assert len(result.json) == 1, result.json
     print("result json is:", result.json)
     print("result output is:", result.output)
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

Today, CLI command from spcs image repo list-images is not updated with SQL version and does not support filtering using like ''. 

This change adds support for filtering images based on a like pattern 
`show images like '%openflow%' in image repository snowflake.images.snowflake_images;`