### PR TITLE
Add support for queries, result and abort commands

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 * Cleaning up the output directory after coping files to the stage for Streamlit, Notebook, SPCS Service and project.
 * Added interactive mode for `snow sql`.
 * Added support for async SQL queries (`;>` syntax).
+* Added support for `!queries`, `!result` and `!abort` commands from SnowSQL.
 
 ## Fixes and improvements
 

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -29,7 +29,6 @@ from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.commands.utils import parse_key_value_variables
 from snowflake.cli.api.output.types import (
     CommandResult,
-    MessageResult,
     MultipleResults,
     QueryResult,
 )
@@ -106,7 +105,7 @@ def execute_sql(
         from snowflake.cli._plugins.sql.repl import Repl
 
         Repl(SqlManager(), data=data, retain_comments=retain_comments).run()
-        return MessageResult("")
+        sys.exit(0)
 
     expected_results_cnt, cursors = SqlManager().execute(
         query, files, std_in, data=data, retain_comments=retain_comments
@@ -115,13 +114,13 @@ def execute_sql(
         # case expected if input only scheduled async queries
         list(cursors)  # evaluate the result to schedule potential async queries
         # ends gracefully with no message for consistency with snowsql.
-        return MessageResult("")
+        sys.exit(0)
 
     if expected_results_cnt == 1:
         # evaluate the result to schedule async queries
         results = list(cursors)
         if not results:
-            return MessageResult("")
+            return sys.exit(0)
         return QueryResult(results[0])
 
     return MultipleResults((QueryResult(c) for c in cursors))

--- a/src/snowflake/cli/_plugins/sql/manager.py
+++ b/src/snowflake/cli/_plugins/sql/manager.py
@@ -103,7 +103,9 @@ class SqlManager(SqlExecutionMixin):
                 # only log query ID for consistency with SnowSQL
                 logger.info("Async execution id: %s", cursor.sfqid)
                 print_result(CollectionResult([{"scheduled query ID": cursor.sfqid}]))
-            else:
+            elif stmt.statement:
                 yield from self.execute_string(
                     stmt.statement, cursor_class=cursor_class
                 )
+            if stmt.command:
+                stmt.command.execute(self._conn)

--- a/src/snowflake/cli/_plugins/sql/snowsql_commands.py
+++ b/src/snowflake/cli/_plugins/sql/snowsql_commands.py
@@ -79,7 +79,7 @@ class QueriesCommand(SnowSQLCommand):
 
     def _execute_queries(self, connection: SnowflakeConnection) -> None:
         url_parameters = {
-            "_dc": "{time}".format(time=time.time()),
+            "_dc": f"{time.time()}",
             "includeDDL": "false",
             "max": self.amount,
         }
@@ -133,7 +133,7 @@ class QueriesCommand(SnowSQLCommand):
         start_time = kwargs.pop("start", None)
         end_time = kwargs.pop("end", None)
         duration = kwargs.pop("duration", None)
-        stmt_type = kwargs.pop("stmtType", None)
+        stmt_type = kwargs.pop("type", None)
         if stmt_type:
             stmt_type = stmt_type.upper()
             if stmt_type not in [

--- a/src/snowflake/cli/_plugins/sql/snowsql_commands.py
+++ b/src/snowflake/cli/_plugins/sql/snowsql_commands.py
@@ -1,0 +1,216 @@
+import enum
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Generator, Iterable, List, Tuple
+from urllib.parse import urlencode
+
+from snowflake.cli._app.printing import print_result
+from snowflake.cli.api.output.types import CollectionResult
+from snowflake.connector import SnowflakeConnection
+
+
+class CommandType(enum.Enum):
+    QUERIES = "queries"
+    UNKNOWN = "unknown"
+    URL = "url"
+
+
+class SnowSQLCommand:
+    def execute(self, connection: SnowflakeConnection):
+        """Executes command and prints the result."""
+        raise NotImplementedError
+
+    @classmethod
+    def from_args(cls, args, kwargs) -> "CompileCommandResult":
+        """Validates arguments and creates command ready for execution."""
+        raise NotImplementedError
+
+
+def _print_result_to_stdout(headers: Iterable[str], rows: Iterable[Iterable[Any]]):
+    formatted_rows: Generator[Dict[str, Any], None, None] = (
+        {key: value for key, value in zip(headers, row)} for row in rows
+    )
+    print_result(CollectionResult(formatted_rows))
+
+
+@dataclass
+class CompileCommandResult:
+    command: SnowSQLCommand | None = None
+    error_message: str | None = None
+
+
+@dataclass
+class QueriesCommand(SnowSQLCommand):
+    help_mode: bool = False
+    from_current_session: bool = False
+    amount: int = 25
+    user: str | None = None
+    warehouse: str | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    duration: str | None = None
+    stmt_type: str | None = None
+    status: str | None = None
+
+    def execute(self, connection: SnowflakeConnection) -> None:
+        if self.help_mode:
+            self._execute_help()
+        else:
+            self._execute_queries(connection)
+
+    def _execute_help(self):
+        filters = []
+        headers = ["FILTER", "ARGUMENT", "DEFAULT"]
+        filters.append(["amount", "integer", "25"])
+        filters.append(["status", "string", "any"])
+        filters.append(["warehouse", "string", "any"])
+        filters.append(["user", "string", "any"])
+        filters.append(["start", "date in milliseconds", "any"])
+        filters.append(["end", "date in milliseconds", "any"])
+        filters.append(["type", "string", "any"])
+        filters.append(["duration", "time in milliseconds", "any"])
+        filters.append(["session", "No arguments", "any"])
+        _print_result_to_stdout(headers, filters)
+
+    def _execute_queries(self, connection: SnowflakeConnection) -> None:
+        url_parameters = {
+            "_dc": "{time}".format(time=time.time()),
+            "includeDDL": "false",
+            "max": self.amount,
+        }
+        if self.user:
+            url_parameters["user"] = self.user
+        if self.warehouse:
+            url_parameters["wh"] = self.warehouse
+        if self.start_time:
+            url_parameters["start"] = self.start_time
+        if self.end_time:
+            url_parameters["end"] = self.end_time
+        if self.duration:
+            url_parameters["min_duration"] = self.duration
+        if self.from_current_session:
+            url_parameters["session_id"] = connection.session_id
+        if self.status:
+            url_parameters["subset"] = self.status
+        if self.stmt_type:
+            url_parameters["stmt_type"] = self.stmt_type
+
+        url = "/monitoring/queries?" + urlencode(url_parameters)
+        ret = connection.rest.request(url=url, method="get", client="rest")
+        if ret.get("data") and ret["data"].get("queries"):
+            _result: Generator[Tuple[str, str, str, str], None, None] = (
+                (
+                    query["id"],
+                    query["sqlText"],
+                    query["state"],
+                    query["totalDuration"],
+                )
+                for query in ret["data"]["queries"]
+            )
+            _print_result_to_stdout(
+                ["QUERY ID", "SQL TEXT", "STATUS", "DURATION_MS"], _result
+            )
+
+    @classmethod
+    def from_args(cls, args, kwargs) -> CompileCommandResult:
+        if "help" in args:
+            return CompileCommandResult(command=cls(help_mode=True))
+
+        # "session" is set by default if no other arguments are provided
+        from_current_session = "session" in args or not kwargs
+        amount = kwargs.pop("amount", "25")
+        if not amount.isdigit():
+            return CompileCommandResult(
+                error_message=f"Invalid argument passed to 'amount' filter: {amount}"
+            )
+        user = kwargs.pop("user", None)
+        warehouse = kwargs.pop("warehouse", None)
+        start_time = kwargs.pop("start", None)
+        end_time = kwargs.pop("end", None)
+        duration = kwargs.pop("duration", None)
+        stmt_type = kwargs.pop("stmtType", None)
+        if stmt_type:
+            stmt_type = stmt_type.upper()
+            if stmt_type not in [
+                "ANY",
+                "SELECT",
+                "INSERT",
+                "UPDATE",
+                "DELETE",
+                "MERGE",
+                "MULTI_TABLE_INSERT",
+                "COPY",
+                "COMMIT",
+                "ROLLBACK",
+                "BEGIN_TRANSACTION",
+                "SHOW",
+                "GRANT",
+                "CREATE",
+                "ALTER",
+            ]:
+                return CompileCommandResult(
+                    error_message=f"Invalid argument passed to 'type' filter: {stmt_type}"
+                )
+
+        status = kwargs.pop("status", None)
+        if status:
+            status = status.upper()
+            if status not in [
+                "RUNNING",
+                "SUCCEEDED",
+                "FAILED",
+                "BLOCKED",
+                "QUEUED",
+                "ABORTED",
+            ]:
+                return CompileCommandResult(
+                    error_message=f"Invalid argument passed to 'status' filter: {status}"
+                )
+
+        for arg in args:
+            if arg.lower() not in ["session", "help"]:
+                return CompileCommandResult(
+                    error_message=f"Invalid argument passed to 'queries' command: {arg}"
+                )
+        if kwargs:
+            key, value = next(kwargs.items())
+            return CompileCommandResult(
+                error_message=f"Invalid argument passed to 'queries' command: {key}={value}"
+            )
+
+        return CompileCommandResult(
+            command=cls(
+                help_mode=False,
+                from_current_session=from_current_session,
+                amount=int(amount),
+                user=user,
+                warehouse=warehouse,
+                start_time=start_time,
+                end_time=end_time,
+                duration=duration,
+                stmt_type=stmt_type,
+                status=status,
+            )
+        )
+
+
+def compile_snowsql_command(command: str, cmd_args: List[str]):
+    """Parses command into SQL query"""
+    args = []
+    kwargs = {}
+    for cmd_arg in cmd_args:
+        if "=" not in cmd_arg:
+            args.append(cmd_arg)
+        else:
+            key, val = cmd_arg.split("=", maxsplit=1)
+            if key in kwargs:
+                return CompileCommandResult(
+                    error_message=f"duplicated argument '{key}' for command '{command}'",
+                )
+            kwargs[key] = val
+
+    match command.lower():
+        case "!queries":
+            return QueriesCommand.from_args(args, kwargs)
+        case _:
+            return CompileCommandResult(error_message=f"Unknown command '{command}'")

--- a/src/snowflake/cli/_plugins/sql/statement_reader.py
+++ b/src/snowflake/cli/_plugins/sql/statement_reader.py
@@ -15,7 +15,7 @@ from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
 from snowflake.connector.util_text import split_statements
 
 COMMAND_PATTERN = re.compile(
-    r"^!(source|load|queries|result)\s*[\"']?(.*?)[\"']?\s*(?:;|$)",
+    r"^!(source|load|queries|result|abort)\s*[\"']?(.*?)[\"']?\s*(?:;|$)",
     flags=re.IGNORECASE,
 )
 URL_PATTERN = re.compile(r"^(\w+?):\/(\/.*)", flags=re.IGNORECASE)
@@ -153,7 +153,7 @@ def parse_statement(source: str, operators: OperatorFunctions) -> ParsedStatemen
                 f"Unknown source: {command_args}",
             )
 
-        case "queries" | "result", (str(),):
+        case "queries" | "result" | "abort", (str(),):
             return ParsedStatement(statement, SourceType.SNOWSQL_COMMAND, None)
 
         case _:

--- a/src/snowflake/cli/_plugins/sql/statement_reader.py
+++ b/src/snowflake/cli/_plugins/sql/statement_reader.py
@@ -15,7 +15,7 @@ from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
 from snowflake.connector.util_text import split_statements
 
 COMMAND_PATTERN = re.compile(
-    r"^!(source|load|queries)\s*[\"']?(.*?)[\"']?\s*(?:;|$)",
+    r"^!(source|load|queries|result)\s*[\"']?(.*?)[\"']?\s*(?:;|$)",
     flags=re.IGNORECASE,
 )
 URL_PATTERN = re.compile(r"^(\w+?):\/(\/.*)", flags=re.IGNORECASE)
@@ -153,7 +153,7 @@ def parse_statement(source: str, operators: OperatorFunctions) -> ParsedStatemen
                 f"Unknown source: {command_args}",
             )
 
-        case "queries", (str(),):
+        case "queries" | "result", (str(),):
             return ParsedStatement(statement, SourceType.SNOWSQL_COMMAND, None)
 
         case _:

--- a/src/snowflake/cli/_plugins/sql/statement_reader.py
+++ b/src/snowflake/cli/_plugins/sql/statement_reader.py
@@ -15,7 +15,7 @@ from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
 from snowflake.connector.util_text import split_statements
 
 COMMAND_PATTERN = re.compile(
-    r"^!(source|load|queries|result|abort)\s*[\"']?(.*?)[\"']?\s*(?:;|$)",
+    r"^!(\w+)\s*[\"']?(.*?)[\"']?\s*(?:;|$)",
     flags=re.IGNORECASE,
 )
 URL_PATTERN = re.compile(r"^(\w+?):\/(\/.*)", flags=re.IGNORECASE)
@@ -157,7 +157,7 @@ def parse_statement(source: str, operators: OperatorFunctions) -> ParsedStatemen
             return ParsedStatement(statement, SourceType.SNOWSQL_COMMAND, None)
 
         case _:
-            error_msg = f"Unknown command: {source}"
+            error_msg = f"Unknown command: {command}"
 
     return ParsedStatement(statement, SourceType.UNKNOWN, None, error_msg)
 

--- a/tests/sql/__snapshots__/test_repl.ambr
+++ b/tests/sql/__snapshots__/test_repl.ambr
@@ -52,7 +52,6 @@
   
   Leaving REPL, bye ...
   
-  
   '''
 # ---
 # name: test_repl_input_handling

--- a/tests/sql/__snapshots__/test_sql.ambr
+++ b/tests/sql/__snapshots__/test_sql.ambr
@@ -8,6 +8,5 @@
   
   Leaving REPL, bye ...
   
-  
   '''
 # ---

--- a/tests/sql/test_snowsql_commands.py
+++ b/tests/sql/test_snowsql_commands.py
@@ -1,0 +1,263 @@
+from unittest import mock
+
+import pytest
+from snowflake.cli._plugins.sql.snowsql_commands import (
+    AbortCommand,
+    CompileCommandResult,
+    QueriesCommand,
+    ResultCommand,
+    SnowSQLCommand,
+    compile_snowsql_command,
+)
+
+_FAKE_QID = "00000000-0000-0000-0000-000000000000"
+
+PRINT_RESULT = "snowflake.cli._plugins.sql.snowsql_commands.print_result"
+
+
+def test_result_from_args():
+    assert ResultCommand.from_args(["incorrect_id"], {}) == CompileCommandResult(
+        error_message="Invalid query ID passed to 'result' command: incorrect_id"
+    )
+    assert ResultCommand.from_args([], {}) == CompileCommandResult(
+        error_message="No arguments passed to 'result' command. Usage: `!result <query id>`"
+    )
+    assert ResultCommand.from_args([1, 2], {}) == CompileCommandResult(
+        error_message="Too many arguments passed to 'result' command. Usage: `!result <query id>`"
+    )
+    assert ResultCommand.from_args([], {"unwanted": "kwarg"}) == CompileCommandResult(
+        error_message="Invalid argument passed to 'result' command: unwanted=kwarg"
+    )
+    assert ResultCommand.from_args([_FAKE_QID], {}) == CompileCommandResult(
+        command=ResultCommand(_FAKE_QID)
+    )
+
+
+def test_abort_from_args():
+    assert AbortCommand.from_args(["incorrect_id"], {}) == CompileCommandResult(
+        error_message="Invalid query ID passed to 'abort' command: incorrect_id"
+    )
+    assert AbortCommand.from_args([], {}) == CompileCommandResult(
+        error_message="No arguments passed to 'abort' command. Usage: `!abort <query id>`"
+    )
+    assert AbortCommand.from_args([1, 2], {}) == CompileCommandResult(
+        error_message="Too many arguments passed to 'abort' command. Usage: `!abort <query id>`"
+    )
+    assert AbortCommand.from_args([], {"unwanted": "kwarg"}) == CompileCommandResult(
+        error_message="Invalid argument passed to 'abort' command: unwanted=kwarg"
+    )
+    assert AbortCommand.from_args([_FAKE_QID], {}) == CompileCommandResult(
+        command=AbortCommand(_FAKE_QID)
+    )
+
+
+@mock.patch(PRINT_RESULT)
+def test_result_execute(mock_print, mock_ctx):
+    command = ResultCommand(_FAKE_QID)
+    ctx = mock_ctx()
+    command.execute(ctx)
+    ctx.cursor().query_result.assert_called_once_with(_FAKE_QID)
+    mock_print.assert_called_once()
+
+
+@mock.patch(PRINT_RESULT)
+def test_abort_execute(mock_print, mock_ctx):
+    command = AbortCommand(_FAKE_QID)
+    ctx = mock_ctx()
+    command.execute(ctx)
+    ctx.cursor().execute.assert_called_once_with(
+        f"SELECT SYSTEM$CANCEL_QUERY('{_FAKE_QID}')"
+    )
+    mock_print.assert_called_once()
+
+
+def test_queries_from_args():
+    # default values
+    assert QueriesCommand.from_args([], {}) == (
+        CompileCommandResult(
+            command=QueriesCommand(amount=25, from_current_session=True)
+        )
+    )
+
+    # session is set only if kwargs are empty
+    assert QueriesCommand.from_args([], {"amount": "3"}) == (
+        CompileCommandResult(
+            command=QueriesCommand(amount=3, from_current_session=False)
+        )
+    )
+
+    # unless "session" arg is provided
+    assert QueriesCommand.from_args(["session"], {"amount": "3"}) == (
+        CompileCommandResult(
+            command=QueriesCommand(amount=3, from_current_session=True)
+        )
+    )
+
+    # help
+    assert QueriesCommand.from_args(["help", "session"], {"amount": 3}) == (
+        CompileCommandResult(command=QueriesCommand(help_mode=True))
+    )
+
+    # all arguments
+    assert QueriesCommand.from_args(
+        ["session"],
+        {
+            "warehouse": "warehouse",
+            "user": "user",
+            "amount": "3",
+            "start": "1234",
+            "end": "1234",
+            "duration": "200",
+            "type": "insert",
+            "status": "running",
+        },
+    ) == (
+        CompileCommandResult(
+            command=QueriesCommand(
+                help_mode=False,
+                from_current_session=True,
+                amount=3,
+                user="user",
+                warehouse="warehouse",
+                start_time="1234",
+                end_time="1234",
+                duration="200",
+                stmt_type="INSERT",
+                status="RUNNING",
+            )
+        )
+    )
+
+    # errors
+    assert QueriesCommand.from_args(["unknown_arg"], {}) == (
+        CompileCommandResult(
+            error_message="Invalid argument passed to 'queries' command: unknown_arg"
+        )
+    )
+    assert QueriesCommand.from_args([], {"unknown": "kwarg"}) == (
+        CompileCommandResult(
+            error_message="Invalid argument passed to 'queries' command: unknown=kwarg"
+        )
+    )
+    assert QueriesCommand.from_args([], {"amount": "text"}) == (
+        CompileCommandResult(
+            error_message="Invalid argument passed to 'amount' filter: text"
+        )
+    )
+    assert QueriesCommand.from_args([], {"type": "invalid"}) == (
+        CompileCommandResult(
+            error_message="Invalid argument passed to 'type' filter: INVALID"
+        )
+    )
+    assert QueriesCommand.from_args([], {"status": "invalid"}) == (
+        CompileCommandResult(
+            error_message="Invalid argument passed to 'status' filter: INVALID"
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["RUNNING", "SUCCEEDED", "FAILED", "BLOCKED", "QUEUED", "ABORTED"],
+)
+def test_queries_status_values(status):
+    assert QueriesCommand.from_args(
+        [], {"status": status.capitalize()}
+    ) == CompileCommandResult(command=QueriesCommand(status=status.upper()))
+
+
+@pytest.mark.parametrize(
+    "type_",
+    [
+        "ANY",
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "MERGE",
+        "MULTI_TABLE_INSERT",
+        "COPY",
+        "COMMIT",
+        "ROLLBACK",
+        "BEGIN_TRANSACTION",
+        "SHOW",
+        "GRANT",
+        "CREATE",
+        "ALTER",
+    ],
+)
+def test_queries_type_values(type_):
+    assert QueriesCommand.from_args(
+        [], {"type": type_.capitalize()}
+    ) == CompileCommandResult(command=QueriesCommand(stmt_type=type_.upper()))
+
+
+@mock.patch("time.time")
+@mock.patch(PRINT_RESULT)
+@pytest.mark.parametrize("current_session", [True, False])
+def test_queries_execute(mock_print, mock_time, mock_ctx, current_session):
+    mock_time.return_value = "mocked_time"
+    ctx = mock_ctx()
+    ctx.session_id = "mocked_session_id"
+    QueriesCommand(
+        help_mode=False,
+        from_current_session=current_session,
+        amount=3,
+        user="user",
+        warehouse="warehouse",
+        start_time="1234",
+        end_time="1234",
+        duration="200",
+        stmt_type="INSERT",
+        status="RUNNING",
+    ).execute(ctx)
+
+    expected_url = (
+        "/monitoring/queries?_dc=mocked_time&includeDDL=false&max=3&user=user&wh=warehouse"
+        "&start=1234&end=1234&min_duration=200"
+        f"{'&session_id=mocked_session_id' if current_session else ''}"
+        "&subset=RUNNING&stmt_type=INSERT"
+    )
+    ctx.rest.request.assert_called_once_with(
+        url=expected_url, method="get", client="rest"
+    )
+    mock_print.assert_called_once()
+
+
+@mock.patch(PRINT_RESULT)
+def test_queries_execute_help(mock_print, mock_ctx):
+    ctx = mock_ctx()
+    ctx.session_id = "mocked_session_id"
+    QueriesCommand(help_mode=True).execute(ctx)
+
+    ctx.rest.request.assert_not_called()
+    mock_print.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "command,args,expected",
+    [
+        ("!result", [_FAKE_QID], ResultCommand(_FAKE_QID)),
+        ("!abort", [_FAKE_QID], AbortCommand(_FAKE_QID)),
+        ("!queries", ["amount=3", "user=jdoe"], QueriesCommand(amount=3, user="jdoe")),
+        ("!QuERies", ["session"], QueriesCommand(from_current_session=True)),
+        (
+            "!ResUlT",
+            [],
+            "No arguments passed to 'result' command. Usage: `!result <query id>`",
+        ),
+        (
+            "!AbORT",
+            ["incorrect_id"],
+            "Invalid query ID passed to 'abort' command: incorrect_id",
+        ),
+        ("!unknown", [], "Unknown command '!unknown'"),
+    ],
+)
+def test_compile_commands(command, args, expected):
+    if isinstance(expected, SnowSQLCommand):
+        expected_result = CompileCommandResult(command=expected)
+    else:
+        expected_result = CompileCommandResult(error_message=expected)
+
+    assert compile_snowsql_command(command=command, cmd_args=args) == expected_result

--- a/tests/sql/test_statement_reader.py
+++ b/tests/sql/test_statement_reader.py
@@ -365,9 +365,9 @@ def test_detect_async_queries():
     assert errors == []
     assert expected_results == 2
     assert list(compiled_statements) == [
-        CompiledStatement(statement="select 1", execute_async=True),
-        CompiledStatement(statement="select -1;", execute_async=False),
-        CompiledStatement(statement="select 2", execute_async=True),
-        CompiledStatement(statement="select -2;", execute_async=False),
-        CompiledStatement(statement="select 3", execute_async=True),
+        CompiledStatement(statement="select 1", execute_async=True, command=None),
+        CompiledStatement(statement="select -1;", execute_async=False, command=None),
+        CompiledStatement(statement="select 2", execute_async=True, command=None),
+        CompiledStatement(statement="select -2;", execute_async=False, command=None),
+        CompiledStatement(statement="select 3", execute_async=True, command=None),
     ]

--- a/tests/sql/test_statement_reader.py
+++ b/tests/sql/test_statement_reader.py
@@ -371,3 +371,22 @@ def test_detect_async_queries():
         CompiledStatement(statement="select -2;", execute_async=False, command=None),
         CompiledStatement(statement="select 3", execute_async=True, command=None),
     ]
+
+
+@pytest.mark.parametrize("command", ["queries", "abort", "result", "AbOrT"])
+def test_parse_command(command):
+    query = f"!{command} args k1=v1 k2=v2;"
+    parsed_statement = parse_statement(query, [])
+    assert parsed_statement.source_type == SourceType.SNOWSQL_COMMAND
+    assert parsed_statement.source.read() == query
+    assert parsed_statement.source_path is None
+    assert parsed_statement.error is None
+
+
+def test_parse_unknown_command():
+    query = f"!unknown_cmd a=b c d"
+    parsed_statement = parse_statement(query, [])
+    assert parsed_statement.source_type == SourceType.UNKNOWN
+    assert parsed_statement.source.read() == query
+    assert parsed_statement.source_path is None
+    assert parsed_statement.error == "Unknown command: unknown_cmd"

--- a/tests/sql/test_statement_reader.py
+++ b/tests/sql/test_statement_reader.py
@@ -7,7 +7,7 @@ from snowflake.cli._plugins.sql.snowsql_templating import transpile_snowsql_temp
 from snowflake.cli._plugins.sql.statement_reader import (
     CompiledStatement,
     ParsedStatement,
-    SourceType,
+    StatementType,
     compile_statements,
     files_reader,
     parse_statement,
@@ -183,10 +183,10 @@ def test_read_files(tmp_path_factory: pytest.TempPathFactory):
 def test_parsed_source_repr():
     query = "select 1;"
 
-    source = ParsedStatement(query, SourceType.QUERY, None)
+    source = ParsedStatement(query, StatementType.QUERY, None)
     assert (
         str(source)
-        == "ParsedStatement(source_type=SourceType.QUERY, source_path=None, error=None)"
+        == "ParsedStatement(statement_type=StatementType.QUERY, source_path=None, error=None)"
     )
 
 
@@ -196,11 +196,11 @@ def test_parse_source_url(httpserver: HTTPServer):
     query = f"!source {httpserver.url_for('f1.sql')};"
     source = parse_statement(query, WORKING_OPERATOR_FUNCS)
 
-    assert source.source_type == SourceType.URL
+    assert source.statement_type == StatementType.URL
     assert source.source_path and source.source_path == httpserver.url_for("f1.sql")
     assert source.source_path.startswith("http://localhost:")
     assert source.source_path.endswith("/f1.sql")
-    assert source.source.read() == "select 1;"
+    assert source.statement.read() == "select 1;"
     assert source.error is None
 
 
@@ -212,15 +212,15 @@ def test_parse_source_invalid_url(httpserver: HTTPServer):
 
     source = parse_statement(invalid_source, WORKING_OPERATOR_FUNCS)
 
-    assert source.source_type == SourceType.URL
+    assert source.statement_type == StatementType.URL
     assert source.source_path == invalid_source
-    assert source.source.read() == invalid_url
+    assert source.statement.read() == invalid_url
     assert source.error and source.error.startswith("Could not fetch")
 
 
 def test_parse_source_just_query():
     source = parse_statement("select 1;", WORKING_OPERATOR_FUNCS)
-    expected = ParsedStatement("select 1;", SourceType.QUERY, None, None)
+    expected = ParsedStatement("select 1;", StatementType.QUERY, None, None)
     assert source == expected
 
 
@@ -231,7 +231,7 @@ def test_parse_source_just_query():
             "!source {path};",
             ParsedStatement(
                 "select 73;",
-                SourceType.FILE,
+                StatementType.FILE,
                 "path",
             ),
         ),
@@ -239,7 +239,7 @@ def test_parse_source_just_query():
             "!SoUrCe {path};",
             ParsedStatement(
                 "select 73;",
-                SourceType.FILE,
+                StatementType.FILE,
                 "path",
             ),
         ),
@@ -247,7 +247,7 @@ def test_parse_source_just_query():
             "!SOURCE {path};",
             ParsedStatement(
                 "select 73;",
-                SourceType.FILE,
+                StatementType.FILE,
                 "path",
             ),
         ),
@@ -255,7 +255,7 @@ def test_parse_source_just_query():
             "!load {path};",
             ParsedStatement(
                 "select 73;",
-                SourceType.FILE,
+                StatementType.FILE,
                 "path",
             ),
         ),
@@ -263,7 +263,7 @@ def test_parse_source_just_query():
             "!LoaD {path};",
             ParsedStatement(
                 "select 73;",
-                SourceType.FILE,
+                StatementType.FILE,
                 "path",
             ),
         ),
@@ -271,7 +271,7 @@ def test_parse_source_just_query():
             "!LOAD {path};",
             ParsedStatement(
                 "select 73;",
-                SourceType.FILE,
+                StatementType.FILE,
                 "path",
             ),
         ),
@@ -295,10 +295,10 @@ def test_parse_source_file(tmp_path_factory: pytest.TempPathFactory):
     query = f"!source {f1.as_posix()};"
     source = parse_statement(query, WORKING_OPERATOR_FUNCS)
 
-    assert source.source_type == SourceType.FILE
+    assert source.statement_type == StatementType.FILE
     assert source.source_path
     assert source.source_path == f1.as_posix()
-    assert source.source.read() == "select 1;"
+    assert source.statement.read() == "select 1;"
     assert source.error is None
 
 
@@ -309,9 +309,9 @@ def test_parse_source_invalid_file(tmp_path_factory: pytest.TempPathFactory):
     invalid_source = f"!source {invalid_path};"
     source = parse_statement(invalid_source, WORKING_OPERATOR_FUNCS)
 
-    assert source.source_type == SourceType.FILE
+    assert source.statement_type == StatementType.FILE
     assert source.source_path == invalid_source
-    assert source.source.read() == invalid_path
+    assert source.statement.read() == invalid_path
     assert source.error and source.error.startswith("Could not read")
 
 
@@ -323,9 +323,9 @@ def test_parse_source_default_fallback(command):
     source = parse_statement(unknown_source, WORKING_OPERATOR_FUNCS)
 
     assert not source
-    assert source.source_type == SourceType.UNKNOWN
+    assert source.statement_type == StatementType.UNKNOWN
     assert source.source_path == path
-    assert source.source.read() == unknown_source
+    assert source.statement.read() == unknown_source
     assert source.error and source.error.startswith("Unknown source")
 
 
@@ -345,9 +345,9 @@ def test_rendering_of_sql_with_commands(query):
         partial(snowflake_sql_jinja_render, data={"aaa": "foo", "bbb": "bar"}),
     )
     parsed_source = parse_statement(query, stmt_operators)
-    assert parsed_source.source_type == SourceType.FILE
+    assert parsed_source.statement_type == StatementType.FILE
     assert parsed_source.source_path == "!source foo.bar"
-    assert parsed_source.source.read() == "foo.bar"
+    assert parsed_source.statement.read() == "foo.bar"
     assert parsed_source.error == "Could not read: foo.bar"
 
 
@@ -377,8 +377,8 @@ def test_detect_async_queries():
 def test_parse_command(command):
     query = f"!{command} args k1=v1 k2=v2;"
     parsed_statement = parse_statement(query, [])
-    assert parsed_statement.source_type == SourceType.SNOWSQL_COMMAND
-    assert parsed_statement.source.read() == query
+    assert parsed_statement.statement_type == StatementType.SNOWSQL_COMMAND
+    assert parsed_statement.statement.read() == query
     assert parsed_statement.source_path is None
     assert parsed_statement.error is None
 
@@ -386,7 +386,7 @@ def test_parse_command(command):
 def test_parse_unknown_command():
     query = f"!unknown_cmd a=b c d"
     parsed_statement = parse_statement(query, [])
-    assert parsed_statement.source_type == SourceType.UNKNOWN
-    assert parsed_statement.source.read() == query
+    assert parsed_statement.statement_type == StatementType.UNKNOWN
+    assert parsed_statement.statement.read() == query
     assert parsed_statement.source_path is None
     assert parsed_statement.error == "Unknown command: unknown_cmd"

--- a/tests_integration/sql/__snapshots__/test_snowsql_commands.ambr
+++ b/tests_integration/sql/__snapshots__/test_snowsql_commands.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_queries_help
+  '''
+  +--------------------------------------------+
+  | FILTER    | ARGUMENT             | DEFAULT |
+  |-----------+----------------------+---------|
+  | amount    | integer              | 25      |
+  | status    | string               | any     |
+  | warehouse | string               | any     |
+  | user      | string               | any     |
+  | start     | date in milliseconds | any     |
+  | end       | date in milliseconds | any     |
+  | type      | string               | any     |
+  | duration  | time in milliseconds | any     |
+  | session   | No arguments         | any     |
+  +--------------------------------------------+
+  
+  '''
+# ---

--- a/tests_integration/sql/test_snowsql_commands.py
+++ b/tests_integration/sql/test_snowsql_commands.py
@@ -26,6 +26,13 @@ def test_queries(runner):
 
 
 @pytest.mark.integration
+def test_queries_help(runner, snapshot):
+    result = runner.invoke_with_connection(["sql", "-q", "!queries help;"])
+    assert result.exit_code == 0, result.output
+    assert result.output == snapshot
+
+
+@pytest.mark.integration
 def test_result(runner, existing_query_id):
     result = runner.invoke_with_connection_json(
         ["sql", "-q", f"!result {existing_query_id}"]

--- a/tests_integration/sql/test_snowsql_commands.py
+++ b/tests_integration/sql/test_snowsql_commands.py
@@ -1,0 +1,47 @@
+import pytest
+
+
+@pytest.fixture
+def existing_query_id(runner):
+    result = runner.invoke_with_connection_json(["sql", "-q", "select 15;>"])
+    assert result.exit_code == 0, result.output
+    yield result.json[0]["scheduled query ID"]
+
+
+@pytest.mark.integration
+def test_queries(runner):
+    query = """select 1;
+    select 3;
+    select 13;
+    !queries;
+    select 4;"""
+    result = runner.invoke_with_connection(["sql", "-q", query])
+    assert result.exit_code == 0, result.output
+    assert result.output.count("select 13") == 2
+    assert result.output.count("select 3") == 2
+    assert result.output.count("select 4") == 1
+    assert result.output.count("SUCCEEDED") == 3
+    for header in ["QUERY ID", "SQL TEXT", "STATUS", "DURATION_MS"]:
+        assert header in result.output
+
+
+@pytest.mark.integration
+def test_result(runner, existing_query_id):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", f"!result {existing_query_id}"]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.json == [{"15": 15}]
+
+
+@pytest.mark.integration
+def test_abort(runner, existing_query_id):
+    result = runner.invoke_with_connection_json(
+        ["sql", "-q", f"!abort {existing_query_id}"]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.json == [
+        {
+            f"SYSTEM$CANCEL_QUERY('{existing_query_id.upper()}')": "Identified SQL statement is not currently executing.",
+        },
+    ]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Add support for `!queries`, `!result` and `!abort` commands for SnowSQL. They're meant to be used in `--output=TABLE` format and might malfunction when mixed with other commands in `--json` output format.