### PR TITLE
SNOW-2054743 Fix for error with `!=` in requirements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,7 +26,7 @@
 * Added support for `!queries`, `!result` and `!abort` commands from SnowSQL.
 
 ## Fixes and improvements
-
+* Fix for deploying Snowpark project using `!=` operator in `requirements.txt`
 
 # v3.7.1
 

--- a/src/snowflake/cli/_plugins/snowpark/package/anaconda_packages.py
+++ b/src/snowflake/cli/_plugins/snowpark/package/anaconda_packages.py
@@ -88,6 +88,9 @@ class AnacondaPackages:
             return False
         if skip_version_check or not package.specs:
             return True
+        if any(spec[0] == "!=" for spec in package.specs):
+            # Snowflake doesn't support '!=' so we need to resolve this requirement externally
+            return False
         return self._packages[package.name].is_required_version_available(package)
 
     def package_latest_version(self, package: Requirement) -> str | None:

--- a/tests/snowpark/test_anaconda.py
+++ b/tests/snowpark/test_anaconda.py
@@ -92,7 +92,7 @@ def test_versions():
         ("Shrubbery<=1.3", True),
         ("shrubbery==1.2.*", True),
         ("shrubbery!=1.2.*", False),
-        ("dummy-pkg!=1.0.*", True),
+        ("dummy-pkg!=1.0.*", False),
         ("shrubbery>1,!=1.2.*", False),
         ("shrubbery>1,<4", True),
         # safe-fail for non-pep508 version formats

--- a/tests/snowpark/test_package.py
+++ b/tests/snowpark/test_package.py
@@ -175,11 +175,3 @@ class TestPackage:
     ):
         result = runner.invoke(["snowpark", "package", "create", "foo"])
         assert "is deprecated" not in result.output
-
-    @staticmethod
-    def mocked_anaconda_response(response: dict):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = response
-
-        return mock_response


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Created workaround for missing `!=` operator for package import in Snowpark
