### PR TITLE
Snow 2089072 fix escaping identifiers for "use" commands

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,6 +27,7 @@
 
 ## Fixes and improvements
 * Fix for deploying Snowpark project using `!=` operator in `requirements.txt`
+* Fix escaping identifiers for `use` commands.
 
 # v3.7.1
 

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -148,6 +148,7 @@ class SnowflakeSQLFacade:
             yield
             return
 
+        name = to_identifier(name)
         try:
             current_obj_result_row = self._sql_executor.execute_query(
                 f"select current_{object_type}()"
@@ -158,7 +159,7 @@ class SnowflakeSQLFacade:
             )
 
         try:
-            prev_obj = current_obj_result_row[0]
+            prev_obj = to_identifier(current_obj_result_row[0])
         except IndexError:
             prev_obj = None
 
@@ -230,12 +231,13 @@ class SnowflakeSQLFacade:
         with self._use_role_optional(role_to_use):
             try:
                 self._sql_executor.execute_query(
-                    f"grant {comma_separated_privileges} on {object_type_and_name} to role {role_to_grant}"
+                    f"grant {comma_separated_privileges} on {object_type_and_name} to role {to_identifier(role_to_grant)}"
                 )
             except Exception as err:
                 handle_unclassified_error(
                     err,
-                    f"Failed to grant {comma_separated_privileges} on {object_type_and_name} to role {role_to_grant}.",
+                    f"Failed to grant {comma_separated_privileges} on {object_type_and_name}"
+                    f" to role {to_identifier(role_to_grant)}.",
                 )
 
     def execute_user_script(

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -34,6 +34,7 @@ from snowflake.cli.api.exceptions import (
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.util import (
     identifier_to_show_like_pattern,
+    to_identifier,
     unquote_identifier,
 )
 from snowflake.cli.api.utils.cursor import find_first_row
@@ -121,7 +122,7 @@ class SqlExecutor(BaseSqlExecutor):
             raise CouldNotUseObjectError(object_type=object_type, name=name) from err
 
     def current_role(self) -> str:
-        return self.execute_query(f"select current_role()").fetchone()[0]
+        return to_identifier(self.execute_query(f"select current_role()").fetchone()[0])
 
     @contextmanager
     def use_role(self, new_role: str):
@@ -129,6 +130,7 @@ class SqlExecutor(BaseSqlExecutor):
         Switches to a different role for a while, then switches back.
         This is a no-op if the requested role is already active.
         """
+        new_role = to_identifier(new_role)
         prev_role = self.current_role()
         is_different_role = new_role.lower() != prev_role.lower()
         if is_different_role:
@@ -152,10 +154,11 @@ class SqlExecutor(BaseSqlExecutor):
         If there is no default warehouse in the account, it will throw an error.
         """
 
+        new_wh = to_identifier(new_wh)
         wh_result = self.execute_query(f"select current_warehouse()").fetchone()
         # If user has an assigned default warehouse, prev_wh will contain a value even if the warehouse is suspended.
         try:
-            prev_wh = wh_result[0]
+            prev_wh = to_identifier(wh_result[0])
         except:
             prev_wh = None
 

--- a/tests/api/test_sql_execution.py
+++ b/tests/api/test_sql_execution.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 import pytest
+from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.sql_execution import SqlExecutor
 
 EXECUTE_QUERY = f"snowflake.cli.api.sql_execution.BaseSqlExecutor.execute_query"
@@ -109,3 +110,9 @@ def test_use_warehouse_same_id(
     with SqlExecutor().use_warehouse(new_warehouse):
         pass
     assert mock_execute_query.mock_calls == [mock.call("select current_warehouse()")]
+
+
+@mock.patch(EXECUTE_QUERY)
+def test_use_schema_fqn(mock_execute_query):
+    SqlExecutor().use(ObjectType.SCHEMA, "db.schema")
+    assert mock_execute_query.mock_calls == [mock.call("use schema db.schema")]

--- a/tests/api/test_sql_execution.py
+++ b/tests/api/test_sql_execution.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+from snowflake.cli.api.sql_execution import SqlExecutor
+
+EXECUTE_QUERY = f"snowflake.cli.api.sql_execution.BaseSqlExecutor.execute_query"
+
+
+@pytest.mark.parametrize(
+    "new_role, expected_new_role, current_role, expected_current_role",
+    [
+        ("new_role", "new_role", "current_role", "current_role"),
+        ("new-role", '"new-role"', "current-role", '"current-role"'),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+def test_use_role_different_id(
+    mock_execute_query,
+    mock_cursor,
+    new_role,
+    expected_new_role,
+    current_role,
+    expected_current_role,
+):
+    mock_execute_query.return_value = mock_cursor([(current_role,)], [])
+    with SqlExecutor().use_role(new_role):
+        pass
+    assert mock_execute_query.mock_calls == [
+        mock.call("select current_role()"),
+        mock.call(f"use role {expected_new_role}"),
+        mock.call(f"use role {expected_current_role}"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "new_role, current_role",
+    [
+        ("test_role", "test_role"),
+        ("test role", '"test role"'),
+        ("test role", "test role"),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+def test_use_role_same_id(mock_execute_query, mock_cursor, new_role, current_role):
+    mock_execute_query.return_value = mock_cursor([(current_role,)], [])
+    with SqlExecutor().use_role(new_role):
+        pass
+    assert mock_execute_query.mock_calls == [mock.call("select current_role()")]
+
+
+@pytest.mark.parametrize(
+    "new_warehouse, expected_new_warehouse, current_warehouse, expected_current_warehouse",
+    [
+        ("new_warehouse", "new_warehouse", "current_warehouse", "current_warehouse"),
+        (
+            "new-warehouse",
+            '"new-warehouse"',
+            "current-warehouse",
+            '"current-warehouse"',
+        ),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+def test_use_warehouse_different_id(
+    mock_execute_query,
+    mock_cursor,
+    new_warehouse,
+    expected_new_warehouse,
+    current_warehouse,
+    expected_current_warehouse,
+):
+    mock_execute_query.return_value = mock_cursor([(current_warehouse,)], [])
+    with SqlExecutor().use_warehouse(new_warehouse):
+        pass
+    assert mock_execute_query.mock_calls == [
+        mock.call("select current_warehouse()"),
+        mock.call(f"use warehouse {expected_new_warehouse}"),
+        mock.call(f"use warehouse {expected_current_warehouse}"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "new_warehouse, current_warehouse",
+    [
+        ("test_warehouse", "test_warehouse"),
+        ("test warehouse", '"test warehouse"'),
+        ("test warehouse", "test warehouse"),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+def test_use_warehouse_same_id(
+    mock_execute_query, mock_cursor, new_warehouse, current_warehouse
+):
+    mock_execute_query.return_value = mock_cursor([(current_warehouse,)], [])
+    with SqlExecutor().use_warehouse(new_warehouse):
+        pass
+    assert mock_execute_query.mock_calls == [mock.call("select current_warehouse()")]

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -2624,6 +2624,7 @@ def test_run_app_from_release_directive_with_default_channel_when_release_channe
     }
     mock_show_release_channels.return_value = []
     mock_conn.return_value = MockConnectionCtx()
+    mock_execute.return_value = mock_cursor([("app_role",)], [])
     mock_sql_facade_upgrade_application.side_effect = (
         UpgradeApplicationRestrictionError(DEFAULT_USER_INPUT_ERROR_MESSAGE)
     )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Fix escaping identifiers for "use" commands in SqlExecutor and nativeapp's SnowflakeSQLFacade

### Testing
Set connection role to one requiring escaping (for example `test-role`) and follow [this tutorial](https://quickstarts.snowflake.com/guide/native-app-chairlift/index.html?index=..%2F..index#0) - `snow app run` command should succeed
