### PR TITLE
Add artifact repository fields to Snowpark Entity Model

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 * Added interactive mode for `snow sql`.
 * Added support for async SQL queries (`;>` syntax).
 * Added support for `!queries`, `!result` and `!abort` commands from SnowSQL.
+* Added `artifact_repository` and `artifact_repository_packages` fields to the Snowpark Entity Model to support direct usage of non-anaconda packages
 
 ## Fixes and improvements
 * Fix for deploying Snowpark project using `!=` operator in `requirements.txt`

--- a/src/snowflake/cli/_plugins/snowpark/common.py
+++ b/src/snowflake/cli/_plugins/snowpark/common.py
@@ -103,6 +103,15 @@ class SnowparkObjectManager(SqlExecutionMixin):
         if isinstance(entity, ProcedureEntityModel) and entity.execute_as_caller:
             query.append("execute as caller")
 
+        if entity.artifact_repository and entity.artifact_repository_packages:
+            packages = [f"'{item}'" for item in entity.artifact_repository_packages]
+            query.extend(
+                [
+                    f"ARTIFACT_REPOSITORY= {entity.artifact_repository}",
+                    f"ARTIFACT_REPOSITORY_PACKAGES=({','.join(packages)})",
+                ]
+            )
+
         return self.execute_query("\n".join(query))
 
     def deploy_entity(

--- a/src/snowflake/cli/_plugins/snowpark/snowpark_entity.py
+++ b/src/snowflake/cli/_plugins/snowpark/snowpark_entity.py
@@ -176,6 +176,15 @@ class SnowparkEntity(EntityBase[Generic[T]]):
         if self.model.type == "procedure" and self.model.execute_as_caller:
             query.append("EXECUTE AS CALLER")
 
+        if self.model.artifact_repository and self.model.artifact_repository_packages:
+            packages = [f"'{item}'" for item in self.model.artifact_repository_packages]
+            query.extend(
+                [
+                    f"ARTIFACT_REPOSITORY= {self.model.artifact_repository} ",
+                    f"ARTIFACT_REPOSITORY_PACKAGES=({','.join(packages)})",
+                ]
+            )
+
         return "\n".join(query)
 
     def get_execute_sql(self, execution_arguments: List[str] | None = None):

--- a/tests/snowpark/__snapshots__/test_models.ambr
+++ b/tests/snowpark/__snapshots__/test_models.ambr
@@ -1,4 +1,22 @@
 # serializer version: 1
+# name: test_error_is_raised_when_packages_are_specified_with_no_repository
+  '''
+  +- Error ----------------------------------------------------------------------+
+  | During evaluation of DefinitionV20 in project definition following errors    |
+  | were encountered:                                                            |
+  | For field entities.func1.function you provided '{'artifacts': [{'dest':      |
+  | 'my_snowpark_project', 'src': 'app.py'}], 'stage': 'dev_deployment',         |
+  | 'artifact_repository_packages': ['package'], 'external_access_integrations': |
+  | [], 'handler': 'app.func1_handler', 'identifier': {'name': 'func1'},         |
+  | 'imports': [], 'meta': {'use_mixins': ['snowpark_shared']}, 'returns':       |
+  | 'string', 'runtime': '3.10', 'secrets': {}, 'signature': [{'default':        |
+  | 'default value', 'name': 'a', 'type': 'string'}, {'name': 'b', 'type':       |
+  | 'variant'}], 'type': 'function'}'. This caused: Value error, You specified   |
+  | Artifact_repository_packages without setting Artifact_repository.            |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
 # name: test_raise_error_when_artifact_contains_asterix
   '''
   +- Error ----------------------------------------------------------------------+

--- a/tests/snowpark/__snapshots__/test_snowpark_entity.ambr
+++ b/tests/snowpark/__snapshots__/test_snowpark_entity.ambr
@@ -50,6 +50,19 @@
   HANDLER='app.func1_handler'
   '''
 # ---
+# name: test_get_deploy_sql_with_repository_packages
+  '''
+  CREATE FUNCTION IDENTIFIER('func1')
+  COPY GRANTS
+  RETURNS string
+  LANGUAGE PYTHON
+  RUNTIME_VERSION '3.10'
+  IMPORTS=
+  HANDLER='app.func1_handler'
+  ARTIFACT_REPOSITORY= snowflake.snowpark.pypi_shared_repository 
+  ARTIFACT_REPOSITORY_PACKAGES=('package1','package2')
+  '''
+# ---
 # name: test_nativeapp_children_interface
   '''
   CREATE FUNCTION IDENTIFIER('func1')

--- a/tests/snowpark/test_models.py
+++ b/tests/snowpark/test_models.py
@@ -100,3 +100,19 @@ def test_raise_error_when_artifact_contains_asterix(
 
         assert result.exit_code == 1
         assert result.output == os_agnostic_snapshot
+
+
+def test_error_is_raised_when_packages_are_specified_with_no_repository(
+    runner, project_directory, alter_snowflake_yml, os_agnostic_snapshot
+):
+    with project_directory("snowpark_functions_v2") as tmp_dir:
+        alter_snowflake_yml(
+            tmp_dir / "snowflake.yml",
+            "entities.func1.artifact_repository_packages",
+            ["package"],
+        )
+
+        result = runner.invoke(["snowpark", "build"])
+
+        assert result.exit_code == 1
+        assert result.output == os_agnostic_snapshot

--- a/tests/snowpark/test_snowpark_entity.py
+++ b/tests/snowpark/test_snowpark_entity.py
@@ -224,3 +224,11 @@ def test_get_usage_grant_sql(example_function_workspace):
         entity.get_usage_grant_sql("test_role")
         == "GRANT USAGE ON FUNCTION IDENTIFIER('func1') TO ROLE test_role;"
     )
+
+
+def test_get_deploy_sql_with_repository_packages(example_function_workspace, snapshot):
+    entity, _ = example_function_workspace
+    entity.model.artifact_repository = "snowflake.snowpark.pypi_shared_repository"
+    entity.model.artifact_repository_packages = ["package1", "package2"]
+    deploy_sql = entity.get_deploy_sql(CreateMode.create)
+    assert deploy_sql == snapshot

--- a/tests_integration/test_data/projects/snowpark_artifact_repository/app.py
+++ b/tests_integration/test_data/projects/snowpark_artifact_repository/app.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dummy_pkg_for_tests import shrubbery
+from snowflake.snowpark import Session
+
+
+def test_procedure(session: Session) -> str:
+    return shrubbery.knights_of_nii_says()
+
+
+def test_function() -> str:
+    return shrubbery.knights_of_nii_says()

--- a/tests_integration/test_data/projects/snowpark_artifact_repository/requirements.txt
+++ b/tests_integration/test_data/projects/snowpark_artifact_repository/requirements.txt
@@ -1,0 +1,1 @@
+snowflake-snowpark-python

--- a/tests_integration/test_data/projects/snowpark_artifact_repository/snowflake.yml
+++ b/tests_integration/test_data/projects/snowpark_artifact_repository/snowflake.yml
@@ -1,0 +1,30 @@
+definition_version: 2
+mixins:
+  snowpark_shared:
+    stage: "dev_deployment"
+    signature: ""
+    returns: string
+    artifact_repository: snowflake.snowpark.pypi_shared_repository
+    artifact_repository_packages:
+      - 'dummy-pkg-for-tests'
+    artifacts:
+      - "app.py"
+
+entities:
+  test_procedure:
+    type: "procedure"
+    identifier:
+      name: "test_procedure"
+    handler: "app.test_procedure"
+    meta:
+      use_mixins:
+        - "snowpark_shared"
+
+  test_function:
+    type: "function"
+    handler: "app.test_function"
+    identifier:
+      name: "test_function"
+    meta:
+      use_mixins:
+        - "snowpark_shared"

--- a/tests_integration/test_snowpark.py
+++ b/tests_integration/test_snowpark.py
@@ -1714,6 +1714,54 @@ def test_if_excluding_version_of_anaconda_package_moves_it_to_other_requirements
             assert any("about_time" in name for name in zf.namelist())
 
 
+def test_using_external_packages_from_package_repository(
+    test_database, runner, project_directory
+):
+
+    with project_directory("snowpark_artifact_repository") as tmp_dir:
+        result = runner.invoke_with_connection(
+            [
+                "snowpark",
+                "build",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Build done." in result.output
+
+        result = runner.invoke_with_connection(
+            [
+                "snowpark",
+                "deploy",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+
+        result = runner.invoke_with_connection(
+            [
+                "snowpark",
+                "execute",
+                "function",
+                "test_function()",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "We want... a shrubbery!" in result.output
+
+        result = runner.invoke_with_connection(
+            [
+                "snowpark",
+                "execute",
+                "procedure",
+                "test_procedure()",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "We want... a shrubbery!" in result.output
+
+
 @pytest.fixture
 def _test_setup(
     runner,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
Adding `artifact_repository` and `artifact_repository_packages` fields to the Snowpark Entity Model to support direct usage of non-anaconda packages
