### PR TITLE
SNOW-1994541: Change cortex complete to use snowflake.core APIs

### DIFF
--- a/src/snowflake/cli/_plugins/cortex/constants.py
+++ b/src/snowflake/cli/_plugins/cortex/constants.py
@@ -14,4 +14,5 @@
 
 from snowflake.cli._plugins.cortex.types import Model
 
-DEFAULT_MODEL: Model = Model("snowflake-arctic")
+DEFAULT_MODEL: Model = Model("llama3.1-70b")
+DEFAULT_BACKEND = "rest"

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -58,7 +58,7 @@
   
   :samp:`--model {TEXT}`
     String specifying the model to be used. Default: llama3.1-70b.
-
+  
   :samp:`--backend [sql|rest]`
     String specifying whether to use sql or rest backend. Default: rest.
   

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -11,6 +11,7 @@
     snow cortex complete
       <text>
       --model <model>
+      --backend <backend>
       --file <file>
       --connection <connection>
       --host <host>
@@ -56,7 +57,10 @@
   ===============================================================================
   
   :samp:`--model {TEXT}`
-    String specifying the model to be used. Default: snowflake-arctic.
+    String specifying the model to be used. Default: llama3.1-70b.
+
+  :samp:`--backend [sql|rest]`
+    String specifying whether to use sql or rest backend. Default: rest.
   
   :samp:`--file {FILE}`
     JSON file containing conversation history to be used to generate a completion. Cannot be combined with TEXT argument.

--- a/tests/cortex/test_cortex_commands.py
+++ b/tests/cortex/test_cortex_commands.py
@@ -51,13 +51,15 @@ def _mock_cortex_result(mock_ctx, mock_cursor):
 def test_cortex_complete_for_prompt_with_default_model(_mock_cortex_result, runner):
     with _mock_cortex_result(
         raw_result="Yes",
-        expected_query="SELECT SNOWFLAKE.CORTEX.COMPLETE( 'snowflake-arctic', 'Is 5 more than 4? Please answer using one word without a period.' ) AS CORTEX_RESULT;",
+        expected_query="SELECT SNOWFLAKE.CORTEX.COMPLETE( 'llama3.1-70b', 'Is 5 more than 4? Please answer using one word without a period.' ) AS CORTEX_RESULT;",
     ):
         result = runner.invoke(
             [
                 "cortex",
                 "complete",
                 "Is 5 more than 4? Please answer using one word without a period.",
+                "--backend",
+                "sql",
             ]
         )
         assert_successful_result_message(result, expected_msg="Yes")
@@ -121,7 +123,7 @@ def test_cortex_complete_for_prompt_with_chosen_model(_mock_cortex_result, runne
 def test_cortex_complete_for_file(_mock_cortex_result, runner):
     with _mock_cortex_result(
         raw_result="""{"choices": [{"messages": "No, I'm not"}]}""",
-        expected_query="""SELECT SNOWFLAKE.CORTEX.COMPLETE( 'snowflake-arctic', PARSE_JSON('[ { "role": "user", "content": "how does a \\\\"snowflake\\\\" get its \\'unique\\' pattern?" }, { "role": "system", "content": "I don\\'t know" }, { "role": "user", "content": "I thought \\\\"you\\\\" are smarter" } ] '), {} ) AS CORTEX_RESULT;""",
+        expected_query="""SELECT SNOWFLAKE.CORTEX.COMPLETE( 'llama3.1-70b', PARSE_JSON('[ { "role": "user", "content": "how does a \\\\"snowflake\\\\" get its \\'unique\\' pattern?" }, { "role": "system", "content": "I don\\'t know" }, { "role": "user", "content": "I thought \\\\"you\\\\" are smarter" } ] '), {} ) AS CORTEX_RESULT;""",
     ):
         result = runner.invoke(
             [
@@ -129,6 +131,8 @@ def test_cortex_complete_for_file(_mock_cortex_result, runner):
                 "complete",
                 "--file",
                 str(TEST_DIR / "test_data/cortex/conversation.json"),
+                "--backend",
+                "sql",
             ]
         )
         assert_successful_result_message(result, expected_msg="No, I'm not")

--- a/tests/cortex/test_cortex_commands.py
+++ b/tests/cortex/test_cortex_commands.py
@@ -115,6 +115,8 @@ def test_cortex_complete_for_prompt_with_chosen_model(_mock_cortex_result, runne
                 "Is 5 more than 4? Please answer using one word without a period.",
                 "--model",
                 "reka-flash",
+                "--backend",
+                "sql",
             ]
         )
         assert_successful_result_message(result, expected_msg="Yes")


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

This PR is a resubmission of a previous one that encountered issues with the CI merge gates and was unable to proceed.
Original PR: https://github.com/snowflakedb/snowflake-cli/pull/2152
This new PR contains the same code changes as the original.

The Snowflake CLI has a snowflake cortex complete command which calls into Cortex complete, but uses the SQL backend. This means that latency will be more variable for users using this tool.
This PR:

Changes the default model to llama3.1-70b.
Adds a --backend flag to switch between SQL and REST backends and implements support for calling into both.
Enables REST backend by default.
...
