### PR TITLE
fix error showing for --help messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
+  "click==8.1.8",
   "GitPython==3.1.44",
   "PyYAML==6.0.2",
   "jinja2==3.1.6",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,3 +1,4 @@
+click==8.1.8
 GitPython==3.1.44
 PyYAML==6.0.2
 jinja2==3.1.6


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
After `click 8.2.0` release typer raises error while displaying help messages. This PR freezes click dependency to latest compatible version (`8.1.8`)
