### PR TITLE
Cherry picks to 3.7.2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,16 @@
 ## Fixes and improvements
 
 
+# v3.7.2
+
+## Deprecations
+
+## New additions
+
+## Fixes and improvements
+* Fix error appearing on help messages after click BCR update.
+
+
 # v3.7.1
 
 ## Deprecations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
+  "click==8.1.8",
   "GitPython==3.1.44",
   "jinja2==3.1.6",
   "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "requirements-parser==0.11.0",
   "rich==14.0.0",
   "setuptools==78.1.0",
-  "snowflake-connector-python[secure-local-storage]==3.14.0",
+  "snowflake-connector-python[secure-local-storage]==3.15.0",
   'snowflake-snowpark-python>=1.15.0,<1.26.0;python_version < "3.12"',
   'snowflake.core==1.2.0; python_version < "3.12"',
   "tomlkit==0.13.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.10"
 description = "Snowflake CLI"
 readme = "README.md"
 dependencies = [
-  "certifi==2025.1.31",
   "GitPython==3.1.44",
   "jinja2==3.1.6",
   "packaging",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,4 +1,3 @@
-certifi==2025.1.31
 GitPython==3.1.44
 jinja2==3.1.6
 packaging

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -10,7 +10,7 @@ requests==2.32.3
 requirements-parser==0.11.0
 rich==14.0.0
 setuptools==78.1.0
-snowflake-connector-python[secure-local-storage]==3.14.0
+snowflake-connector-python[secure-local-storage]==3.15.0
 snowflake-snowpark-python>=1.15.0,<1.26.0;python_version < "3.12"
 snowflake.core==1.2.0; python_version < "3.12"
 tomlkit==0.13.2

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -1,3 +1,4 @@
+click==8.1.8
 GitPython==3.1.44
 jinja2==3.1.6
 packaging

--- a/src/snowflake/cli/__about__.py
+++ b/src/snowflake/cli/__about__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from enum import Enum, unique
 
-VERSION = "3.7.1"
+VERSION = "3.7.2"
 
 
 @unique


### PR DESCRIPTION
### Cherry picks
* update `snowflake-connector-python` to 3.15
* https://github.com/snowflakedb/snowflake-cli/pull/2238
* https://github.com/snowflakedb/snowflake-cli/pull/2272
