### PR TITLE
SNOW-2097298: Add --private-link flag to the snow spcs image-registry url command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* Added `--private-link` flag to `snow spcs image-registry url` command for retrieving private link URLs.
 
 ## Fixes and improvements
 

--- a/src/snowflake/cli/_plugins/spcs/image_registry/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/image_registry/commands.py
@@ -24,6 +24,14 @@ app = SnowTyperFactory(
     short_help="Manages image registries.",
 )
 
+import typer
+
+PrivateLinkOption: bool = typer.Option(
+    False,
+    "--private-link",
+    help="Please return the private link URL instead of the public URL.",
+)
+
 
 _TOKEN_EPILOG = """\
 Usage Example: snow spcs image-registry token --format JSON | docker login $(snow spcs image-registry url) -u 0sessiontoken --password-stdin
@@ -46,13 +54,13 @@ def token(**options) -> ObjectResult:
 
 
 @app.command(requires_connection=True)
-def url(**options) -> MessageResult:
+def url(private_link: bool = PrivateLinkOption, **options) -> MessageResult:
     """
     Gets the image registry URL for the current account.
 
     Must be called from a role that can view at least one image repository in the image registry.
     """
-    return MessageResult(RegistryManager().get_registry_url())
+    return MessageResult(RegistryManager().get_registry_url(private_link))
 
 
 @app.command(requires_connection=True)

--- a/src/snowflake/cli/_plugins/spcs/image_registry/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/image_registry/commands.py
@@ -29,7 +29,7 @@ import typer
 PrivateLinkOption: bool = typer.Option(
     False,
     "--private-link",
-    help="Please return the private link URL instead of the public URL.",
+    help="Get the private link URL instead of the public URL.",
 )
 
 

--- a/src/snowflake/cli/_plugins/spcs/image_registry/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/image_registry/manager.py
@@ -73,7 +73,7 @@ class RegistryManager(SqlExecutionMixin):
     def _has_url_scheme(self, url: str):
         return re.fullmatch(r"^.*//.+", url) is not None
 
-    def get_registry_url(self) -> str:
+    def get_registry_url(self, private_link: bool = False) -> str:
         images_query = "show image repositories in schema snowflake.images;"
         images_result = self.execute_query(images_query, cursor_class=DictCursor)
 
@@ -88,7 +88,15 @@ class RegistryManager(SqlExecutionMixin):
             if not results:
                 raise NoImageRepositoriesFoundError()
 
-        sample_repository_url = results["repository_url"]
+        if private_link:
+            privatelink_repository_url = "privatelink_repository_url"
+
+            if privatelink_repository_url not in results:
+                return ""
+            sample_repository_url = results[privatelink_repository_url]
+        else:
+            sample_repository_url = results["repository_url"]
+
         if not self._has_url_scheme(sample_repository_url):
             sample_repository_url = f"//{sample_repository_url}"
         return urlparse(sample_repository_url).netloc

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -11360,7 +11360,9 @@
    image registry.                                                                
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --help  -h        Show this message and exit.                                |
+  | --private-link            Please return the private link URL instead of the  |
+  |                           public URL.                                        |
+  | --help          -h        Show this message and exit.                        |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -11113,7 +11113,7 @@
    image registry.                                                                
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --help  -h        Show this message and exit.                                |
+  | --help          -h        Show this message and exit.                        |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |
@@ -11360,8 +11360,8 @@
    image registry.                                                                
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --private-link            Please return the private link URL instead of the  |
-  |                           public URL.                                        |
+  | --private-link            Get the private link URL instead of the public     |
+  |                           URL.                                               |
   | --help          -h        Show this message and exit.                        |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -11113,7 +11113,7 @@
    image registry.                                                                
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --help          -h        Show this message and exit.                        |
+  | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/spcs/test_registry.py
+++ b/tests/spcs/test_registry.py
@@ -87,7 +87,19 @@ def test_get_registry_url(mock_execute, mock_conn, mock_cursor):
 @mock.patch(
     "snowflake.cli._plugins.spcs.image_registry.manager.RegistryManager.execute_query"
 )
-def test_get_registry_privatelink_url(mock_execute, mock_conn, mock_cursor):
+@pytest.mark.parametrize(
+    "column_value, expected",
+    [
+        (
+            "orgname-alias.registry.privatelink.snowflakecomputing.com/DB/SCHEMA/IMAGES",
+            "orgname-alias.registry.privatelink.snowflakecomputing.com",
+        ),
+        ("", ""),
+    ],
+)
+def test_get_registry_privatelink_url(
+    mock_execute, mock_conn, mock_cursor, column_value, expected
+):
     mock_row = [
         "2023-01-01 00:00:00",
         "IMAGES",
@@ -97,7 +109,7 @@ def test_get_registry_privatelink_url(mock_execute, mock_conn, mock_cursor):
         "TEST_ROLE",
         "ROLE",
         "",
-        "orgname-alias.registry.privatelink.snowflakecomputing.com/DB/SCHEMA/IMAGES",
+        column_value,
     ]
 
     mock_execute.return_value = mock_cursor(
@@ -116,14 +128,14 @@ def test_get_registry_privatelink_url(mock_execute, mock_conn, mock_cursor):
     expected_query = "show image repositories in account"
     assert mock_execute.call_count == 2
     mock_execute.assert_any_call(expected_query, cursor_class=DictCursor)
-    assert result == "orgname-alias.registry.privatelink.snowflakecomputing.com"
+    assert result == expected
 
 
 @mock.patch("snowflake.cli._plugins.spcs.image_registry.manager.RegistryManager._conn")
 @mock.patch(
     "snowflake.cli._plugins.spcs.image_registry.manager.RegistryManager.execute_query"
 )
-def test_get_registry_privatelink_url_returns_empty_response(
+def test_get_registry_privatelink_url_returns_empty_for_missing_column(
     mock_execute, mock_conn, mock_cursor
 ):
     mock_row = [


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
This PR enhances the `snow spcs image-registry url` command by adding a `--private-link` flag. When used, the command will return the private link URL (or an empty response if not available) instead of the public URL.

This is cherry-pick of https://github.com/snowflakedb/snowflake-cli/pull/2275
