### PR TITLE
Snow 2108617 delay upgrade available message

### DIFF
--- a/src/snowflake/cli/_app/version_check.py
+++ b/src/snowflake/cli/_app/version_check.py
@@ -1,5 +1,6 @@
 import json
 import time
+from collections import namedtuple
 from warnings import warn
 
 import requests
@@ -11,12 +12,15 @@ from snowflake.connector.config_manager import CONFIG_MANAGER
 
 REPOSITORY_URL = "https://pypi.org/pypi/snowflake-cli/json"
 
+VersionAndTime = namedtuple("VersionAndTime", ["version", "upload_time"])
+
 
 def get_new_version_msg() -> str | None:
     last = _VersionCache().get_last_version()
     current = Version(VERSION)
-    if last and last > current:
-        return f"\nNew version of Snowflake CLI available. Newest: {last}, current: {VERSION}\n"
+    new_version_available = last and last.version and Version(last.version) > current
+    if new_version_available:
+        return f"\nNew version of Snowflake CLI available. Newest: {last.version}, current: {VERSION}\n"  # type:ignore
     return None
 
 
@@ -31,6 +35,7 @@ def show_new_version_banner_callback(msg):
 class _VersionCache:
     _last_time = "last_time_check"
     _version = "version"
+    _upload_time = "upload_time"
     _version_cache_file = SecurePath(
         CONFIG_MANAGER.file_path.parent / ".cli_version.cache"
     )
@@ -38,37 +43,47 @@ class _VersionCache:
     def __init__(self):
         self._cache_file = _VersionCache._version_cache_file
 
-    def _save_latest_version(self, version: str):
+    def _save_latest_version(self, version_and_time: VersionAndTime) -> None:
         data = {
             _VersionCache._last_time: time.time(),
-            _VersionCache._version: str(version),
+            _VersionCache._version: str(version_and_time.version),
+            _VersionCache._upload_time: version_and_time.upload_time,
         }
         self._cache_file.write_text(json.dumps(data))
 
     @staticmethod
-    def _get_version_from_pypi() -> str | None:
+    def _get_version_from_pypi() -> VersionAndTime:
         headers = {"Content-Type": "application/vnd.pypi.simple.v1+json"}
         response = requests.get(REPOSITORY_URL, headers=headers, timeout=3)
         response.raise_for_status()
-        return response.json()["info"]["version"]
+        data = response.json()
+        version = data["info"]["version"]
+        upload_time = None
+        try:
+            if version:
+                upload_time = data["releases"][version][0]["upload_time"]
+        except (KeyError, IndexError):
+            upload_time = None
+        return VersionAndTime(version, upload_time)
 
-    def _update_latest_version(self) -> Version | None:
-        version = self._get_version_from_pypi()
-        if version is None:
-            return None
-        self._save_latest_version(version)
-        return Version(version)
+    def _update_latest_version(self) -> VersionAndTime:
+        version_and_time = self._get_version_from_pypi()
+        if version_and_time.version:
+            self._save_latest_version(version_and_time)
+        return version_and_time
 
-    def _read_latest_version(self) -> Version | None:
+    def _read_latest_version(self) -> VersionAndTime:
         if self._cache_file.exists():
             data = json.loads(self._cache_file.read_text(file_size_limit_mb=1))
             now = time.time()
             if data[_VersionCache._last_time] > now - 60 * 60:
-                return Version(data[_VersionCache._version])
+                version = data[_VersionCache._version]
+                upload_time = data.get(_VersionCache._upload_time, None)
+                return VersionAndTime(version, upload_time)
 
         return self._update_latest_version()
 
-    def get_last_version(self) -> Version | None:
+    def get_last_version(self) -> VersionAndTime | None:
         try:
             return self._read_latest_version()
         except:  # anything, this it not crucial feature

--- a/src/snowflake/cli/_app/version_check.py
+++ b/src/snowflake/cli/_app/version_check.py
@@ -13,7 +13,7 @@ from snowflake.connector.config_manager import CONFIG_MANAGER
 
 REPOSITORY_URL = "https://pypi.org/pypi/snowflake-cli/json"
 
-# delay version check warning by X days, as homebrew version takes more time to become available
+# delay version check warning by 2 days, as homebrew index needs ~day to propagate the upgrade.
 NEW_VERSION_AVAILABLE_WARNING_DELAY = timedelta(days=2)
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
Delay "new version available" message by two days after pypi upload. Reason: homebrew index takes a ~day after CLI release propagate the upgrade.
