### PR TITLE
SNOW-2089589: add --private-link flag to the snow spcs image-registry login command

### DIFF
--- a/src/snowflake/cli/_plugins/spcs/image_registry/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/image_registry/commands.py
@@ -64,10 +64,10 @@ def url(private_link: bool = PrivateLinkOption, **options) -> MessageResult:
 
 
 @app.command(requires_connection=True)
-def login(**options) -> MessageResult:
+def login(private_link: bool = PrivateLinkOption, **options) -> MessageResult:
     """
     Logs in to the account image registry with the current user's credentials through Docker.
 
     Must be called from a role that can view at least one image repository in the image registry.
     """
-    return MessageResult(RegistryManager().docker_registry_login().strip())
+    return MessageResult(RegistryManager().docker_registry_login(private_link).strip())

--- a/src/snowflake/cli/_plugins/spcs/image_registry/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/image_registry/manager.py
@@ -101,8 +101,8 @@ class RegistryManager(SqlExecutionMixin):
             sample_repository_url = f"//{sample_repository_url}"
         return urlparse(sample_repository_url).netloc
 
-    def docker_registry_login(self) -> str:
-        registry_url = self.get_registry_url()
+    def docker_registry_login(self, private_link: bool = False) -> str:
+        registry_url = self.get_registry_url(private_link)
         token = self.get_token()
         command = [
             "docker",

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -13202,7 +13202,9 @@
    image registry.                                                                
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --help  -h        Show this message and exit.                                |
+  | --private-link            Get the private link URL instead of the public     |
+  |                           URL.                                               |
+  | --help          -h        Show this message and exit.                        |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/spcs/__snapshots__/test_registry.ambr
+++ b/tests/spcs/__snapshots__/test_registry.ambr
@@ -15,6 +15,22 @@
   
   '''
 # ---
+# name: test_docker_registry_login_cli_private_link
+  '''
+  Login Succeeded
+  
+  '''
+# ---
+# name: test_docker_registry_login_cli_private_link_no_repo
+  '''
+  +- Error ----------------------------------------------------------------------+
+  | No image repository found. To run this command, please switch to a role with |
+  | read access to at least one image repository or create a new image           |
+  | repository first.                                                            |
+  +------------------------------------------------------------------------------+
+  
+  '''
+# ---
 # name: test_docker_registry_login_subprocess_error
   'Login Failed: Docker Failed'
 # ---


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
This PR enhances the `snow spcs image-registry login` command by adding a `--private-link` flag. When used, the command will log in using the private link URL instead of the public URL.
