### PR TITLE
Jw/snow 2134871 remove deprecated streamlit features

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,7 +30,7 @@
 
 ## Fixes and improvements
 * Fixed failing snow sql command when snowflake.yml is invalid and query has no templating.
-* Refactored Streamlit app deployment and management code; removed deprecated Streamlit features and improved handling of default warehouse deprecation warnings.
+* Refactored Streamlit app deployment (using `FROM` <stage>` syntax); removed deprecated Streamlit features
 
 # v3.9.1
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,7 +31,7 @@
 ## Fixes and improvements
 * Fixed failing snow sql command when snowflake.yml is invalid and query has no templating.
 * Fix JSON serialization for `Decimal`, `time` and `binary`.
-* Refactored Streamlit app deployment (using `FROM` <stage>` syntax); removed deprecated Streamlit features
+* Refactored Streamlit app deployment (using `FROM <stage>` syntax); removed deprecated Streamlit features
 
 
 # v3.9.1

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,7 @@
 
 ## Fixes and improvements
 * Fixed failing snow sql command when snowflake.yml is invalid and query has no templating.
+* Refactored Streamlit app deployment and management code; removed deprecated Streamlit features and improved handling of default warehouse deprecation warnings.
 
 # v3.9.1
 

--- a/src/snowflake/cli/_plugins/git/manager.py
+++ b/src/snowflake/cli/_plugins/git/manager.py
@@ -64,11 +64,6 @@ class GitStagePathParts(StagePathParts):
     def full_path(self) -> str:
         return f"{self.stage.rstrip('/')}/{self.directory}"
 
-    def replace_stage_prefix(self, file_path: str) -> str:
-        stage = Path(self.stage).parts[0]
-        file_path_without_prefix = Path(file_path).parts[OMIT_FIRST]
-        return f"{stage}/{'/'.join(file_path_without_prefix)}"
-
     def add_stage_prefix(self, file_path: str) -> str:
         stage = self.stage.rstrip("/")
         return f"{stage}/{file_path.lstrip('/')}"

--- a/src/snowflake/cli/_plugins/git/manager.py
+++ b/src/snowflake/cli/_plugins/git/manager.py
@@ -14,9 +14,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from textwrap import dedent
-from typing import List
 
 from click import UsageError
 from snowflake.cli._plugins.stage.manager import (
@@ -67,10 +66,6 @@ class GitStagePathParts(StagePathParts):
     def add_stage_prefix(self, file_path: str) -> str:
         stage = self.stage.rstrip("/")
         return f"{stage}/{file_path.lstrip('/')}"
-
-    def get_directory_from_file_path(self, file_path: str) -> List[str]:
-        stage_path_length = len(Path(self.directory).parts)
-        return list(Path(file_path).parts[3 + stage_path_length : -1])
 
 
 class GitManager(StageManager):

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application_package.py
@@ -1330,7 +1330,7 @@ class ApplicationPackageEntity(EntityBase[ApplicationPackageEntityModel]):
                 role=self.role,
                 prune=prune,
                 recursive=recursive,
-                stage_path=stage_path,
+                stage_path_parts=stage_path,
                 local_paths_to_sync=paths,
                 print_diff=print_diff,
             )

--- a/src/snowflake/cli/_plugins/stage/diff.py
+++ b/src/snowflake/cli/_plugins/stage/diff.py
@@ -239,6 +239,7 @@ def sync_local_diff_with_stage(
     deploy_root_path: Path,
     diff_result: DiffResult,
     stage_full_path: str,
+    force_overwrite: bool = False,
 ):
     """
     Syncs a given local directory's contents with a Snowflake stage, including removing old files, and re-uploading modified and new files.
@@ -267,6 +268,7 @@ def sync_local_diff_with_stage(
             deploy_root_path=deploy_root_path,
             stage_paths=diff_result.only_local,
             role=role,
+            overwrite=force_overwrite,
         )
     except Exception as err:
         # Could be ProgrammingError or IntegrityError from SnowflakeCursor

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -132,14 +132,6 @@ class StagePathParts:
         return path
 
 
-def _strip_standard_stage_prefix(path: str) -> str:
-    """Removes '@' or 'snow://' prefix from given string"""
-    for prefix in [AT_PREFIX, SNOW_PREFIX]:
-        if path.startswith(prefix):
-            path = path.removeprefix(prefix)
-    return path
-
-
 @dataclass
 class DefaultStagePathParts(StagePathParts):
     """
@@ -197,7 +189,7 @@ class VStagePathParts(StagePathParts):
     def __init__(self, stage_path: str):
         match = re.fullmatch(VSTAGE_PATH_REGEX, stage_path)
         if match is None or not match.group("resource_type") or not match.group("name"):
-            raise CliError("Invalid vstage path")
+            raise CliError(f"Invalid vstage path: {stage_path}.")
         self.resource_type = match.group("resource_type")
         self.directory = match.group("directory")
         self._schema = match.group("second_qualifier") or match.group("first_qualifier")

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -60,7 +60,7 @@ log = logging.getLogger(__name__)
 UNQUOTED_FILE_URI_REGEX = r"[\w/*?\-.=&{}$#[\]\"\\!@%^+:]+"
 AT_PREFIX = "@"
 USER_STAGE_PREFIX = "@~"
-VSTAGE_PREFIX = "snow://"
+SNOW_PREFIX = "snow://"
 
 EXECUTE_SUPPORTED_FILES_FORMATS = (
     ".sql",
@@ -75,7 +75,7 @@ STAGE_PATH_REGEX = rf"(?P<prefix>(@|{re.escape('snow://')}))?(?:(?P<first_qualif
 VSTAGE_RESOURCE_TYPES = ("streamlit", "notebook")
 VSTAGE_RESOURCE_TYPES_REGEX = "|".join(map(re.escape, VSTAGE_RESOURCE_TYPES))
 VSTAGE_PATH_REGEX = (
-    rf"(?P<prefix>{re.escape(VSTAGE_PREFIX)})"
+    rf"(?P<prefix>{re.escape(SNOW_PREFIX)})"
     rf"(?P<resource_type>{VSTAGE_RESOURCE_TYPES_REGEX})/?"
     rf"(?:(?P<first_qualifier>{VALID_IDENTIFIER_REGEX})\.)?"
     rf"(?:(?P<second_qualifier>{VALID_IDENTIFIER_REGEX})\.)?"
@@ -143,7 +143,7 @@ class StagePathParts:
 
 def _strip_standard_stage_prefix(path: str) -> str:
     """Removes '@' or 'snow://' prefix from given string"""
-    for prefix in [AT_PREFIX, VSTAGE_PREFIX]:
+    for prefix in [AT_PREFIX, SNOW_PREFIX]:
         if path.startswith(prefix):
             path = path.removeprefix(prefix)
     return path
@@ -301,7 +301,7 @@ class StageManager(SqlExecutionMixin):
         if isinstance(name, FQN):
             name = name.identifier
         # Handle vstages
-        if name.startswith(VSTAGE_PREFIX) or name.startswith(AT_PREFIX):
+        if name.startswith(SNOW_PREFIX) or name.startswith(AT_PREFIX):
             return name
 
         return f"{AT_PREFIX}{name}"
@@ -795,7 +795,7 @@ class StageManager(SqlExecutionMixin):
         stage_path = StageManager.get_standard_stage_prefix(stage_path)
         if stage_path.startswith(USER_STAGE_PREFIX):
             return UserStagePathParts(stage_path)
-        elif stage_path.startswith(VSTAGE_PREFIX):
+        elif stage_path.startswith(SNOW_PREFIX):
             return VStagePathParts(stage_path)
         return DefaultStagePathParts(stage_path)
 

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -137,9 +137,6 @@ class StagePathParts:
             return path + "/"
         return path
 
-    def strip_stage_prefix(self, path: str):
-        raise NotImplementedError
-
 
 def _strip_standard_stage_prefix(path: str) -> str:
     """Removes '@' or 'snow://' prefix from given string"""
@@ -195,17 +192,6 @@ class DefaultStagePathParts(StagePathParts):
     @property
     def schema(self) -> str | None:
         return self._schema
-
-    def replace_stage_prefix(self, file_path: str) -> str:
-        file_path = _strip_standard_stage_prefix(file_path)
-        file_path_without_prefix = Path(file_path).parts[OMIT_FIRST]
-        return f"{self.stage}/{'/'.join(file_path_without_prefix)}"
-
-    def strip_stage_prefix(self, file_path: str) -> str:
-        file_path = _strip_standard_stage_prefix(file_path)
-        if file_path.startswith(self.stage_name):
-            return file_path[len(self.stage_name) :]
-        return file_path
 
     def add_stage_prefix(self, file_path: str) -> str:
         stage = self.stage.rstrip("/")
@@ -272,11 +258,6 @@ class UserStagePathParts(StagePathParts):
     @property
     def full_path(self) -> str:
         return f"{self.stage}/{self.directory}".rstrip("/")
-
-    def replace_stage_prefix(self, file_path: str) -> str:
-        if Path(file_path).parts[0] == self.stage_name:
-            return file_path
-        return f"{self.stage}/{file_path}"
 
     def add_stage_prefix(self, file_path: str) -> str:
         return f"{self.stage}/{file_path}"

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -113,13 +113,7 @@ class StagePathParts:
     def schema(self) -> str | None:
         raise NotImplementedError
 
-    def replace_stage_prefix(self, file_path: str) -> str:
-        raise NotImplementedError
-
     def add_stage_prefix(self, file_path: str) -> str:
-        raise NotImplementedError
-
-    def get_directory_from_file_path(self, file_path: str) -> List[str]:
         raise NotImplementedError
 
     def get_full_stage_path(self, path: str):
@@ -197,10 +191,6 @@ class DefaultStagePathParts(StagePathParts):
         stage = self.stage.rstrip("/")
         return f"{stage}/{file_path.lstrip('/')}"
 
-    def get_directory_from_file_path(self, file_path: str) -> List[str]:
-        stage_path_length = len(Path(self.directory).parts)
-        return list(Path(file_path).parts[1 + stage_path_length : -1])
-
 
 @dataclass
 class VStagePathParts(StagePathParts):
@@ -228,6 +218,16 @@ class VStagePathParts(StagePathParts):
         return f"{self._prefix}{self.stage_name.rstrip('/')}/{self.directory}".rstrip(
             "/"
         )
+
+    @property
+    def schema(self) -> str | None:
+        return self._schema
+
+    def add_stage_prefix(self, file_path: str) -> str:
+        return self.full_path
+
+    def get_standard_stage_path(self) -> str:
+        return self.full_path
 
 
 @dataclass
@@ -261,10 +261,6 @@ class UserStagePathParts(StagePathParts):
 
     def add_stage_prefix(self, file_path: str) -> str:
         return f"{self.stage}/{file_path}"
-
-    def get_directory_from_file_path(self, file_path: str) -> List[str]:
-        stage_path_length = len(Path(self.directory).parts)
-        return list(Path(file_path).parts[stage_path_length:-1])
 
 
 class StageManager(SqlExecutionMixin):

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -223,7 +223,6 @@ class EmbeddedStagePathParts(StagePathParts):
             raise ClickException("Invalid embedded stage path")
         self.resource_type = match.group("resource_type")
         self.directory = match.group("directory")
-        self.resource_type = match.group("resource_type")
         self._schema = match.group("second_qualifier") or match.group("first_qualifier")
         self._prefix = match.group("prefix")
         self.stage = stage_path.removesuffix(self.directory).rstrip("/")

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -243,6 +243,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
                 raise
 
         stage_root = f"snow://streamlit/{self.model.fqn.using_connection(self._conn).identifier}/versions/live"
+        # import pudb; pudb.set_trace()
 
         sync_deploy_root_with_stage(
             console=self._workspace_ctx.console,

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -166,7 +166,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         else:
             query = "CREATE STREAMLIT"
 
-        query += f" {self._get_identifier(schema, database)}"
+        query += f" {self._get_sql_identifier(schema, database)}"
 
         if from_stage_name:
             query += f"\nROOT_LOCATION = '{from_stage_name}'"
@@ -201,13 +201,15 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         return query + ";"
 
     def get_describe_sql(self) -> str:
-        return f"DESCRIBE STREAMLIT {self._get_identifier()};"
+        return f"DESCRIBE STREAMLIT {self._get_sql_identifier()};"
 
     def get_share_sql(self, to_role: str) -> str:
-        return f"GRANT USAGE ON STREAMLIT {self._get_identifier()} TO ROLE {to_role};"
+        return (
+            f"GRANT USAGE ON STREAMLIT {self._get_sql_identifier()} TO ROLE {to_role};"
+        )
 
     def get_execute_sql(self):
-        return f"EXECUTE STREAMLIT {self._get_identifier()}();"
+        return f"EXECUTE STREAMLIT {self._get_sql_identifier()}();"
 
     def get_usage_grant_sql(self, app_role: str, schema: Optional[str] = None) -> str:
         entity_id = self.entity_id

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -253,5 +253,5 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
             recursive=True,
             stage_path=stage_path,
             print_diff=True,
-            force_overwrite=True,  # files copied to streamlit embedded stages been to be overwritten
+            force_overwrite=True,  # files copied to streamlit vstage need to be overwritten
         )

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -122,7 +122,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
                 bundle_map=bundle_map,
                 prune=prune,
                 recursive=True,
-                stage_path=StageManager().stage_path_parts_from_str(stage_root),
+                stage_path_parts=StageManager().stage_path_parts_from_str(stage_root),
                 print_diff=True,
             )
 
@@ -244,7 +244,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
                 raise
 
         stage_root = self.describe().fetchone()["live_version_location_uri"]
-        stage_path = StageManager().stage_path_parts_from_str(stage_root)
+        stage_path_parts = StageManager().stage_path_parts_from_str(stage_root)
 
         sync_deploy_root_with_stage(
             console=self._workspace_ctx.console,
@@ -252,7 +252,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
             bundle_map=bundle_map,
             prune=prune,
             recursive=True,
-            stage_path=stage_path,
+            stage_path_parts=stage_path_parts,
             print_diff=True,
             force_overwrite=True,  # files copied to streamlit vstage need to be overwritten
         )

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -145,6 +145,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
     def get_add_live_version_sql(
         self, schema: Optional[str] = None, database: Optional[str] = None
     ):
+        # this query unlike most others doesn't accept fqn wrapped in `IDENTIFIER('')`
         return f"ALTER STREAMLIT {self._get_identifier(schema,database)} ADD LIVE VERSION FROM LAST;"
 
     def get_deploy_sql(

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -240,7 +240,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         try:
             if GlobalFeatureFlag.ENABLE_STREAMLIT_VERSIONED_STAGE.is_enabled():
                 self._execute_query(self.get_add_live_version_sql())
-            elif not GlobalFeatureFlag.ENABLE_STREAMLIT_NO_CHECKOUTS.is_enabled():
+            else:
                 self._execute_query(self.get_checkout_sql())
         except ProgrammingError as e:
             if "Checkout already exists" in str(

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -102,7 +102,6 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         if (
             experimental
             or GlobalFeatureFlag.ENABLE_STREAMLIT_VERSIONED_STAGE.is_enabled()
-            or GlobalFeatureFlag.ENABLE_STREAMLIT_EMBEDDED_STAGE.is_enabled()
         ):
             self._deploy_experimental(bundle_map=bundle_map, replace=replace)
         else:

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -242,15 +242,18 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
             else:
                 raise
 
-        stage_root = f"snow://streamlit/{self.model.fqn.using_connection(self._conn).identifier}/versions/live"
-        # import pudb; pudb.set_trace()
+        # TODO: fetch embedded stage path from server
+        # TODO: there's no way to alter existing streamlits
+        stage_root = f"snow://streamlit/{self.model.fqn.using_connection(self._conn).identifier}/versions/live/"
 
+        stage_path = StageManager().stage_path_parts_from_str(stage_root)
         sync_deploy_root_with_stage(
             console=self._workspace_ctx.console,
             deploy_root=bundle_map.deploy_root(),
             bundle_map=bundle_map,
             prune=prune,
             recursive=True,
-            stage_path=StageManager().stage_path_parts_from_str(stage_root),
+            stage_path=stage_path,
             print_diff=True,
+            force_overwrite=True,  # files copied to streamlit embedded stages been to be overwritten
         )

--- a/src/snowflake/cli/api/artifacts/upload.py
+++ b/src/snowflake/cli/api/artifacts/upload.py
@@ -30,7 +30,7 @@ def sync_artifacts_with_stage(
         bundle_map=bundle_map,
         prune=prune,
         recursive=True,
-        stage_path=stage_path_parts,
+        stage_path_parts=stage_path_parts,
         print_diff=True,
     )
     project_paths.clean_up_output()

--- a/src/snowflake/cli/api/entities/common.py
+++ b/src/snowflake/cli/api/entities/common.py
@@ -102,10 +102,8 @@ class EntityBase(Generic[T]):
     ) -> SqlExecutor:
         return get_sql_executor()
 
-    def _execute_query(
-        self, sql: str, cursor_class: Type[SnowflakeCursor] = SnowflakeCursor
-    ) -> SnowflakeCursor:
-        return self._sql_executor.execute_query(sql, cursor_class=cursor_class)
+    def _execute_query(self, sql: str, **kwargs) -> SnowflakeCursor:
+        return self._sql_executor.execute_query(sql, **kwargs)
 
     @functools.cached_property
     def _conn(self) -> SnowflakeConnection:

--- a/src/snowflake/cli/api/entities/common.py
+++ b/src/snowflake/cli/api/entities/common.py
@@ -133,12 +133,22 @@ class EntityBase(Generic[T]):
     def get_drop_sql(self) -> str:
         return f"DROP {self.model.type.upper()} {self.identifier};"  # type: ignore[attr-defined]
 
+    def _get_fqn(
+        self, schema: Optional[str] = None, database: Optional[str] = None
+    ) -> FQN:
+        schema_to_use = schema or self._entity_model.fqn.schema or self._conn.schema  # type: ignore
+        db_to_use = database or self._entity_model.fqn.database or self._conn.database  # type: ignore
+        return self._entity_model.fqn.set_schema(schema_to_use).set_database(db_to_use)  # type: ignore
+
+    def _get_sql_identifier(
+        self, schema: Optional[str] = None, database: Optional[str] = None
+    ) -> str:
+        return str(self._get_fqn(schema, database).sql_identifier)
+
     def _get_identifier(
         self, schema: Optional[str] = None, database: Optional[str] = None
     ) -> str:
-        schema_to_use = schema or self._entity_model.fqn.schema or self._conn.schema  # type: ignore
-        db_to_use = database or self._entity_model.fqn.database or self._conn.database  # type: ignore
-        return f"{self._entity_model.fqn.set_schema(schema_to_use).set_database(db_to_use).sql_identifier}"  # type: ignore
+        return str(self._get_fqn(schema, database).identifier)
 
     def get_from_fqn_or_conn(self, attribute_name: str) -> str:
         attribute = getattr(self.fqn, attribute_name, None) or getattr(

--- a/src/snowflake/cli/api/entities/common.py
+++ b/src/snowflake/cli/api/entities/common.py
@@ -102,8 +102,10 @@ class EntityBase(Generic[T]):
     ) -> SqlExecutor:
         return get_sql_executor()
 
-    def _execute_query(self, sql: str) -> SnowflakeCursor:
-        return self._sql_executor.execute_query(sql)
+    def _execute_query(
+        self, sql: str, cursor_class: Type[SnowflakeCursor] = SnowflakeCursor
+    ) -> SnowflakeCursor:
+        return self._sql_executor.execute_query(sql, cursor_class=cursor_class)
 
     @functools.cached_property
     def _conn(self) -> SnowflakeConnection:

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -91,6 +91,7 @@ def sync_deploy_root_with_stage(
     package_name: str | None = None,
     local_paths_to_sync: List[Path] | None = None,
     print_diff: bool = True,
+    force_overwrite: bool = False,
 ) -> DiffResult:
     """
     Ensures that the files on our remote stage match the artifacts we have in
@@ -108,11 +109,14 @@ def sync_deploy_root_with_stage(
         local_paths_to_sync (List[Path], optional): List of local paths to sync. Defaults to None to sync all
         local paths. Note that providing an empty list here is equivalent to None.
         print_diff (bool): Whether to print the diff between the local files and the remote stage. Defaults to True
+        force_overwrite (bool): Some resources (e.g. streamlit) need to overwrite files on the stage. Defaults to False.
 
     Returns:
         A `DiffResult` instance describing the changes that were performed.
     """
-    if not package_name:
+    if stage_path.is_embedded:
+        pass
+    elif not package_name:
         # ensure stage exists
         stage_fqn = FQN.from_stage(stage_path.stage)
         console.step(f"Creating stage {stage_fqn} if not exists.")
@@ -202,6 +206,7 @@ def sync_deploy_root_with_stage(
             deploy_root_path=deploy_root,
             diff_result=diff,
             stage_full_path=stage_path.full_path,
+            force_overwrite=force_overwrite,
         )
     return diff
 

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -114,7 +114,7 @@ def sync_deploy_root_with_stage(
     Returns:
         A `DiffResult` instance describing the changes that were performed.
     """
-    if stage_path.is_embedded:
+    if stage_path.is_vstage:
         pass
     elif not package_name:
         # ensure stage exists

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -115,6 +115,7 @@ def sync_deploy_root_with_stage(
         A `DiffResult` instance describing the changes that were performed.
     """
     if stage_path.is_vstage:
+        # vstages are created by FBE, so no need to do it manually
         pass
     elif not package_name:
         # ensure stage exists

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -86,7 +86,7 @@ def sync_deploy_root_with_stage(
     bundle_map: BundleMap,
     prune: bool,
     recursive: bool,
-    stage_path: StagePathParts,
+    stage_path_parts: StagePathParts,
     role: str | None = None,
     package_name: str | None = None,
     local_paths_to_sync: List[Path] | None = None,
@@ -102,7 +102,7 @@ def sync_deploy_root_with_stage(
         role (str): The name of the role to use for queries and commands.
         prune (bool): Whether to prune artifacts from the stage that don't exist locally.
         recursive (bool): Whether to traverse directories recursively.
-        stage_path (DefaultStagePathParts): stage path object.
+        stage_path_parts (StagePathParts): stage path parts object.
 
         package_name (str): supported for Native App compatibility. Should be None out of Native App context.
 
@@ -114,19 +114,19 @@ def sync_deploy_root_with_stage(
     Returns:
         A `DiffResult` instance describing the changes that were performed.
     """
-    if stage_path.is_vstage:
+    if stage_path_parts.is_vstage:
         # vstages are created by FBE, so no need to do it manually
         pass
     elif not package_name:
         # ensure stage exists
-        stage_fqn = FQN.from_stage(stage_path.stage)
+        stage_fqn = FQN.from_stage(stage_path_parts.stage)
         console.step(f"Creating stage {stage_fqn} if not exists.")
         StageManager().create(fqn=stage_fqn)
     else:
         # ensure stage exists - nativeapp behavior
         sql_facade = get_snowflake_facade()
-        schema = stage_path.schema
-        stage_fqn = stage_path.stage
+        schema = stage_path_parts.schema
+        stage_fqn = stage_path_parts.stage
         # Does a stage already exist within the application package, or we need to create one?
         # Using "if not exists" should take care of either case.
         console.step(
@@ -139,12 +139,12 @@ def sync_deploy_root_with_stage(
     # Perform a diff operation and display results to the user for informational purposes
     if print_diff:
         console.step(
-            f"Performing a diff between the Snowflake stage: {stage_path.path} and your local deploy_root: {deploy_root.resolve()}."
+            f"Performing a diff between the Snowflake stage: {stage_path_parts.path} and your local deploy_root: {deploy_root.resolve()}."
         )
 
     diff: DiffResult = compute_stage_diff(
         local_root=deploy_root,
-        stage_path=stage_path,
+        stage_path=stage_path_parts,
     )
 
     if local_paths_to_sync:
@@ -206,7 +206,7 @@ def sync_deploy_root_with_stage(
             role=role,
             deploy_root_path=deploy_root,
             diff_result=diff,
-            stage_full_path=stage_path.full_path,
+            stage_full_path=stage_path_parts.full_path,
             force_overwrite=force_overwrite,
         )
     return diff

--- a/src/snowflake/cli/api/feature_flags.py
+++ b/src/snowflake/cli/api/feature_flags.py
@@ -56,9 +56,6 @@ class FeatureFlagMixin(Enum):
 
 @unique
 class FeatureFlag(FeatureFlagMixin):
-    ENABLE_STREAMLIT_EMBEDDED_STAGE = BooleanFlag(
-        "ENABLE_STREAMLIT_EMBEDDED_STAGE", False
-    )
     ENABLE_STREAMLIT_NO_CHECKOUTS = BooleanFlag("ENABLE_STREAMLIT_NO_CHECKOUTS", False)
     ENABLE_STREAMLIT_VERSIONED_STAGE = BooleanFlag(
         "ENABLE_STREAMLIT_VERSIONED_STAGE", False

--- a/src/snowflake/cli/api/feature_flags.py
+++ b/src/snowflake/cli/api/feature_flags.py
@@ -56,7 +56,6 @@ class FeatureFlagMixin(Enum):
 
 @unique
 class FeatureFlag(FeatureFlagMixin):
-    ENABLE_STREAMLIT_NO_CHECKOUTS = BooleanFlag("ENABLE_STREAMLIT_NO_CHECKOUTS", False)
     ENABLE_STREAMLIT_VERSIONED_STAGE = BooleanFlag(
         "ENABLE_STREAMLIT_VERSIONED_STAGE", False
     )

--- a/src/snowflake/cli/api/stage_path.py
+++ b/src/snowflake/cli/api/stage_path.py
@@ -99,15 +99,14 @@ class StagePath:
 
     @classmethod
     def from_stage_str(cls, stage_str: str | FQN) -> StagePath:
-        _at_prefixed, _snow_prefixed = str(stage_str).startswith("@"), str(
-            stage_str
-        ).startswith(SNOW_PREFIX)
+        _is_at_prefixed = str(stage_str).startswith("@")
+        _is_snow_prefixed = str(stage_str).startswith(SNOW_PREFIX)
         stage_str = cls.strip_stage_prefixes(str(stage_str))
-        if _snow_prefixed:
-            resource = stage_str.split("/", maxsplit=1)[0]
-            stage_str = stage_str.removeprefix(resource + "/")
+        if _is_snow_prefixed:
+            resource_type = stage_str.split("/", maxsplit=1)[0]
+            stage_str = stage_str.removeprefix(resource_type + "/")
         else:
-            resource = None
+            resource_type = ""
         parts = stage_str.split("/", maxsplit=1)
         parts = [p for p in parts if p]
         if len(parts) == 2:
@@ -115,11 +114,10 @@ class StagePath:
         else:
             stage_string = parts[0]
             path = None
-        if _at_prefixed:
+        if _is_at_prefixed:
             stage_string = cls.add_at_prefix(stage_string)
-        if _snow_prefixed:
-            stage_string = resource + "/" + stage_string
-            stage_string = cls.add_snow_prefix(stage_string)
+        if _is_snow_prefixed:
+            stage_string = cls.add_snow_prefix(resource_type + "/" + stage_string)
         stage_path = cls(
             stage_name=stage_string, path=path, trailing_slash=stage_str.endswith("/")
         )
@@ -131,15 +129,14 @@ class StagePath:
         @configuration_repo / branches/main  / scripts/setup.sql
         @configuration_repo / branches/"foo/main"  / scripts/setup.sql
         """
-        _at_prefixed, _snow_prefixed = git_str.startswith("@"), git_str.startswith(
-            SNOW_PREFIX
-        )
+        _is_at_prefixed = git_str.startswith("@")
+        _is_snow_prefixed = git_str.startswith(SNOW_PREFIX)
         repo_name, git_ref, path = cls._split_repo_path(
             cls.strip_stage_prefixes(git_str)
         )
-        if _at_prefixed:
+        if _is_at_prefixed:
             repo_name = cls.add_at_prefix(repo_name)
-        if _snow_prefixed:
+        if _is_snow_prefixed:
             repo_name = cls.add_snow_prefix(repo_name)
         return cls(
             stage_name=repo_name,

--- a/src/snowflake/cli/api/stage_path.py
+++ b/src/snowflake/cli/api/stage_path.py
@@ -99,10 +99,15 @@ class StagePath:
 
     @classmethod
     def from_stage_str(cls, stage_str: str | FQN) -> StagePath:
-        _at_prefixed, _snow_prefixed = stage_str.startswith("@"), stage_str.startswith(
-            SNOW_PREFIX
-        )
+        _at_prefixed, _snow_prefixed = str(stage_str).startswith("@"), str(
+            stage_str
+        ).startswith(SNOW_PREFIX)
         stage_str = cls.strip_stage_prefixes(str(stage_str))
+        if _snow_prefixed:
+            resource = stage_str.split("/", maxsplit=1)[0]
+            stage_str = stage_str.removeprefix(resource + "/")
+        else:
+            resource = None
         parts = stage_str.split("/", maxsplit=1)
         parts = [p for p in parts if p]
         if len(parts) == 2:
@@ -113,6 +118,7 @@ class StagePath:
         if _at_prefixed:
             stage_string = cls.add_at_prefix(stage_string)
         if _snow_prefixed:
+            stage_string = resource + "/" + stage_string
             stage_string = cls.add_snow_prefix(stage_string)
         stage_path = cls(
             stage_name=stage_string, path=path, trailing_slash=stage_str.endswith("/")

--- a/src/snowflake/cli/api/stage_path.py
+++ b/src/snowflake/cli/api/stage_path.py
@@ -9,6 +9,7 @@ from snowflake.cli.api.project.util import (
 )
 
 USER_STAGE_PREFIX = "~"
+SNOW_PREFIX = "snow://"
 
 
 class StagePath:
@@ -19,6 +20,7 @@ class StagePath:
         git_ref: str | None = None,
         trailing_slash: bool = False,
     ):
+        self._is_snow_prefixed_stage = stage_name.startswith(SNOW_PREFIX)
         self._stage_name = self.strip_stage_prefixes(stage_name)
         self._path = PurePosixPath(path) if path else PurePosixPath(".")
 
@@ -53,6 +55,10 @@ class StagePath:
     def stage_with_at(self) -> str:
         return self.add_at_prefix(self._stage_name)
 
+    @property
+    def stage_with_snow(self) -> str:
+        return self.add_snow_prefix(self._stage_name)
+
     def is_user_stage(self) -> bool:
         return self._is_user_stage
 
@@ -70,6 +76,12 @@ class StagePath:
         return text
 
     @staticmethod
+    def add_snow_prefix(text: str):
+        if not text.startswith(SNOW_PREFIX):
+            return SNOW_PREFIX + text
+        return text
+
+    @staticmethod
     def strip_at_prefix(text: str):
         if text.startswith("@"):
             return text[1:]
@@ -77,8 +89,8 @@ class StagePath:
 
     @staticmethod
     def strip_snow_prefix(text: str):
-        if text.startswith("snow://"):
-            return text[len("snow://") :]
+        if text.startswith(SNOW_PREFIX):
+            return text[len(SNOW_PREFIX) :]
         return text
 
     @classmethod
@@ -86,7 +98,10 @@ class StagePath:
         return cls.strip_at_prefix(cls.strip_snow_prefix(text))
 
     @classmethod
-    def from_stage_str(cls, stage_str: str | FQN):
+    def from_stage_str(cls, stage_str: str | FQN) -> StagePath:
+        _at_prefixed, _snow_prefixed = stage_str.startswith("@"), stage_str.startswith(
+            SNOW_PREFIX
+        )
         stage_str = cls.strip_stage_prefixes(str(stage_str))
         parts = stage_str.split("/", maxsplit=1)
         parts = [p for p in parts if p]
@@ -95,9 +110,14 @@ class StagePath:
         else:
             stage_string = parts[0]
             path = None
-        return cls(
+        if _at_prefixed:
+            stage_string = cls.add_at_prefix(stage_string)
+        if _snow_prefixed:
+            stage_string = cls.add_snow_prefix(stage_string)
+        stage_path = cls(
             stage_name=stage_string, path=path, trailing_slash=stage_str.endswith("/")
         )
+        return stage_path
 
     @classmethod
     def from_git_str(cls, git_str: str):
@@ -105,9 +125,16 @@ class StagePath:
         @configuration_repo / branches/main  / scripts/setup.sql
         @configuration_repo / branches/"foo/main"  / scripts/setup.sql
         """
+        _at_prefixed, _snow_prefixed = git_str.startswith("@"), git_str.startswith(
+            SNOW_PREFIX
+        )
         repo_name, git_ref, path = cls._split_repo_path(
             cls.strip_stage_prefixes(git_str)
         )
+        if _at_prefixed:
+            repo_name = cls.add_at_prefix(repo_name)
+        if _snow_prefixed:
+            repo_name = cls.add_snow_prefix(repo_name)
         return cls(
             stage_name=repo_name,
             path=path,
@@ -150,7 +177,9 @@ class StagePath:
             path = path / self._path
 
         str_path = str(path)
-        if at_prefix:
+        if self._is_snow_prefixed_stage:
+            str_path = self.add_snow_prefix(str_path)
+        elif at_prefix:
             str_path = self.add_at_prefix(str_path)
 
         if self._trailing_slash:

--- a/tests/nativeapp/test_application_package_entity.py
+++ b/tests/nativeapp/test_application_package_entity.py
@@ -246,7 +246,7 @@ def test_deploy(
         role="app_role",
         prune=False,
         recursive=False,
-        stage_path=DefaultStagePathParts.from_fqn("pkg.app_src.stage"),
+        stage_path_parts=DefaultStagePathParts.from_fqn("pkg.app_src.stage"),
         local_paths_to_sync=["a/b", "c"],
         print_diff=True,
     )
@@ -347,7 +347,7 @@ def test_deploy_w_stage_subdir(
         role="app_role",
         prune=False,
         recursive=False,
-        stage_path=DefaultStagePathParts.from_fqn("pkg.app_src.stage", "v1"),
+        stage_path_parts=DefaultStagePathParts.from_fqn("pkg.app_src.stage", "v1"),
         local_paths_to_sync=["a/b", "c"],
         print_diff=True,
     )

--- a/tests/nativeapp/test_children.py
+++ b/tests/nativeapp/test_children.py
@@ -121,7 +121,7 @@ def test_valid_children():
 
 
 @mock.patch(
-    "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._get_identifier",
+    "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._get_sql_identifier",
     return_value="IDENTIFIER('v_schema.my_streamlit')",
 )
 def test_children_bundle_with_custom_dir(mock_id, project_directory):

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -167,6 +167,7 @@ def test_sync_deploy_root_with_stage(
         deploy_root_path=dm.project_root / pkg_model.deploy_root,
         diff_result=mock_diff_result,
         stage_full_path="app_pkg.app_src.stage",
+        force_overwrite=False,
     )
 
 
@@ -231,6 +232,7 @@ def test_sync_deploy_root_with_stage_subdir(
         deploy_root_path=dm.project_root / pkg_model.deploy_root,
         diff_result=mock_diff_result,
         stage_full_path=stage_full_path,
+        force_overwrite=False,
     )
 
 

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -151,7 +151,7 @@ def test_sync_deploy_root_with_stage(
         role="new_role",
         prune=True,
         recursive=True,
-        stage_path=DefaultStagePathParts.from_fqn(stage_fqn),
+        stage_path_parts=DefaultStagePathParts.from_fqn(stage_fqn),
     )
 
     mock_stage_exists.assert_called_once_with(stage_fqn)
@@ -216,7 +216,7 @@ def test_sync_deploy_root_with_stage_subdir(
         role="new_role",
         prune=True,
         recursive=True,
-        stage_path=DefaultStagePathParts.from_fqn(stage_fqn, "v1"),
+        stage_path_parts=DefaultStagePathParts.from_fqn(stage_fqn, "v1"),
     )
 
     mock_stage_exists.assert_called_once_with(stage_fqn)
@@ -287,7 +287,7 @@ def test_sync_deploy_root_with_stage_prune(
         role="new_role",
         prune=prune,
         recursive=True,
-        stage_path=DefaultStagePathParts.from_fqn(stage_fqn),
+        stage_path_parts=DefaultStagePathParts.from_fqn(stage_fqn),
     )
 
     if expected_warn:

--- a/tests/stage/test_stage_path.py
+++ b/tests/stage/test_stage_path.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from snowflake.cli._plugins.stage.manager import DefaultStagePathParts
+from click import ClickException
+from snowflake.cli._plugins.stage.manager import DefaultStagePathParts, VStagePathParts
 from snowflake.cli.api.stage_path import StagePath
 
 # (path, is_git_repo)
@@ -484,3 +485,117 @@ def test_join_system_path():
 def test_vstage_paths(stage_str):
     stage_path = StagePath.from_stage_str(stage_str)
     assert str(stage_path) == stage_str
+
+
+@pytest.mark.parametrize(
+    "input_path, expected_path, expected_full_path, expected_schema, expected_stage, expected_stage_name, expected_resource_type, expected_directory, expected_is_directory",
+    [
+        # Basic cases
+        (
+            "snow://streamlit/name",
+            "snow://streamlit/name",
+            "snow://streamlit/name",
+            None,
+            "snow://streamlit/name",
+            "streamlit/name",
+            "streamlit",
+            "",
+            False,
+        ),
+        (
+            "snow://notebook/schema.name",
+            "snow://notebook/schema.name",
+            "snow://notebook/schema.name",
+            "schema",
+            "snow://notebook/schema.name",
+            "notebook/schema.name",
+            "notebook",
+            "",
+            False,
+        ),
+        (
+            "snow://streamlit/db.schema.name",
+            "snow://streamlit/db.schema.name",
+            "snow://streamlit/db.schema.name",
+            "schema",
+            "snow://streamlit/db.schema.name",
+            "streamlit/db.schema.name",
+            "streamlit",
+            "",
+            False,
+        ),
+        # With directories
+        (
+            "snow://streamlit/name/dir",
+            "snow://streamlit/name/dir",
+            "snow://streamlit/name/dir",
+            None,
+            "snow://streamlit/name",
+            "streamlit/name",
+            "streamlit",
+            "dir",
+            False,
+        ),
+        (
+            "snow://streamlit/db.schema.name/nested/path/file.py",
+            "snow://streamlit/db.schema.name/nested/path/file.py",
+            "snow://streamlit/db.schema.name/nested/path/file.py",
+            "schema",
+            "snow://streamlit/db.schema.name",
+            "streamlit/db.schema.name",
+            "streamlit",
+            "nested/path/file.py",
+            False,
+        ),
+        (
+            "snow://notebook/name/deep/nested/structure/",
+            "snow://notebook/name/deep/nested/structure",
+            "snow://notebook/name/deep/nested/structure",
+            None,
+            "snow://notebook/name",
+            "notebook/name",
+            "notebook",
+            "deep/nested/structure/",
+            True,
+        ),
+    ],
+)
+def test_vstage_path_parts_properties(
+    input_path,
+    expected_path,
+    expected_full_path,
+    expected_schema,
+    expected_stage,
+    expected_stage_name,
+    expected_resource_type,
+    expected_directory,
+    expected_is_directory,
+):
+    vstage_parts = VStagePathParts(input_path)
+
+    assert vstage_parts.path == vstage_parts.get_standard_stage_path() == expected_path
+    assert vstage_parts.full_path == expected_full_path
+    assert vstage_parts.schema == expected_schema
+    assert vstage_parts.stage == expected_stage
+    assert vstage_parts.stage_name == expected_stage_name
+    assert vstage_parts.resource_type == expected_resource_type
+    assert vstage_parts.directory == expected_directory
+    assert vstage_parts.is_directory == expected_is_directory
+    assert vstage_parts.is_vstage == True
+
+
+@pytest.mark.parametrize(
+    "invalid_path",
+    [
+        "snow://invalid_resource/name",
+        "snow://streamlit",  # Missing name
+        "regular_stage/path",
+        "@stage/path",
+        "snow://",
+        "snow://streamlit/",
+        "",
+    ],
+)
+def test_vstage_path_parts_invalid_paths(invalid_path):
+    with pytest.raises(ClickException, match="Invalid vstage path"):
+        VStagePathParts(invalid_path)

--- a/tests/stage/test_stage_path.py
+++ b/tests/stage/test_stage_path.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from click import ClickException
 from snowflake.cli._plugins.stage.manager import DefaultStagePathParts, VStagePathParts
+from snowflake.cli.api.exceptions import CliError
 from snowflake.cli.api.stage_path import StagePath
 
 # (path, is_git_repo)
@@ -587,7 +587,7 @@ def test_vstage_path_parts_properties(
 @pytest.mark.parametrize(
     "invalid_path",
     [
-        "snow://invalid_resource/name",
+        "snow://invalid@resource/name",
         "snow://streamlit",  # Missing name
         "regular_stage/path",
         "@stage/path",
@@ -597,5 +597,5 @@ def test_vstage_path_parts_properties(
     ],
 )
 def test_vstage_path_parts_invalid_paths(invalid_path):
-    with pytest.raises(ClickException, match="Invalid vstage path"):
+    with pytest.raises(CliError, match="Invalid vstage path"):
         VStagePathParts(invalid_path)

--- a/tests/stage/test_stage_path.py
+++ b/tests/stage/test_stage_path.py
@@ -120,12 +120,9 @@ def test_dir_with_file_paths(path, is_git_repo):
     assert stage_path.suffix == ".py"
     assert stage_path.stem == "file"
     assert stage_path.stage == path.lstrip("@").replace("snow://", "").split("/")[0]
-    if path.startswith("snow://"):
-        assert stage_path.absolute_path() == path.rstrip("/")
-    else:
-        assert stage_path.absolute_path() == "@" + path.lstrip("@").replace(
-            "snow://", ""
-        ).rstrip("/")
+    assert stage_path.absolute_path() == "@" + path.lstrip("@").replace(
+        "snow://", ""
+    ).rstrip("/")
 
 
 def test_join_path():
@@ -473,3 +470,17 @@ def test_join_system_path():
     stage_path = StagePath.from_stage_str("stage")
     system_path = Path("dir") / "subdir" / "file.txt"
     assert str(stage_path / system_path) == "@stage/dir/subdir/file.txt"
+
+
+@pytest.mark.parametrize(
+    "stage_str",
+    [
+        "snow://streamlit/db.schema.name/live/version",
+        "snow://notebook/db.schema.name/live/version",
+        "snow://streamlit/schema.name/live/version",
+        "snow://streamlit/name/live/version",
+    ],
+)
+def test_vstage_paths(stage_str):
+    stage_path = StagePath.from_stage_str(stage_str)
+    assert str(stage_path) == stage_str

--- a/tests/stage/test_stage_path.py
+++ b/tests/stage/test_stage_path.py
@@ -53,14 +53,8 @@ def with_at_prefix(test_data: list[tuple[str, bool]]):
     return [(f"@{path}", is_git_repo) for path, is_git_repo in test_data]
 
 
-def with_snow_prefix(test_data: list[tuple[str, bool]]):
-    return [(f"snow://{path}", is_git_repo) for path, is_git_repo in test_data]
-
-
 def parametrize_with(data: list[tuple[str, bool]]):
-    return pytest.mark.parametrize(
-        "path, is_git_repo", [*data, *with_at_prefix(data), *with_snow_prefix(data)]
-    )
+    return pytest.mark.parametrize("path, is_git_repo", [*data, *with_at_prefix(data)])
 
 
 def build_stage_path(path, is_git_repo):
@@ -126,9 +120,12 @@ def test_dir_with_file_paths(path, is_git_repo):
     assert stage_path.suffix == ".py"
     assert stage_path.stem == "file"
     assert stage_path.stage == path.lstrip("@").replace("snow://", "").split("/")[0]
-    assert stage_path.absolute_path() == "@" + path.lstrip("@").replace(
-        "snow://", ""
-    ).rstrip("/")
+    if path.startswith("snow://"):
+        assert stage_path.absolute_path() == path.rstrip("/")
+    else:
+        assert stage_path.absolute_path() == "@" + path.lstrip("@").replace(
+            "snow://", ""
+        ).rstrip("/")
 
 
 def test_join_path():

--- a/tests/streamlit/test_streamlit_commands.py
+++ b/tests/streamlit/test_streamlit_commands.py
@@ -310,12 +310,10 @@ class TestStreamlitCommands(StreamlitTestClass):
         "project_name", ["example_streamlit", "example_streamlit_v2"]
     )
     @pytest.mark.parametrize("enable_streamlit_versioned_stage", [True, False])
-    @pytest.mark.parametrize("enable_streamlit_no_checkouts", [True, False])
     def test_deploy_streamlit_main_and_pages_files_experimental(
         self,
         os_agnostic_snapshot,
         enable_streamlit_versioned_stage,
-        enable_streamlit_no_checkouts,
         project_name,
         project_directory,
         runner,
@@ -325,10 +323,6 @@ class TestStreamlitCommands(StreamlitTestClass):
             mock.patch(
                 "snowflake.cli.api.feature_flags.FeatureFlag.ENABLE_STREAMLIT_VERSIONED_STAGE.is_enabled",
                 return_value=enable_streamlit_versioned_stage,
-            ),
-            mock.patch(
-                "snowflake.cli.api.feature_flags.FeatureFlag.ENABLE_STREAMLIT_NO_CHECKOUTS.is_enabled",
-                return_value=enable_streamlit_no_checkouts,
             ),
         ):
             with project_directory(project_name) as tmp_dir:
@@ -347,12 +341,9 @@ class TestStreamlitCommands(StreamlitTestClass):
         if enable_streamlit_versioned_stage:
             post_create_command = f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') ADD LIVE VERSION FROM LAST;"
         else:
-            if enable_streamlit_no_checkouts:
-                post_create_command = None
-            else:
-                post_create_command = (
-                    f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') CHECKOUT;"
-                )
+            post_create_command = (
+                f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') CHECKOUT;"
+            )
 
         expected_query = dedent(
             f"""

--- a/tests/streamlit/test_streamlit_commands.py
+++ b/tests/streamlit/test_streamlit_commands.py
@@ -338,12 +338,7 @@ class TestStreamlitCommands(StreamlitTestClass):
                     )
                 result = runner.invoke(["streamlit", "deploy", "--experimental"])
 
-        if enable_streamlit_versioned_stage:
-            post_create_command = f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') ADD LIVE VERSION FROM LAST;"
-        else:
-            post_create_command = (
-                f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') CHECKOUT;"
-            )
+        post_create_command = f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') ADD LIVE VERSION FROM LAST;"
 
         expected_query = dedent(
             f"""
@@ -377,12 +372,7 @@ class TestStreamlitCommands(StreamlitTestClass):
             with project_directory(project_name) as tmp_dir:
                 result = runner.invoke(["streamlit", "deploy", "--experimental"])
 
-        if enable_streamlit_versioned_stage:
-            post_create_command = f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') ADD LIVE VERSION FROM LAST;"
-        else:
-            post_create_command = (
-                f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') CHECKOUT;"
-            )
+        post_create_command = f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') ADD LIVE VERSION FROM LAST;"
 
         expected_query = dedent(
             f"""
@@ -428,9 +418,6 @@ class TestStreamlitCommands(StreamlitTestClass):
         ).strip()
         assert result.exit_code == 0, result.output
         self.mock_execute.assert_any_call(expected_query)
-        self.mock_execute.assert_any_call(
-            f"ALTER STREAMLIT IDENTIFIER('{STREAMLIT_NAME}') CHECKOUT;"
-        )
         self._assert_that_exactly_those_files_were_put_to_stage(
             ["streamlit_app.py", "environment.yml", "pages/my_page.py"],
         )

--- a/tests_integration/snowflake_connector.py
+++ b/tests_integration/snowflake_connector.py
@@ -24,6 +24,7 @@ import pytest
 from snowflake import connector
 from snowflake.cli.api.exceptions import EnvironmentVariableNotFoundError
 from snowflake.cli._app.snow_connector import update_connection_details_with_private_key
+from snowflake.connector import SnowflakeConnection
 
 _ENV_PARAMETER_PREFIX = "SNOWFLAKE_CONNECTIONS_INTEGRATION"
 SCHEMA_ENV_PARAMETER = f"{_ENV_PARAMETER_PREFIX}_SCHEMA"
@@ -88,7 +89,7 @@ def test_role(snowflake_session):
 
 
 @pytest.fixture(scope="session")
-def snowflake_session():
+def snowflake_session() -> SnowflakeConnection:
     config = {
         "application": "INTEGRATION_TEST",
         "authenticator": "SNOWFLAKE_JWT",

--- a/tests_integration/test_streamlit.py
+++ b/tests_integration/test_streamlit.py
@@ -9,9 +9,12 @@ APP_1 = "app_1"
 
 @pytest.mark.integration
 def test_streamlit_flow(
-    _streamlit_test_steps, project_directory, test_database, alter_snowflake_yml
+    _streamlit_test_steps,
+    project_directory,
+    test_database,
+    snowflake_session,
+    alter_snowflake_yml,
 ):
-
     database = test_database.upper()
     with project_directory("streamlit_v2"):
         _streamlit_test_steps.list_streamlit_should_return_empty_list()
@@ -19,11 +22,68 @@ def test_streamlit_flow(
         _streamlit_test_steps.deploy_should_result_in_error_as_there_are_multiple_entities_in_project_file()
 
         _streamlit_test_steps.deploy_with_entity_id_specified_should_succeed(
-            "app_1", database
+            "app_1", snowflake_session
         )
+
         _streamlit_test_steps.assert_that_only_those_files_were_uploaded(
             ["app_1_stage/app_1/app_1.py", "app_1_stage/app_1/streamlit_app.py"],
             f"{database}.public.app_1_stage",
+        )
+        _streamlit_test_steps.assert_that_only_those_entities_are_listed(
+            [f"{database}.PUBLIC.APP_1"], "APP_1"
+        )
+
+        _streamlit_test_steps.another_deploy_without_replace_flag_should_end_with_error(
+            "app_1", database
+        )
+        _streamlit_test_steps.another_deploy_with_replace_flag_should_succeed(
+            "app_1", database
+        )
+
+        _streamlit_test_steps.assert_that_only_those_entities_are_listed(
+            [f"{database}.PUBLIC.APP_1"], "APP_1"
+        )
+
+        _streamlit_test_steps.assert_that_only_those_files_were_uploaded(
+            ["app_1_stage/app_1/app_1.py", "app_1_stage/app_1/streamlit_app.py"],
+            f"{database}.public.app_1_stage",
+        )
+
+        _streamlit_test_steps.streamlit_describe_should_show_proper_streamlit(
+            APP_1, database
+        )
+
+        _streamlit_test_steps.get_url_should_give_proper_url(APP_1, database)
+
+        _streamlit_test_steps.execute_should_run_streamlit(APP_1, database)
+
+        _streamlit_test_steps.drop_should_succeed(APP_1, database)
+
+        _streamlit_test_steps.list_streamlit_should_return_empty_list()
+
+
+@pytest.mark.integration
+def test_streamlit_experimental_flow(
+    _streamlit_test_steps,
+    project_directory,
+    test_database,
+    snowflake_session,
+    alter_snowflake_yml,
+):
+    database = test_database.upper()
+    with project_directory("streamlit_v2"):
+        _streamlit_test_steps.list_streamlit_should_return_empty_list()
+
+        _streamlit_test_steps.deploy_should_result_in_error_as_there_are_multiple_entities_in_project_file()
+
+        _streamlit_test_steps.deploy_with_entity_id_specified_should_succeed(
+            "app_1", snowflake_session, experimental=True
+        )
+
+        stage_root = f"snow://streamlit/{snowflake_session.database}.{snowflake_session.schema}.app_1/versions/live/"
+
+        _streamlit_test_steps.assert_that_only_those_files_were_uploaded(
+            ["app_1.py", "streamlit_app.py"], stage_root, uploaded_to_live_version=True
         )
         _streamlit_test_steps.assert_that_only_those_entities_are_listed(
             [f"{database}.PUBLIC.APP_1"], "APP_1"

--- a/tests_integration/test_streamlit.py
+++ b/tests_integration/test_streamlit.py
@@ -34,10 +34,10 @@ def test_streamlit_flow(
         )
 
         _streamlit_test_steps.another_deploy_without_replace_flag_should_end_with_error(
-            "app_1", database
+            "app_1", snowflake_session
         )
         _streamlit_test_steps.another_deploy_with_replace_flag_should_succeed(
-            "app_1", database
+            "app_1", snowflake_session
         )
 
         _streamlit_test_steps.assert_that_only_those_entities_are_listed(
@@ -50,14 +50,14 @@ def test_streamlit_flow(
         )
 
         _streamlit_test_steps.streamlit_describe_should_show_proper_streamlit(
-            APP_1, database
+            APP_1, snowflake_session
         )
 
-        _streamlit_test_steps.get_url_should_give_proper_url(APP_1, database)
+        _streamlit_test_steps.get_url_should_give_proper_url(APP_1, snowflake_session)
 
-        _streamlit_test_steps.execute_should_run_streamlit(APP_1, database)
+        _streamlit_test_steps.execute_should_run_streamlit(APP_1, snowflake_session)
 
-        _streamlit_test_steps.drop_should_succeed(APP_1, database)
+        _streamlit_test_steps.drop_should_succeed(APP_1, snowflake_session)
 
         _streamlit_test_steps.list_streamlit_should_return_empty_list()
 
@@ -90,10 +90,10 @@ def test_streamlit_experimental_flow(
         )
 
         _streamlit_test_steps.another_deploy_without_replace_flag_should_end_with_error(
-            "app_1", database
+            "app_1", snowflake_session
         )
         _streamlit_test_steps.another_deploy_with_replace_flag_should_succeed(
-            "app_1", database
+            "app_1", snowflake_session, experimental=True
         )
 
         _streamlit_test_steps.assert_that_only_those_entities_are_listed(
@@ -101,19 +101,18 @@ def test_streamlit_experimental_flow(
         )
 
         _streamlit_test_steps.assert_that_only_those_files_were_uploaded(
-            ["app_1_stage/app_1/app_1.py", "app_1_stage/app_1/streamlit_app.py"],
-            f"{database}.public.app_1_stage",
+            ["app_1.py", "streamlit_app.py"], stage_root, uploaded_to_live_version=True
         )
 
         _streamlit_test_steps.streamlit_describe_should_show_proper_streamlit(
-            APP_1, database
+            APP_1, snowflake_session
         )
 
-        _streamlit_test_steps.get_url_should_give_proper_url(APP_1, database)
+        _streamlit_test_steps.get_url_should_give_proper_url(APP_1, snowflake_session)
 
-        _streamlit_test_steps.execute_should_run_streamlit(APP_1, database)
+        _streamlit_test_steps.execute_should_run_streamlit(APP_1, snowflake_session)
 
-        _streamlit_test_steps.drop_should_succeed(APP_1, database)
+        _streamlit_test_steps.drop_should_succeed(APP_1, snowflake_session)
 
         _streamlit_test_steps.list_streamlit_should_return_empty_list()
 

--- a/tests_integration/testing_utils/snowpark_utils.py
+++ b/tests_integration/testing_utils/snowpark_utils.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple, Optional
 from zipfile import ZipFile
 
+from snowflake.cli._plugins.stage.manager import StageManager
 from syrupy import SnapshotAssertion
 
 from snowflake.cli.api.feature_flags import FeatureFlag
@@ -63,7 +64,8 @@ class FlowTestSetup:
     def query_files_uploaded_in_this_test_case(
         self, stage_name: str
     ) -> List[Dict[str, Any]]:
-        return self.sql_test_helper.execute_single_sql(f"LIST @{stage_name}")
+        stage_string = StageManager().build_path(stage_name)
+        return self.sql_test_helper.execute_single_sql(f"LIST {stage_string}")
 
 
 class SnowparkTestSteps:


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
https://snowflakecomputing.atlassian.net/browse/SNOW-2131951
https://snowflakecomputing.atlassian.net/browse/SNOW-2134871
https://snowflakecomputing.atlassian.net/browse/SNOW-2059362
https://snowflakecomputing.atlassian.net/browse/SNOW-2028404
https://snowflakecomputing.atlassian.net/browse/SNOW-2170527

Question for reviewers - do we know about any other use of `snow://` that might not be covered by those changes?

Next in line: changing the behaviour of streamlits - what now is the default way to deploy will become the legacy way. And nowadays expermiental will become the new default