### PR TITLE
Fix failing integ tests due to release channels enabled by default

### DIFF
--- a/tests_integration/nativeapp/test_init_run.py
+++ b/tests_integration/nativeapp/test_init_run.py
@@ -530,11 +530,7 @@ def test_nativeapp_force_cross_upgrade(
 
         # Set default release directive
         result = runner.invoke_with_connection(
-            [
-                "sql",
-                "-q",
-                f"alter application package {pkg_name} set default release directive version = v1 patch = 0",
-            ]
+            ["app", "publish", "--version", "v1", "--patch", "0"]
         )
         assert result.exit_code == 0
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
Fix failing integ tests due to release channels enabled by default

`snow app publish` should handle both cases (enabled/disabled)