### PR TITLE
Snow 2148566 fix flaky spcs tests

### DIFF
--- a/tests_integration/tests_using_container_services/spcs/test_registry.py
+++ b/tests_integration/tests_using_container_services/spcs/test_registry.py
@@ -40,11 +40,13 @@ def test_get_registry_url(test_database, test_role, runner, snowflake_session):
     snowflake_session.execute_string(f"create image repository {test_repo}")
 
     # Commented due to different behaviour between prod and qa
-    # fail_result = runner.invoke_with_connection(
-    #     ["spcs", "image-registry", "url", "--role", test_role]
-    # )
-    # assert fail_result.exit_code == 1, fail_result.output
-    # assert "No image repository found." in fail_result.output
+    fail_result = runner.invoke_with_connection(
+        ["spcs", "image-registry", "url", "--role", test_role]
+    )
+    print(">>> result <<<")
+    print(fail_result.output)
+    assert fail_result.exit_code == 1, fail_result.output
+    assert "No image repository found." in fail_result.output
 
     # role should be able to get registry URL once granted read access to an image repository
     repo_list_cursor = snowflake_session.execute_string("show image repositories")
@@ -65,7 +67,6 @@ def test_get_registry_url(test_database, test_role, runner, snowflake_session):
 
 
 @pytest.mark.integration
-@pytest.mark.skip("Possibly flaky test")
 def test_registry_login(runner):
     result = runner.invoke_with_connection_json(["spcs", "image-registry", "login"])
     assert_that_result_is_successful_and_output_json_equals(

--- a/tests_integration/tests_using_container_services/spcs/test_registry.py
+++ b/tests_integration/tests_using_container_services/spcs/test_registry.py
@@ -34,36 +34,19 @@ def test_token(runner):
 
 
 @pytest.mark.integration
-def test_get_registry_url(test_database, test_role, runner, snowflake_session):
-    # newly created test_role should have no access to image repositories and should not be able to get registry URL
+def test_get_registry_url(test_database, runner, snowflake_session):
     test_repo = ObjectNameProvider("test_repo").create_and_get_next_object_name()
     snowflake_session.execute_string(f"create image repository {test_repo}")
 
-    # Commented due to different behaviour between prod and qa
-    fail_result = runner.invoke_with_connection(
-        ["spcs", "image-registry", "url", "--role", test_role]
-    )
-    print(">>> result <<<")
-    print(fail_result.output)
-    assert fail_result.exit_code == 1, fail_result.output
-    assert "No image repository found." in fail_result.output
-
-    # role should be able to get registry URL once granted read access to an image repository
     repo_list_cursor = snowflake_session.execute_string("show image repositories")
     expected_repo_url = row_from_snowflake_session(repo_list_cursor)[0][
         "repository_url"
     ]
     expected_registry_url = "/".join(expected_repo_url.split("/")[:-3])
-    snowflake_session.execute_string(
-        f"grant usage on database {snowflake_session.database} to role {test_role};"
-        f"grant usage on schema {snowflake_session.schema} to role {test_role};"
-        f"grant read on image repository {test_repo} to role {test_role};"
-    )
-    success_result = runner.invoke_with_connection(
-        ["spcs", "image-registry", "url", "--role", test_role]
-    )
-    assert success_result.exit_code == 0, success_result.output
-    assert success_result.output.strip() == expected_registry_url
+
+    result = runner.invoke_with_connection(["spcs", "image-registry", "url"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == expected_registry_url
 
 
 @pytest.mark.integration

--- a/tests_integration/tests_using_container_services/spcs/test_services.py
+++ b/tests_integration/tests_using_container_services/spcs/test_services.py
@@ -23,8 +23,8 @@ from tests_integration.tests_using_container_services.spcs.testing_utils.spcs_se
 
 
 @pytest.mark.integration
-@pytest.mark.skip("Skipped temporarily")
-def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
+# @pytest.mark.skip("Skipped temporarily")
+def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str], test_database):
 
     test_steps, service_name = _test_steps
 
@@ -50,14 +50,12 @@ def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
     test_steps.list_containers_should_show_containers(service_name)
     test_steps.list_roles_should_show_roles(service_name)
     test_steps.upgrade_service_should_change_spec(service_name)
-    test_steps.metrics_should_include_services_from_both_dbs(
-        service_name, "hello-world"
+    test_steps.metrics_command_should_execute_correctly(service_name, "hello-world")
+    test_steps.metrics_command_should_execute_correctly(
+        service_name, "hello-world", test_steps.database
     )
-    test_steps.metrics_with_fqn_should_include_only_one_service(
-        service_name, test_steps.database, "hello-world"
-    )
-    test_steps.metrics_with_fqn_should_include_only_one_service(
-        service_name, test_steps.another_database, "hello-world"
+    test_steps.metrics_command_should_execute_correctly(
+        service_name, "hello-world", test_steps.another_database
     )
     test_steps.set_unset_service_property(service_name)
     test_steps.drop_service(service_name)
@@ -141,10 +139,10 @@ def _test_setup(
 
 
 @pytest.fixture
-def _test_steps(_test_setup):
+def _test_steps(_test_setup, test_database):
     random_uuid = uuid.uuid4().hex
     service_name = f"spcs_service_{random_uuid}"
-    test_steps = SnowparkServicesTestSteps(_test_setup)
+    test_steps = SnowparkServicesTestSteps(_test_setup, another_database=test_database)
 
     yield test_steps, service_name
 

--- a/tests_integration/tests_using_container_services/spcs/test_services.py
+++ b/tests_integration/tests_using_container_services/spcs/test_services.py
@@ -23,7 +23,6 @@ from tests_integration.tests_using_container_services.spcs.testing_utils.spcs_se
 
 
 @pytest.mark.integration
-# @pytest.mark.skip("Skipped temporarily")
 def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str], test_database):
 
     test_steps, service_name = _test_steps
@@ -109,7 +108,7 @@ def test_service_create_from_project_definition(
 
 
 @pytest.mark.integration
-@pytest.mark.xfail(reason="Consistently timing out on execute call")
+# @pytest.mark.xfail(reason="Consistently timing out on execute call")
 def test_job_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
     test_steps, job_service_name = _test_steps

--- a/tests_integration/tests_using_container_services/spcs/test_services.py
+++ b/tests_integration/tests_using_container_services/spcs/test_services.py
@@ -108,7 +108,6 @@ def test_service_create_from_project_definition(
 
 
 @pytest.mark.integration
-# @pytest.mark.xfail(reason="Consistently timing out on execute call")
 def test_job_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
     test_steps, job_service_name = _test_steps


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
 * [x] test_spcs/test_registry.py::test_registry_login - removed part checking permissions. Context
   * The permissions check is ran on the server
   * The server introduced "secondary roles" since the tests was added, so firing this check would require big changes in integration account setup
   *  "no permissions" case is covered by unit tests
 * [x] test_spcs/test_services.py::test_job_services - unskipped. The test seem to be working in lower frequency workflow.
 * [x] test_spcs/test_services.py::test_services - removed flaky assertions on `metrics` command, which was failing due to the server lag. The command is covered by unit tests checking generated SQL.
