### PR TITLE
add sleep before checking async query results

### DIFF
--- a/tests_integration/sql/test_async_queries.py
+++ b/tests_integration/sql/test_async_queries.py
@@ -1,4 +1,5 @@
 import pytest
+from time import sleep
 
 
 class TableForTesting:
@@ -15,6 +16,9 @@ class TableForTesting:
         return f"INSERT INTO {self.name} VALUES ('{value}')"
 
     def get_contents(self):
+        # as very rarely the result of the last async query is not yet visible in the test result,
+        # we wait short amount of time to avoid false-negative test results
+        sleep(0.1)
         result = self.runner.invoke_with_connection_json(
             ["sql", "-q", f"SELECT {self.col} FROM {self.name}"]
         )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description
Wait short amount of time before checking async query results to avoid false-negative test results.
Reason: very rarely the result of the last async call is missing.