### PR TITLE
SNOW-2118790: Adding new scripts for dynamic mac certification loading within Jenkins building Job

### DIFF
--- a/scripts/packaging/delete_mac_certs.sh
+++ b/scripts/packaging/delete_mac_certs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e -x
+
+# Set the Keychain path where the certificates will be imported
+KEYCHAIN_PATH=$HOME/Library/Keychains/login.keychain-db
+
+# Delete the Developer ID Installer certificate from the keychain
+security delete-certificate -c "Developer ID Installer: Snowflake Computing INC. (W4NT6CRQ7U)" "$KEYCHAIN_PATH"
+
+# Delete the Developer ID Application certificate from the keychain
+security delete-certificate -c "Developer ID Application: Snowflake Computing INC. (W4NT6CRQ7U)" "$KEYCHAIN_PATH"
+
+# Inform the user about the successful cleanup
+echo "Temporary files cleaned up successfully"

--- a/scripts/packaging/load_mac_certs.sh
+++ b/scripts/packaging/load_mac_certs.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e -x
+
+# Set the path to the temporary files for the certificates
+APPLE_CERT_DEVELOPER_INSTALLER="apple_dev_installer_cert.p12"
+APPLE_CERT_DEVELOPER_APPLICATION="apple_dev_application_cert.p12"
+
+# Decode Developer ID Installer certificate from base64 into temporary file
+base64 -d $APPLE_CERT_DEVELOPER_INSTALLER_BASE64 > $APPLE_CERT_DEVELOPER_INSTALLER
+
+# Check the checksum of the decoded Developer ID Installer certificate
+echo "1f9d2dfd1a6dc87c87fe0426a6ee136e $APPLE_CERT_DEVELOPER_INSTALLER" | md5sum -c -
+
+# Decode Developer ID Application certificate from base64 into temporary file
+base64 -d $APPLE_CERT_DEVELOPER_APPLICATION_BASE64 > $APPLE_CERT_DEVELOPER_APPLICATION
+
+# Check the checksum of the decoded Developer ID Application certificate
+echo "658613e0abe5c3187284e9662f18e1f0 $APPLE_CERT_DEVELOPER_APPLICATION" | md5sum -c -
+
+# Set the Keychain path where the certificates will be imported
+KEYCHAIN_PATH=$HOME/Library/Keychains/login.keychain-db
+
+# Unlock the keychain using the provided password
+security unlock-keychain -p $MAC_USERNAME_PASSWORD $KEYCHAIN_PATH
+
+# Import Developer ID Installer certificate to the keychain
+security import $APPLE_CERT_DEVELOPER_INSTALLER -k $KEYCHAIN_PATH -P $APPLE_CERT_DEVELOPER_INSTALLER_PASSWORD -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcrun -T /usr/bin/productsign -T /usr/bin/productbuild
+
+# Check if the import was successful
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to import installer certificate"
+    exit 1
+fi
+
+# Import Developer ID Installer certificate to the keychain
+security import $APPLE_CERT_DEVELOPER_APPLICATION -k $KEYCHAIN_PATH -P $APPLE_CERT_DEVELOPER_APPLICATION_PASSWORD -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcrun -T /usr/bin/productsign -T /usr/bin/productbuild
+
+# Check if the import was successful
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to import application certificate"
+    exit 1
+fi
+
+# Inform the user about the successful import
+echo "Certificates imported successfully to $KEYCHAIN_PATH"
+
+# Clean up the temporary files
+rm -f $APPLE_CERT_DEVELOPER_INSTALLER
+rm -f $APPLE_CERT_DEVELOPER_APPLICATION
+
+# Inform the user about the successful cleanup
+echo "Temporary files cleaned up successfully"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
The changes are not touching any code so the above checks are not applicable. The change is only to enable dynamic loading of the mac certs so these are more secure and not always enabled on the node, but only for the signing.
