### PR TITLE
SNOW-2210870 Proper `is_dir` and `is_file` implementations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## Fixes and improvements
 * Fixed DBT deploy command to properly handle fully qualified names
+* Fixed DBT deploy command to properly handle directories with dots in names
 
 
 # v3.10.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@
 
 ## Fixes and improvements
 * Fixed DBT deploy command to properly handle fully qualified names
-* Fixed DBT deploy command to properly handle directories with dots in names
+* Fixed DBT deploy command to properly handle local directories with dots in names
 
 
 # v3.10.0

--- a/src/snowflake/cli/api/stage_path.py
+++ b/src/snowflake/cli/api/stage_path.py
@@ -220,10 +220,14 @@ class StagePath:
         return self._path.name
 
     def is_dir(self) -> bool:
-        return Path(self._path).is_dir()
+        if Path(self.path).exists():
+            return Path(self.path).exists()
+        return "." not in self.name
 
     def is_file(self) -> bool:
-        return Path(self._path).is_file()
+        if Path(self.path).exists():
+            return Path(self.path).is_file()
+        return not self.is_dir()
 
     @property
     def suffix(self) -> str:

--- a/src/snowflake/cli/api/stage_path.py
+++ b/src/snowflake/cli/api/stage_path.py
@@ -220,10 +220,10 @@ class StagePath:
         return self._path.name
 
     def is_dir(self) -> bool:
-        return "." not in self.name
+        return Path(self._path).is_dir()
 
     def is_file(self) -> bool:
-        return not self.is_dir()
+        return Path(self._path).is_file()
 
     @property
     def suffix(self) -> str:

--- a/tests/stage/test_stage_path.py
+++ b/tests/stage/test_stage_path.py
@@ -602,10 +602,12 @@ def test_vstage_path_parts_invalid_paths(invalid_path):
         VStagePathParts(invalid_path)
 
 
-def test_dir_with_dot_are_identified_as_dir_not_file():
+def test_local_dir_with_dot_are_identified_as_dir_not_file():
     with tempfile.TemporaryDirectory(suffix="dot.in.name") as dir_path:
         assert "." in dir_path
-        stage_path = StagePath(dir_path)
+        assert Path(dir_path).exists()
+        assert Path(dir_path).is_dir()
+        stage_path = StagePath("stageName", dir_path)
 
         assert stage_path.is_dir()
         assert not stage_path.is_file()

--- a/tests/stage/test_stage_path.py
+++ b/tests/stage/test_stage_path.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -599,3 +600,12 @@ def test_vstage_path_parts_properties(
 def test_vstage_path_parts_invalid_paths(invalid_path):
     with pytest.raises(CliError, match="Invalid vstage path"):
         VStagePathParts(invalid_path)
+
+
+def test_dir_with_dot_are_identified_as_dir_not_file():
+    with tempfile.TemporaryDirectory(suffix="dot.in.name") as dir_path:
+        assert "." in dir_path
+        stage_path = StagePath(dir_path)
+
+        assert stage_path.is_dir()
+        assert not stage_path.is_file()


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
SNOW-2210870 Proper `is_dir` and `is_file` implementations - use `is_file` and `is_dir` from `Path` 