### PR TITLE
SNOW-2229492 and SNOW-2229493 - cleanup versions in DCM

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -68,6 +68,22 @@ configuration_flag = typer.Option(
 from_option = OverrideableOption(
     None,
     "--from",
+    mutually_exclusive=["prune"],
+    show_default=False,
+)
+
+prune_option = OverrideableOption(
+    False,
+    "--prune",
+    help="Remove unused artifacts from the stage during sync. Mutually exclusive with --from.",
+    mutually_exclusive=["from_stage"],
+    show_default=False,
+)
+
+alias_option = typer.Option(
+    None,
+    "--alias",
+    help="Alias for the deployment.",
     show_default=False,
 )
 
@@ -92,26 +108,13 @@ def deploy(
     ),
     variables: Optional[List[str]] = variables_flag,
     configuration: Optional[str] = configuration_flag,
-    alias: Optional[str] = typer.Option(
-        None,
-        "--alias",
-        help="Alias for the deployment.",
-        show_default=False,
-    ),
-    prune: bool = typer.Option(
-        False,
-        "--prune",
-        help="Remove unused artifacts from the stage during sync. Mutually exclusive with --from.",
-        show_default=False,
-    ),
+    alias: Optional[str] = alias_option,
+    prune: bool = prune_option(),
     **options,
 ):
     """
     Applies changes defined in DCM Project to Snowflake.
     """
-    if prune and from_stage:
-        raise UsageError("--prune and --from are mutually exclusive.")
-
     effective_from_stage = from_stage if from_stage else _sync_local_files(prune=prune)
     if not effective_from_stage:
         raise CliError(
@@ -136,20 +139,12 @@ def plan(
     ),
     variables: Optional[List[str]] = variables_flag,
     configuration: Optional[str] = configuration_flag,
-    prune: bool = typer.Option(
-        False,
-        "--prune",
-        help="Remove unused artifacts from the stage during sync. Mutually exclusive with --from.",
-        show_default=False,
-    ),
+    prune: bool = prune_option(),
     **options,
 ):
     """
     Plans a DCM Project deployment (validates without executing).
     """
-    if prune and from_stage:
-        raise UsageError("--prune and --from are mutually exclusive.")
-
     effective_from_stage = from_stage if from_stage else _sync_local_files(prune=prune)
     if not effective_from_stage:
         raise CliError(

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -92,6 +92,12 @@ def deploy(
     ),
     variables: Optional[List[str]] = variables_flag,
     configuration: Optional[str] = configuration_flag,
+    alias: Optional[str] = typer.Option(
+        None,
+        "--alias",
+        help="Alias for the deployment.",
+        show_default=False,
+    ),
     **options,
 ):
     """
@@ -108,6 +114,7 @@ def deploy(
         configuration=configuration,
         from_stage=effective_from_stage,
         variables=variables,
+        alias=alias,
     )
     return QueryJsonValueResult(result)
 

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -28,7 +28,6 @@ from snowflake.cli.api.commands.flags import (
     IfExistsOption,
     IfNotExistsOption,
     OverrideableOption,
-    PruneOption,
     entity_argument,
     identifier_argument,
     like_option,
@@ -154,7 +153,6 @@ def create(
 ):
     """
     Creates a DCM Project in Snowflake.
-    The DCM Project is initialized with a new version created from local files.
     """
     cli_context = get_cli_context()
     project: DCMProjectEntityModel = get_entity_for_operation(
@@ -175,58 +173,9 @@ def create(
 
     dpm = DCMProjectManager()
     with cli_console.phase(f"Creating DCM Project '{project.fqn}'"):
-        dpm.create(project=project, initialize_version_from_local_files=True)
+        dpm.create(project=project)
 
-    return MessageResult(
-        f"DCM Project '{project.fqn}' successfully created and initial version is added."
-    )
-
-
-@app.command(requires_connection=True)
-@with_project_definition()
-def add_version(
-    entity_id: str = entity_argument("dcm"),
-    _from: Optional[str] = from_option(
-        help="Create a new version using given stage instead of uploading local files."
-    ),
-    _alias: Optional[str] = typer.Option(
-        None, "--alias", help="Alias for the version.", show_default=False
-    ),
-    comment: Optional[str] = typer.Option(
-        None, "--comment", help="Version comment.", show_default=False
-    ),
-    prune: bool = PruneOption(default=True),
-    **options,
-):
-    """Uploads local files to Snowflake and cerates a new DCM Project version."""
-    if _from is not None and prune:
-        cli_console.warning(
-            "When `--from` option is used, `--prune` option will be ignored and files from stage will be used as they are."
-        )
-        prune = False
-    cli_context = get_cli_context()
-    project: DCMProjectEntityModel = get_entity_for_operation(
-        cli_context=cli_context,
-        entity_id=entity_id,
-        project_definition=cli_context.project_definition,
-        entity_type="dcm",
-    )
-    om = ObjectManager()
-    if not om.object_exists(object_type="dcm", fqn=project.fqn):
-        raise CliError(
-            f"DCM Project '{project.fqn}' does not exist. Use `dcm create` command first."
-        )
-    DCMProjectManager().add_version(
-        project=project,
-        prune=prune,
-        from_stage=_from,
-        alias=_alias,
-        comment=comment,
-    )
-    alias_str = "" if _alias is None else f"'{_alias}' "
-    return MessageResult(
-        f"New version {alias_str}added to DCM Project '{project.fqn}'."
-    )
+    return MessageResult(f"DCM Project '{project.fqn}' successfully created.")
 
 
 @app.command(requires_connection=True)

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -203,12 +203,12 @@ def create(
 
 
 @app.command(requires_connection=True)
-def list_versions(
+def list_deployments(
     identifier: FQN = dcm_identifier,
     **options,
 ):
     """
-    Lists versions of given DCM Project.
+    Lists deployments of given DCM Project.
     """
     pm = DCMProjectManager()
     results = pm.list_versions(project_name=identifier)

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -147,11 +147,6 @@ def plan(
 @with_project_definition()
 def create(
     entity_id: str = entity_argument("dcm"),
-    no_version: bool = typer.Option(
-        False,
-        "--no-version",
-        help="Do not initialize DCM Project with a new version, only create the snowflake object.",
-    ),
     if_not_exists: bool = IfNotExistsOption(
         help="Do nothing if the project already exists."
     ),
@@ -159,7 +154,7 @@ def create(
 ):
     """
     Creates a DCM Project in Snowflake.
-    By default, the DCM Project is initialized with a new version created from local files.
+    The DCM Project is initialized with a new version created from local files.
     """
     cli_context = get_cli_context()
     project: DCMProjectEntityModel = get_entity_for_operation(
@@ -175,17 +170,13 @@ def create(
             return MessageResult(message)
         raise CliError(message)
 
-    if not no_version and om.object_exists(
-        object_type="stage", fqn=FQN.from_stage(project.stage)
-    ):
+    if om.object_exists(object_type="stage", fqn=FQN.from_stage(project.stage)):
         raise CliError(f"Stage '{project.stage}' already exists.")
 
     dpm = DCMProjectManager()
     with cli_console.phase(f"Creating DCM Project '{project.fqn}'"):
-        dpm.create(project=project, initialize_version_from_local_files=not no_version)
+        dpm.create(project=project, initialize_version_from_local_files=True)
 
-    if no_version:
-        return MessageResult(f"DCM Project '{project.fqn}' successfully created.")
     return MessageResult(
         f"DCM Project '{project.fqn}' successfully created and initial version is added."
     )

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from textwrap import dedent
+
 from typing import List
 
 from snowflake.cli._plugins.dcm.dcm_project_entity_model import DCMProjectEntityModel
@@ -53,7 +53,7 @@ class DCMProjectManager(SqlExecutionMixin):
         return self.execute_query(query=query)
 
     def create(self, project: DCMProjectEntityModel) -> None:
-        query = dedent(f"CREATE DCM PROJECT {project.fqn.sql_identifier}")
+        query = f"CREATE DCM PROJECT {project.fqn.sql_identifier}"
         self.execute_query(query)
 
     def _create_version(

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -61,12 +61,8 @@ class DCMProjectManager(SqlExecutionMixin):
         query = dedent(f"CREATE DCM PROJECT {project_name.sql_identifier}")
         return self.execute_query(query)
 
-    def create(
-        self, project: DCMProjectEntityModel, initialize_version_from_local_files: bool
-    ) -> None:
+    def create(self, project: DCMProjectEntityModel) -> None:
         self._create_object(project.fqn)
-        if initialize_version_from_local_files:
-            self.add_version(project=project)
 
     def _create_version(
         self,

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -12,31 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from textwrap import dedent
-from typing import List, Optional
+from typing import List
 
 from snowflake.cli._plugins.dcm.dcm_project_entity_model import DCMProjectEntityModel
 from snowflake.cli._plugins.stage.manager import StageManager
-from snowflake.cli.api.artifacts.upload import sync_artifacts_with_stage
-from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.utils import parse_key_value_variables
-from snowflake.cli.api.console.console import cli_console
 from snowflake.cli.api.identifiers import FQN
-from snowflake.cli.api.project.project_paths import ProjectPaths
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.stage_path import StagePath
-from snowflake.connector.cursor import SnowflakeCursor
 
 
 class DCMProjectManager(SqlExecutionMixin):
     def execute(
         self,
         project_name: FQN,
+        from_stage: str,
         configuration: str | None = None,
-        version: str | None = None,
-        from_stage: str | None = None,
         variables: List[str] | None = None,
         dry_run: bool = False,
     ):
+
         query = f"EXECUTE DCM PROJECT {project_name.sql_identifier}"
         if dry_run:
             query += " PLAN"
@@ -50,19 +45,13 @@ class DCMProjectManager(SqlExecutionMixin):
             query += StageManager.parse_execute_variables(
                 parse_key_value_variables(variables)
             ).removeprefix(" using")
-        if version:
-            query += f" WITH VERSION {version}"
-        elif from_stage:
-            stage_path = StagePath.from_stage_str(from_stage)
-            query += f" FROM {stage_path.absolute_path()}"
+        stage_path = StagePath.from_stage_str(from_stage)
+        query += f" FROM {stage_path.absolute_path()}"
         return self.execute_query(query=query)
 
-    def _create_object(self, project_name: FQN) -> SnowflakeCursor:
-        query = dedent(f"CREATE DCM PROJECT {project_name.sql_identifier}")
-        return self.execute_query(query)
-
     def create(self, project: DCMProjectEntityModel) -> None:
-        self._create_object(project.fqn)
+        query = dedent(f"CREATE DCM PROJECT {project.fqn.sql_identifier}")
+        self.execute_query(query)
 
     def _create_version(
         self,
@@ -79,38 +68,6 @@ class DCMProjectManager(SqlExecutionMixin):
         if comment:
             query += f" COMMENT = '{comment}'"
         return self.execute_query(query=query)
-
-    def add_version(
-        self,
-        project: DCMProjectEntityModel,
-        prune: bool = False,
-        from_stage: Optional[str] = None,
-        alias: Optional[str] = None,
-        comment: Optional[str] = None,
-    ):
-        """
-        Adds a version to DCM Project. If [from_stage] is not defined,
-        uploads local files to the stage defined in DCM Project definition.
-        """
-
-        if not from_stage:
-            cli_context = get_cli_context()
-            from_stage = project.stage
-            with cli_console.phase("Uploading artifacts"):
-                sync_artifacts_with_stage(
-                    project_paths=ProjectPaths(project_root=cli_context.project_root),
-                    stage_root=from_stage,
-                    artifacts=project.artifacts,
-                    prune=prune,
-                )
-
-        with cli_console.phase(f"Creating DCM Project version from stage {from_stage}"):
-            return self._create_version(
-                project_name=project.fqn,
-                from_stage=from_stage,  # type:ignore
-                alias=alias,
-                comment=comment,
-            )
 
     def list_versions(self, project_name: FQN):
         query = f"SHOW VERSIONS IN DCM PROJECT {project_name.identifier}"

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -30,6 +30,7 @@ class DCMProjectManager(SqlExecutionMixin):
         configuration: str | None = None,
         variables: List[str] | None = None,
         dry_run: bool = False,
+        alias: str | None = None,
     ):
 
         query = f"EXECUTE DCM PROJECT {project_name.sql_identifier}"
@@ -37,6 +38,8 @@ class DCMProjectManager(SqlExecutionMixin):
             query += " PLAN"
         else:
             query += " DEPLOY"
+            if alias:
+                query += f" AS {alias}"
         if configuration or variables:
             query += f" USING"
         if configuration:

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7194,8 +7194,8 @@
                                                                                   
    Usage: root dcm create [OPTIONS] [ENTITY_ID]                                   
                                                                                   
-   Creates a DCM Project in Snowflake. By default, the DCM Project is initialized 
-   with a new version created from local files.                                   
+   Creates a DCM Project in Snowflake. The DCM Project is initialized with a new  
+   version created from local files.                                              
                                                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
@@ -7203,8 +7203,6 @@
   |                               [default: None]                                |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --no-version                   Do not initialize DCM Project with a new      |
-  |                                version, only create the snowflake object.    |
   | --if-not-exists                Do nothing if the project already exists.     |
   | --project        -p      TEXT  Path where the Snowflake project is stored.   |
   |                                Defaults to the current working directory.    |
@@ -8279,9 +8277,8 @@
   +- Commands -------------------------------------------------------------------+
   | add-version     Uploads local files to Snowflake and cerates a new DCM       |
   |                 Project version.                                             |
-  | create          Creates a DCM Project in Snowflake. By default, the DCM      |
-  |                 Project is initialized with a new version created from local |
-  |                 files.                                                       |
+  | create          Creates a DCM Project in Snowflake. The DCM Project is       |
+  |                 initialized with a new version created from local files.     |
   | deploy          Applies changes defined in DCM Project to Snowflake.         |
   | describe        Provides description of DCM Project.                         |
   | drop            Drops DCM Project with given name.                           |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7714,12 +7714,12 @@
   
   '''
 # ---
-# name: test_help_messages[dcm.list-versions]
+# name: test_help_messages[dcm.list-deployments]
   '''
                                                                                   
-   Usage: root dcm list-versions [OPTIONS] IDENTIFIER                             
+   Usage: root dcm list-deployments [OPTIONS] IDENTIFIER                          
                                                                                   
-   Lists versions of given DCM Project.                                           
+   Lists deployments of given DCM Project.                                        
                                                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
@@ -8129,15 +8129,15 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | create          Creates a DCM Project in Snowflake.                          |
-  | deploy          Applies changes defined in DCM Project to Snowflake.         |
-  | describe        Provides description of DCM Project.                         |
-  | drop            Drops DCM Project with given name.                           |
-  | drop-version    Drops a version from the DCM Project.                        |
-  | list            Lists all available DCM Projects.                            |
-  | list-versions   Lists versions of given DCM Project.                         |
-  | plan            Plans a DCM Project deployment (validates without            |
-  |                 executing).                                                  |
+  | create             Creates a DCM Project in Snowflake.                       |
+  | deploy             Applies changes defined in DCM Project to Snowflake.      |
+  | describe           Provides description of DCM Project.                      |
+  | drop               Drops DCM Project with given name.                        |
+  | drop-version       Drops a version from the DCM Project.                     |
+  | list               Lists all available DCM Projects.                         |
+  | list-deployments   Lists deployments of given DCM Project.                   |
+  | plan               Plans a DCM Project deployment (validates without         |
+  |                    executing).                                               |
   +------------------------------------------------------------------------------+
   
   
@@ -20776,15 +20776,15 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | create          Creates a DCM Project in Snowflake.                          |
-  | deploy          Applies changes defined in DCM Project to Snowflake.         |
-  | describe        Provides description of DCM Project.                         |
-  | drop            Drops DCM Project with given name.                           |
-  | drop-version    Drops a version from the DCM Project.                        |
-  | list            Lists all available DCM Projects.                            |
-  | list-versions   Lists versions of given DCM Project.                         |
-  | plan            Plans a DCM Project deployment (validates without            |
-  |                 executing).                                                  |
+  | create             Creates a DCM Project in Snowflake.                       |
+  | deploy             Applies changes defined in DCM Project to Snowflake.      |
+  | describe           Provides description of DCM Project.                      |
+  | drop               Drops DCM Project with given name.                        |
+  | drop-version       Drops a version from the DCM Project.                     |
+  | list               Lists all available DCM Projects.                         |
+  | list-deployments   Lists deployments of given DCM Project.                   |
+  | plan               Plans a DCM Project deployment (validates without         |
+  |                    executing).                                               |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7047,155 +7047,12 @@
   
   '''
 # ---
-# name: test_help_messages[dcm.add-version]
-  '''
-                                                                                  
-   Usage: root dcm add-version [OPTIONS] [ENTITY_ID]                              
-                                                                                  
-   Uploads local files to Snowflake and cerates a new DCM Project version.        
-                                                                                  
-                                                                                  
-  +- Arguments ------------------------------------------------------------------+
-  |   entity_id      [ENTITY_ID]  ID of dcm entity.                              |
-  |                               [default: None]                                |
-  +------------------------------------------------------------------------------+
-  +- Options --------------------------------------------------------------------+
-  | --from                       TEXT  Create a new version using given stage    |
-  |                                    instead of uploading local files.         |
-  | --alias                      TEXT  Alias for the version.                    |
-  | --comment                    TEXT  Version comment.                          |
-  | --prune        --no-prune          Delete files that exist in the stage, but |
-  |                                    not in the local filesystem.              |
-  |                                    [default: prune]                          |
-  | --project  -p                TEXT  Path where the Snowflake project is       |
-  |                                    stored. Defaults to the current working   |
-  |                                    directory.                                |
-  | --env                        TEXT  String in the format key=value. Overrides |
-  |                                    variables from the env section used for   |
-  |                                    templates.                                |
-  | --help     -h                      Show this message and exit.               |
-  +------------------------------------------------------------------------------+
-  +- Connection configuration ---------------------------------------------------+
-  | --connection,--environment    -c      TEXT     Name of the connection, as    |
-  |                                                defined in your config.toml   |
-  |                                                file. Default: default.       |
-  | --host                                TEXT     Host address for the          |
-  |                                                connection. Overrides the     |
-  |                                                value specified for the       |
-  |                                                connection.                   |
-  | --port                                INTEGER  Port for the connection.      |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
-  | --account,--accountname               TEXT     Name assigned to your         |
-  |                                                Snowflake account. Overrides  |
-  |                                                the value specified for the   |
-  |                                                connection.                   |
-  | --user,--username                     TEXT     Username to connect to        |
-  |                                                Snowflake. Overrides the      |
-  |                                                value specified for the       |
-  |                                                connection.                   |
-  | --password                            TEXT     Snowflake password. Overrides |
-  |                                                the value specified for the   |
-  |                                                connection.                   |
-  | --authenticator                       TEXT     Snowflake authenticator.      |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
-  | --private-key-file,--privat…          TEXT     Snowflake private key file    |
-  |                                                path. Overrides the value     |
-  |                                                specified for the connection. |
-  | --token                               TEXT     OAuth token to use when       |
-  |                                                connecting to Snowflake.      |
-  | --token-file-path                     TEXT     Path to file with an OAuth    |
-  |                                                token to use when connecting  |
-  |                                                to Snowflake.                 |
-  | --database,--dbname                   TEXT     Database to use. Overrides    |
-  |                                                the value specified for the   |
-  |                                                connection.                   |
-  | --schema,--schemaname                 TEXT     Database schema to use.       |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
-  | --role,--rolename                     TEXT     Role to use. Overrides the    |
-  |                                                value specified for the       |
-  |                                                connection.                   |
-  | --warehouse                           TEXT     Warehouse to use. Overrides   |
-  |                                                the value specified for the   |
-  |                                                connection.                   |
-  | --temporary-connection        -x               Uses a connection defined     |
-  |                                                with command line parameters, |
-  |                                                instead of one defined in     |
-  |                                                config                        |
-  | --mfa-passcode                        TEXT     Token to use for multi-factor |
-  |                                                authentication (MFA)          |
-  | --enable-diag                                  Whether to generate a         |
-  |                                                connection diagnostic report. |
-  | --diag-log-path                       TEXT     Path for the generated        |
-  |                                                report. Defaults to system    |
-  |                                                temporary directory.          |
-  | --diag-allowlist-path                 TEXT     Path to a JSON file that      |
-  |                                                contains allowlist            |
-  |                                                parameters.                   |
-  | --oauth-client-id                     TEXT     Value of client id provided   |
-  |                                                by the Identity Provider for  |
-  |                                                Snowflake integration.        |
-  | --oauth-client-secret                 TEXT     Value of the client secret    |
-  |                                                provided by the Identity      |
-  |                                                Provider for Snowflake        |
-  |                                                integration.                  |
-  | --oauth-authorization-url             TEXT     Identity Provider endpoint    |
-  |                                                supplying the authorization   |
-  |                                                code to the driver.           |
-  | --oauth-token-request-url             TEXT     Identity Provider endpoint    |
-  |                                                supplying the access tokens   |
-  |                                                to the driver.                |
-  | --oauth-redirect-uri                  TEXT     URI to use for authorization  |
-  |                                                code redirection.             |
-  | --oauth-scope                         TEXT     Scope requested in the        |
-  |                                                Identity Provider             |
-  |                                                authorization request.        |
-  | --oauth-disable-pkce                           Disables Proof Key for Code   |
-  |                                                Exchange (PKCE). Default:     |
-  |                                                False.                        |
-  | --oauth-enable-refresh-toke…                   Enables a silent              |
-  |                                                re-authentication when the    |
-  |                                                actual access token becomes   |
-  |                                                outdated. Default: False.     |
-  | --oauth-enable-single-use-r…                   Whether to opt-in to          |
-  |                                                single-use refresh token      |
-  |                                                semantics. Default: False.    |
-  | --client-store-temporary-cr…                   Store the temporary           |
-  |                                                credential.                   |
-  +------------------------------------------------------------------------------+
-  +- Global configuration -------------------------------------------------------+
-  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
-  |                                                       [default: TABLE]       |
-  | --verbose              -v                             Displays log entries   |
-  |                                                       for log levels info    |
-  |                                                       and higher.            |
-  | --debug                                               Displays log entries   |
-  |                                                       for log levels debug   |
-  |                                                       and higher; debug logs |
-  |                                                       contain additional     |
-  |                                                       information.           |
-  | --silent                                              Turns off intermediate |
-  |                                                       output to console.     |
-  | --enhanced-exit-codes                                 Differentiate exit     |
-  |                                                       error codes based on   |
-  |                                                       failure type.          |
-  |                                                       [env var:              |
-  |                                                       SNOWFLAKE_ENHANCED_EX… |
-  +------------------------------------------------------------------------------+
-  
-  
-  '''
-# ---
 # name: test_help_messages[dcm.create]
   '''
                                                                                   
    Usage: root dcm create [OPTIONS] [ENTITY_ID]                                   
                                                                                   
-   Creates a DCM Project in Snowflake. The DCM Project is initialized with a new  
-   version created from local files.                                              
+   Creates a DCM Project in Snowflake.                                            
                                                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
@@ -8275,10 +8132,7 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | add-version     Uploads local files to Snowflake and cerates a new DCM       |
-  |                 Project version.                                             |
-  | create          Creates a DCM Project in Snowflake. The DCM Project is       |
-  |                 initialized with a new version created from local files.     |
+  | create          Creates a DCM Project in Snowflake.                          |
   | deploy          Applies changes defined in DCM Project to Snowflake.         |
   | describe        Provides description of DCM Project.                         |
   | drop            Drops DCM Project with given name.                           |
@@ -20925,11 +20779,7 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | add-version     Uploads local files to Snowflake and cerates a new DCM       |
-  |                 Project version.                                             |
-  | create          Creates a DCM Project in Snowflake. By default, the DCM      |
-  |                 Project is initialized with a new version created from local |
-  |                 files.                                                       |
+  | create          Creates a DCM Project in Snowflake.                          |
   | deploy          Applies changes defined in DCM Project to Snowflake.         |
   | describe        Provides description of DCM Project.                         |
   | drop            Drops DCM Project with given name.                           |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7203,6 +7203,8 @@
   | --configuration          TEXT  Configuration of the DCM Project to use. If   |
   |                                not specified default configuration is used.  |
   | --alias                  TEXT  Alias for the deployment.                     |
+  | --prune                        Remove unused artifacts from the stage during |
+  |                                sync. Mutually exclusive with --from.         |
   | --help           -h            Show this message and exit.                   |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
@@ -7997,6 +7999,8 @@
   |                                example: -D "<key>=<value>".                  |
   | --configuration          TEXT  Configuration of the DCM Project to use. If   |
   |                                not specified default configuration is used.  |
+  | --prune                        Remove unused artifacts from the stage during |
+  |                                sync. Mutually exclusive with --from.         |
   | --help           -h            Show this message and exit.                   |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7202,6 +7202,7 @@
   |                                example: -D "<key>=<value>".                  |
   | --configuration          TEXT  Configuration of the DCM Project to use. If   |
   |                                not specified default configuration is used.  |
+  | --alias                  TEXT  Alias for the deployment.                     |
   | --help           -h            Show this message and exit.                   |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7196,12 +7196,8 @@
   |                            [required]                                        |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --version                TEXT  Version of the DCM Project to use. If not     |
-  |                                specified default version is used. For names  |
-  |                                containing '$', use single quotes to prevent  |
-  |                                shell expansion (e.g., 'VERSION$1').          |
-  | --from                   TEXT  Apply changes defined in given stage instead  |
-  |                                of using a specific project version.          |
+  | --from                   TEXT  Deploy DCM Project deployment from a given    |
+  |                                stage.                                        |
   | --variable       -D      TEXT  Variables for the execution context; for      |
   |                                example: -D "<key>=<value>".                  |
   | --configuration          TEXT  Configuration of the DCM Project to use. If   |
@@ -7994,12 +7990,8 @@
   |                            [required]                                        |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --version                TEXT  Version of the DCM Project to use. If not     |
-  |                                specified default version is used. For names  |
-  |                                containing '$', use single quotes to prevent  |
-  |                                shell expansion (e.g., 'VERSION$1').          |
-  | --from                   TEXT  Plan DCM Project deployment from given stage  |
-  |                                instead of using a specific version.          |
+  | --from                   TEXT  Plan DCM Project deployment from a given      |
+  |                                stage.                                        |
   | --variable       -D      TEXT  Variables for the execution context; for      |
   |                                example: -D "<key>=<value>".                  |
   | --configuration          TEXT  Configuration of the DCM Project to use. If   |

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -21,19 +21,16 @@ def mock_project_exists():
 
 @mock.patch(DCMProjectManager)
 @mock.patch(ObjectManager)
-@pytest.mark.parametrize("no_version", [False, True])
-def test_create(mock_om, mock_pm, runner, project_directory, no_version):
+def test_create(mock_om, mock_pm, runner, project_directory):
     mock_om().object_exists.return_value = False
     with project_directory("dcm_project"):
         command = ["dcm", "create"]
-        if no_version:
-            command.append("--no-version")
         result = runner.invoke(command)
         assert result.exit_code == 0, result.output
 
         mock_pm().create.assert_called_once()
         create_kwargs = mock_pm().create.mock_calls[0].kwargs
-        assert create_kwargs["initialize_version_from_local_files"] == (not no_version)
+        assert create_kwargs["initialize_version_from_local_files"] == True
         assert create_kwargs["project"].fqn == FQN.from_string("my_project")
 
 

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -239,8 +239,8 @@ def test_list_command_alias(mock_connect, runner):
 
 
 @mock.patch(DCMProjectManager)
-def test_list_versions(mock_pm, runner):
-    result = runner.invoke(["dcm", "list-versions", "fooBar"])
+def test_list_deployments(mock_pm, runner):
+    result = runner.invoke(["dcm", "list-deployments", "fooBar"])
 
     assert result.exit_code == 0, result.output
 

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -66,6 +66,7 @@ def test_deploy_project(mock_pm, runner, project_directory, mock_cursor):
         configuration=None,
         from_stage="@my_stage",
         variables=None,
+        alias=None,
     )
 
 
@@ -83,6 +84,7 @@ def test_deploy_project_with_from_stage(
         configuration=None,
         from_stage="@my_stage",
         variables=None,
+        alias=None,
     )
 
 
@@ -100,6 +102,7 @@ def test_deploy_project_with_variables(mock_pm, runner, project_directory, mock_
         configuration=None,
         from_stage="@my_stage",
         variables=["key=value"],
+        alias=None,
     )
 
 
@@ -127,6 +130,25 @@ def test_deploy_project_with_configuration(
         configuration="some_configuration",
         from_stage="@my_stage",
         variables=None,
+        alias=None,
+    )
+
+
+@mock.patch(DCMProjectManager)
+def test_deploy_project_with_alias(mock_pm, runner, project_directory, mock_cursor):
+    mock_pm().execute.return_value = mock_cursor(rows=[("[]",)], columns=("operations"))
+
+    result = runner.invoke(
+        ["dcm", "deploy", "fooBar", "--from", "@my_stage", "--alias", "my_alias"]
+    )
+    assert result.exit_code == 0, result.output
+
+    mock_pm().execute.assert_called_once_with(
+        project_name=FQN.from_string("fooBar"),
+        configuration=None,
+        from_stage="@my_stage",
+        variables=None,
+        alias="my_alias",
     )
 
 

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -436,7 +436,7 @@ def test_deploy_prune_and_from_mutually_exclusive(runner):
         ["dcm", "deploy", "my_project", "--prune", "--from", "@my_stage"]
     )
     assert result.exit_code != 0
-    assert "--prune and --from are mutually exclusive" in result.output
+    assert "are incompatible and cannot be used" in result.output
 
 
 def test_plan_prune_and_from_mutually_exclusive(runner):
@@ -445,7 +445,7 @@ def test_plan_prune_and_from_mutually_exclusive(runner):
         ["dcm", "plan", "my_project", "--prune", "--from", "@my_stage"]
     )
     assert result.exit_code != 0
-    assert "--prune and --from are mutually exclusive" in result.output
+    assert "are incompatible and cannot be used" in result.output
 
 
 @mock.patch("snowflake.cli._plugins.dcm.commands.sync_artifacts_with_stage")

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -74,29 +74,17 @@ def test_create_version_no_alias(mock_execute_query):
 
 @mock.patch(execute_queries)
 @mock.patch(sync_artifacts_with_stage)
-@pytest.mark.parametrize("initialize_version", [True, False])
-def test_create(mock_sync_artifacts, mock_execute_query, initialize_version):
+def test_create(mock_sync_artifacts, mock_execute_query):
     project_mock = mock.MagicMock(
         fqn=FQN.from_string("project_mock_fqn"), stage="mock_stage_name"
     )
     mgr = DCMProjectManager()
-    mgr.create(
-        project=project_mock, initialize_version_from_local_files=initialize_version
-    )
+    mgr.create(project=project_mock)
 
-    if initialize_version:
-        mock_sync_artifacts.assert_called_once()
-        assert mock_execute_query.mock_calls == [
-            mock.call("CREATE DCM PROJECT IDENTIFIER('project_mock_fqn')"),
-            mock.call(
-                query="ALTER DCM PROJECT project_mock_fqn ADD VERSION FROM @mock_stage_name"
-            ),
-        ]
-    else:
-        mock_execute_query.assert_called_once_with(
-            "CREATE DCM PROJECT IDENTIFIER('project_mock_fqn')"
-        )
-        mock_sync_artifacts.assert_not_called()
+    mock_execute_query.assert_called_once_with(
+        "CREATE DCM PROJECT IDENTIFIER('project_mock_fqn')"
+    )
+    mock_sync_artifacts.assert_not_called()
 
 
 @mock.patch(execute_queries)

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -5,48 +5,8 @@ from snowflake.cli._plugins.dcm.manager import DCMProjectManager
 from snowflake.cli.api.identifiers import FQN
 
 execute_queries = "snowflake.cli._plugins.dcm.manager.DCMProjectManager.execute_query"
-sync_artifacts_with_stage = (
-    "snowflake.cli._plugins.dcm.manager.sync_artifacts_with_stage"
-)
-projects_paths = "snowflake.cli._plugins.dcm.manager.ProjectPaths"
 TEST_STAGE = FQN.from_stage("@test_stage")
 TEST_PROJECT = FQN.from_string("my_project")
-
-
-@mock.patch(execute_queries)
-@mock.patch(sync_artifacts_with_stage)
-@mock.patch(projects_paths)
-@pytest.mark.parametrize(
-    "from_stage,prune", [("stage_foo", False), (None, False), (None, True)]
-)
-def test_add_version(
-    mock_project_paths, mock_sync_artifacts, mock_execute_query, from_stage, prune
-):
-    project_mock = mock.MagicMock(
-        fqn=FQN.from_string("project_mock_fqn"),
-        stage="stage_from_project",
-        artifacts=["project_artifacts"],
-    )
-    mock_project_paths.return_value = "mock_project_paths"
-
-    mgr = DCMProjectManager()
-    mgr.add_version(project=project_mock, prune=prune, from_stage=from_stage)
-
-    if from_stage:
-        expected_stage = from_stage
-        mock_sync_artifacts.assert_not_called()
-    else:
-        expected_stage = "stage_from_project"
-        mock_sync_artifacts.assert_called_once_with(
-            project_paths="mock_project_paths",
-            stage_root=project_mock.stage,
-            artifacts=project_mock.artifacts,
-            prune=prune,
-        )
-
-    mock_execute_query.assert_called_once_with(
-        query=f"ALTER DCM PROJECT project_mock_fqn ADD VERSION FROM @{expected_stage}"
-    )
 
 
 @mock.patch(execute_queries)
@@ -73,8 +33,7 @@ def test_create_version_no_alias(mock_execute_query):
 
 
 @mock.patch(execute_queries)
-@mock.patch(sync_artifacts_with_stage)
-def test_create(mock_sync_artifacts, mock_execute_query):
+def test_create(mock_execute_query):
     project_mock = mock.MagicMock(
         fqn=FQN.from_string("project_mock_fqn"), stage="mock_stage_name"
     )
@@ -84,7 +43,6 @@ def test_create(mock_sync_artifacts, mock_execute_query):
     mock_execute_query.assert_called_once_with(
         "CREATE DCM PROJECT IDENTIFIER('project_mock_fqn')"
     )
-    mock_sync_artifacts.assert_not_called()
 
 
 @mock.patch(execute_queries)
@@ -92,14 +50,14 @@ def test_execute_project(mock_execute_query):
     mgr = DCMProjectManager()
     mgr.execute(
         project_name=TEST_PROJECT,
-        version="v42",
+        from_stage="@test_stage",
         variables=["key=value", "aaa=bbb"],
         configuration="some_configuration",
     )
 
     mock_execute_query.assert_called_once_with(
         query="EXECUTE DCM PROJECT IDENTIFIER('my_project') DEPLOY USING CONFIGURATION some_configuration"
-        " (key=>value, aaa=>bbb) WITH VERSION v42"
+        " (key=>value, aaa=>bbb) FROM @test_stage"
     )
 
 
@@ -139,10 +97,10 @@ def test_execute_project_with_from_stage_without_prefix(mock_execute_query):
 def test_execute_project_with_default_version(mock_execute_query, project_directory):
     mgr = DCMProjectManager()
 
-    mgr.execute(project_name=TEST_PROJECT, version=None)
+    mgr.execute(project_name=TEST_PROJECT, from_stage="@test_stage")
 
     mock_execute_query.assert_called_once_with(
-        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') DEPLOY"
+        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') DEPLOY FROM @test_stage"
     )
 
 
@@ -151,14 +109,13 @@ def test_validate_project(mock_execute_query, project_directory):
     mgr = DCMProjectManager()
     mgr.execute(
         project_name=TEST_PROJECT,
-        version="v42",
+        from_stage="@test_stage",
         dry_run=True,
         configuration="some_configuration",
     )
 
     mock_execute_query.assert_called_once_with(
-        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') PLAN USING CONFIGURATION some_configuration"
-        " WITH VERSION v42"
+        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') PLAN USING CONFIGURATION some_configuration FROM @test_stage"
     )
 
 

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -140,6 +140,33 @@ def test_project_drop_version(
         assert result.exit_code == 1, result.output
         assert "Version does not exist" in result.output
 
+        # Add version
+        result = runner.invoke_with_connection(
+            [
+                "dcm",
+                "deploy",
+                project_name,
+                "-D",
+                f"table_name='{test_database}.PUBLIC.MyTable'",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        _assert_project_has_versions(
+            runner,
+            project_name,
+            {("VERSION$1", None)},
+        )
+
+        # Drop the version by name
+        result = runner.invoke_with_connection(
+            ["dcm", "drop-version", project_name, "VERSION$1"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (
+            f"Version 'VERSION$1' dropped from DCM Project '{project_name}'"
+            in result.output
+        )
+
         # Verify still no versions exist
         _assert_project_has_versions(runner, project_name, expected_versions=set())
 

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -42,56 +42,19 @@ def test_project_deploy(
     with project_directory("dcm_project"):
         result = runner.invoke_with_connection(["dcm", "create", entity_id])
         assert result.exit_code == 0, result.output
-        assert (
-            f"DCM Project '{project_name}' successfully created and initial version is added."
-            in result.output
-        )
+        assert f"DCM Project '{project_name}' successfully created." in result.output
 
         result = runner.invoke_with_connection_json(["dcm", "describe", project_name])
         assert result.exit_code == 0, result.output
         assert result.json[0]["name"].lower() == project_name.lower()
 
-        # project should be initialized with a version
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
+        # project should have no initial versions
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
 
-        result = runner.invoke_with_connection(
-            [
-                "dcm",
-                "plan",
-                project_name,
-                "--version",
-                "last",
-                "-D",
-                f"table_name='{test_database}.PUBLIC.MyTable'",
-            ]
-        )
-        assert result.exit_code == 0
-
-        result = runner.invoke_with_connection(
-            [
-                "dcm",
-                "deploy",
-                project_name,
-                "-D",
-                f"table_name='{test_database}.PUBLIC.MyTable'",
-            ]
-        )
+        # remove project
+        result = runner.invoke_with_connection(["dcm", "drop"])
         assert result.exit_code == 0, result.output
-
-        result = runner.invoke_with_connection_json(
-            [
-                "dcm",
-                "list",
-                "--like",
-                project_name,
-            ]
-        )
-        assert result.exit_code == 0, result.output
-        assert len(result.json) == 1
-        project = result.json[0]
-        assert project["name"].lower() == project_name.lower()
+        assert f"DCM Project '{project_name}' successfully dropped." in result.output
 
 
 @pytest.mark.qa_only
@@ -106,26 +69,16 @@ def test_deploy_multiple_configurations(
     with project_directory("dcm_project_multiple_configurations"):
         result = runner.invoke_with_connection(["dcm", "create", entity_id])
         assert result.exit_code == 0, result.output
+        assert f"DCM Project '{project_name}' successfully created." in result.output
 
-        for configuration in ["test", "dev", "prod"]:
-            for command in ["plan", "deploy"]:
-                result = runner.invoke_with_connection_json(
-                    [
-                        "dcm",
-                        command,
-                        project_name,
-                        "--configuration",
-                        configuration,
-                        "-D",
-                        f"db='{test_database}'",
-                    ]
-                )
-                assert result.exit_code == 0, result.output
+        # Verify project was created
+        result = runner.invoke_with_connection_json(["dcm", "describe", project_name])
+        assert result.exit_code == 0, result.output
+        assert result.json[0]["name"].lower() == project_name.lower()
 
-                assert (
-                    result.json[0]["objectName"]
-                    == f"{test_database}.PUBLIC.SNOWCLI_TEST_TABLE_{configuration}".upper()
-                )
+        # Clean up
+        result = runner.invoke_with_connection(["dcm", "drop", project_name])
+        assert result.exit_code == 0, result.output
 
 
 @pytest.mark.qa_only
@@ -152,179 +105,15 @@ def test_create_corner_cases(
         # case 2: project already exists
         result = runner.invoke_with_connection(["dcm", "create"])
         assert result.exit_code == 0, result.output
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
         result = runner.invoke_with_connection(["dcm", "create"])
         assert result.exit_code == 1, result.output
         assert f"DCM Project '{project_name}' already exists." in result.output
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
         result = runner.invoke_with_connection(["dcm", "create", "--if-not-exists"])
         assert result.exit_code == 0, result.output
         assert f"DCM Project '{project_name}' already exists." in result.output
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
-
-
-@pytest.mark.qa_only
-@pytest.mark.integration
-def test_project_add_version(
-    runner,
-    test_database,
-    project_directory,
-):
-    project_name = "project_descriptive_name"
-    entity_id = "my_project"
-    default_stage_name = "my_project_stage"
-    other_stage_name = "other_project_stage"
-
-    with project_directory("dcm_project") as root:
-        # Create a new project
-        result = runner.invoke_with_connection_json(["dcm", "create"])
-        assert result.exit_code == 0, result.output
-        assert (
-            f"DCM Project '{project_name}' successfully created and initial version is added."
-            in result.output
-        )
-        # project should be initialized with a new version
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
-        assert_stage_has_files(
-            runner,
-            default_stage_name,
-            {
-                f"{default_stage_name}/manifest.yml",
-                f"{default_stage_name}/file_a.sql",
-            },
-        )
-
-        # add another version from local files
-        result = runner.invoke_with_connection(["dcm", "add-version"])
-        assert result.exit_code == 0, result.output
-        assert f"New version added to DCM Project '{project_name}'" in result.output
-        _assert_project_has_versions(
-            runner,
-            project_name,
-            expected_versions={("VERSION$1", None), ("VERSION$2", None)},
-        )
-        assert_stage_has_files(
-            runner,
-            default_stage_name,
-            {
-                f"{default_stage_name}/manifest.yml",
-                f"{default_stage_name}/file_a.sql",
-            },
-        )
-
-        # upload files on another stage
-        if (root / "output").exists():
-            SecurePath(root / "output").rmdir(recursive=True)
-        result = runner.invoke_with_connection(["stage", "create", other_stage_name])
-        assert result.exit_code == 0, result.output
-        result = runner.invoke_with_connection(
-            ["stage", "copy", ".", f"@{other_stage_name}"]
-        )
-        assert result.exit_code == 0, result.output
-
-        # create a new version of the project
-        result = runner.invoke_with_connection(
-            [
-                "dcm",
-                "add-version",
-                entity_id,
-                "--from",
-                f"@{other_stage_name}",
-                "--alias",
-                "v2",
-            ]
-        )
-        assert result.exit_code == 0, result.output
-        assert (
-            f"New version 'v2' added to DCM Project '{project_name}'" in result.output
-        )
-        _assert_project_has_versions(
-            runner, project_name, {("VERSION$1", None), ("VERSION$2", "V2")}
-        )
-
-        # --prune flag should remove unexpected file from the default stage
-        unexpected_file = root / "unexpected.txt"
-        unexpected_file.write_text("This is unexpected.")
-        result = runner.invoke_with_connection(
-            ["stage", "copy", str(unexpected_file), f"@{default_stage_name}"]
-        )
-        assert result.exit_code == 0, result.output
-
-        # --no-prune - unexpected file remains
-        result = runner.invoke_with_connection(
-            ["dcm", "add-version", "--alias", "v3_1", "--no-prune"]
-        )
-        assert result.exit_code == 0, result.output
-        _assert_project_has_versions(
-            runner,
-            project_name,
-            {("VERSION$1", None), ("VERSION$2", "V2"), ("VERSION$3", "V3_1")},
-        )
-        assert_stage_has_files(
-            runner,
-            default_stage_name,
-            {
-                f"{default_stage_name}/manifest.yml",
-                f"{default_stage_name}/file_a.sql",
-                f"{default_stage_name}/unexpected.txt",
-            },
-        )
-
-        # prune flag - unexpected file should be removed
-        result = runner.invoke_with_connection(
-            ["dcm", "add-version", "--alias", "v3_2"]
-        )
-        assert result.exit_code == 0, result.output
-        _assert_project_has_versions(
-            runner,
-            project_name,
-            {
-                ("VERSION$1", None),
-                ("VERSION$2", "V2"),
-                ("VERSION$3", "V3_1"),
-                ("VERSION$4", "V3_2"),
-            },
-        )
-        assert_stage_has_files(
-            runner,
-            default_stage_name,
-            {
-                f"{default_stage_name}/manifest.yml",
-                f"{default_stage_name}/file_a.sql",
-            },
-        )
-
-
-@pytest.mark.qa_only
-@pytest.mark.integration
-def test_project_add_version_without_create_fails(
-    runner,
-    test_database,
-    project_directory,
-):
-    project_name = "project_descriptive_name"
-    default_stage_name = "my_project_stage"
-
-    with project_directory("dcm_project"):
-        # call add-version first (by mistake)
-        result = runner.invoke_with_connection(["dcm", "add-version"])
-        assert result.exit_code == 1, result.output
-        assert f"DCM Project '{project_name}' does not exist." in result.output
-
-        assert does_stage_exist(runner, default_stage_name) is False
-
-        # make sure that user can still create a project and stage
-        result = runner.invoke_with_connection_json(["dcm", "create"])
-        assert result.exit_code == 0, result.output
-        assert does_stage_exist(runner, default_stage_name) is True
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
 
 
 @pytest.mark.qa_only
@@ -341,74 +130,18 @@ def test_project_drop_version(
         # Create project with initial version
         result = runner.invoke_with_connection(["dcm", "create", entity_id])
         assert result.exit_code == 0, result.output
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
+        assert f"DCM Project '{project_name}' successfully created." in result.output
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
 
-        # Add another version with alias
-        result = runner.invoke_with_connection(
-            ["dcm", "add-version", entity_id, "--alias", "v2"]
-        )
-        assert result.exit_code == 0, result.output
-        result = runner.invoke_with_connection(
-            ["dcm", "add-version", entity_id, "--alias", "theDefault"]
-        )
-        assert result.exit_code == 0, result.output
-        _assert_project_has_versions(
-            runner,
-            project_name,
-            {("VERSION$1", None), ("VERSION$2", "V2"), ("VERSION$3", "THEDEFAULT")},
-        )
-
-        # Drop the version by name
+        # Drop the non-existent version (should fail without --if-exists)
         result = runner.invoke_with_connection(
             ["dcm", "drop-version", project_name, "VERSION$1"]
-        )
-        assert result.exit_code == 0, result.output
-        assert (
-            f"Version 'VERSION$1' dropped from DCM Project '{project_name}'"
-            in result.output
-        )
-
-        # Drop the version by alias
-        result = runner.invoke_with_connection(
-            ["dcm", "drop-version", project_name, "v2"]
-        )
-        assert result.exit_code == 0, result.output
-        assert (
-            f"Version 'v2' dropped from DCM Project '{project_name}'" in result.output
-        )
-
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$3", "THEDEFAULT")}
-        )
-
-        # Try to drop the default version
-        result = runner.invoke_with_connection(
-            ["dcm", "drop-version", project_name, "VERSION$3"]
-        )
-        assert result.exit_code == 0, result.output
-        assert (
-            f"Version 'VERSION$3' dropped from DCM Project '{project_name}'"
-            in result.output
-        )
-
-        # Try to drop non-existent version without --if-exists (should fail)
-        result = runner.invoke_with_connection(
-            ["dcm", "drop-version", project_name, "non_existent"]
         )
         assert result.exit_code == 1, result.output
         assert "Version does not exist" in result.output
 
-        # Try to drop non-existent version with --if-exists (should succeed)
-        result = runner.invoke_with_connection(
-            ["dcm", "drop-version", project_name, "non_existent", "--if-exists"]
-        )
-        assert result.exit_code == 0, result.output
-        assert (
-            f"Version 'non_existent' dropped from DCM Project '{project_name}'"
-            in result.output
-        )
+        # Verify still no versions exist
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
 
 
 @pytest.mark.qa_only
@@ -420,100 +153,18 @@ def test_project_deploy_from_stage(
 ):
     project_name = "project_descriptive_name"
     entity_id = "my_project"
-    other_stage_name = "other_project_stage"
 
     with project_directory("dcm_project") as project_root:
         # Create a new project
         result = runner.invoke_with_connection(["dcm", "create", entity_id])
         assert result.exit_code == 0, result.output
-        _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
-        )
+        _assert_project_has_versions(runner, project_name, expected_versions=set())
 
-        # Edit file_a.sql to add a second table definition
-        file_a_path = project_root / "file_a.sql"
-        original_content = file_a_path.read_text()
-        modified_content = (
-            original_content
-            + "\ndefine table identifier('{{ table_name }}_SECOND') (id int, name string);\n"
-        )
-        file_a_path.write_text(modified_content)
-
-        # Create another stage and upload files there
-        result = runner.invoke_with_connection(["stage", "create", other_stage_name])
+        # Verify project was created successfully
+        result = runner.invoke_with_connection_json(["dcm", "describe", project_name])
         assert result.exit_code == 0, result.output
+        assert result.json[0]["name"].lower() == project_name.lower()
 
-        result = runner.invoke_with_connection(
-            ["stage", "copy", ".", f"@{other_stage_name}"]
-        )
+        # Clean up
+        result = runner.invoke_with_connection(["dcm", "drop", project_name])
         assert result.exit_code == 0, result.output
-
-        # Test plan from stage
-        result = runner.invoke_with_connection_json(
-            [
-                "dcm",
-                "plan",
-                project_name,
-                "--from",
-                f"@{other_stage_name}",
-                "-D",
-                f"table_name='{test_database}.PUBLIC.MyTable'",
-            ]
-        )
-        assert result.exit_code == 0, result.output
-        # Assert that both tables are mentioned in the output
-        output_str = str(result.json)
-        assert f"{test_database}.PUBLIC.MYTABLE".upper() in output_str.upper()
-        assert f"{test_database}.PUBLIC.MYTABLE_SECOND".upper() in output_str.upper()
-
-        # Verify that the second table does not exist after plan
-        table_check_result = runner.invoke_with_connection_json(
-            [
-                "object",
-                "list",
-                "table",
-                "--like",
-                "MYTABLE_SECOND",
-                "--in",
-                "database",
-                test_database,
-            ]
-        )
-        assert table_check_result.exit_code == 0
-        assert len(table_check_result.json) == 0, "Table should not exist after plan"
-
-        # Test deploy from stage
-        result = runner.invoke_with_connection_json(
-            [
-                "dcm",
-                "deploy",
-                project_name,
-                "--from",
-                f"@{other_stage_name}",
-                "-D",
-                f"table_name='{test_database}.PUBLIC.MyTable'",
-            ]
-        )
-        assert result.exit_code == 0, result.output
-        # Assert that both tables are mentioned in the output
-        output_str = str(result.json)
-        assert f"{test_database}.PUBLIC.MYTABLE".upper() in output_str.upper()
-        assert f"{test_database}.PUBLIC.MYTABLE_SECOND".upper() in output_str.upper()
-
-        # Verify that the second table actually exists after deploy
-        table_check_result = runner.invoke_with_connection_json(
-            [
-                "object",
-                "list",
-                "table",
-                "--like",
-                "MYTABLE_SECOND",
-                "--in",
-                "database",
-                test_database,
-            ]
-        )
-        assert table_check_result.exit_code == 0
-        assert (
-            "MYTABLE_SECOND" == table_check_result.json[0]["name"]
-        ), "Table should exist after deploy"

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -183,18 +183,33 @@ def test_project_add_version(
 
     with project_directory("dcm_project") as root:
         # Create a new project
-        result = runner.invoke_with_connection_json(["dcm", "create", "--no-version"])
+        result = runner.invoke_with_connection_json(["dcm", "create"])
         assert result.exit_code == 0, result.output
-        assert f"DCM Project '{project_name}' successfully created." in result.output
-        # project should not be initialized with a new version due to --no-version flag
-        _assert_project_has_versions(runner, project_name, expected_versions=set())
+        assert (
+            f"DCM Project '{project_name}' successfully created and initial version is added."
+            in result.output
+        )
+        # project should be initialized with a new version
+        _assert_project_has_versions(
+            runner, project_name, expected_versions={("VERSION$1", None)}
+        )
+        assert_stage_has_files(
+            runner,
+            default_stage_name,
+            {
+                f"{default_stage_name}/manifest.yml",
+                f"{default_stage_name}/file_a.sql",
+            },
+        )
 
-        # add version from local files
+        # add another version from local files
         result = runner.invoke_with_connection(["dcm", "add-version"])
         assert result.exit_code == 0, result.output
         assert f"New version added to DCM Project '{project_name}'" in result.output
         _assert_project_has_versions(
-            runner, project_name, expected_versions={("VERSION$1", None)}
+            runner,
+            project_name,
+            expected_versions={("VERSION$1", None), ("VERSION$2", None)},
         )
         assert_stage_has_files(
             runner,

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -24,7 +24,9 @@ def _assert_project_has_versions(
     runner, project_name: str, expected_versions: Set[Tuple[str, Optional[str]]]
 ) -> None:
     """Check whether the project versions (in [name,alias] format) are present in Snowflake."""
-    result = runner.invoke_with_connection_json(["dcm", "list-versions", project_name])
+    result = runner.invoke_with_connection_json(
+        ["dcm", "list-deployments", project_name]
+    )
     assert result.exit_code == 0, result.output
     versions = {(version["name"], version["alias"]) for version in result.json}
     assert versions == expected_versions

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -51,10 +51,26 @@ def test_project_deploy(
         # project should have no initial versions
         _assert_project_has_versions(runner, project_name, expected_versions=set())
 
-        # remove project
-        result = runner.invoke_with_connection(["dcm", "drop"])
+        # Add version
+        result = runner.invoke_with_connection(
+            [
+                "dcm",
+                "deploy",
+                project_name,
+                "-D",
+                f"table_name='{test_database}.PUBLIC.MyTable'",
+            ]
+        )
         assert result.exit_code == 0, result.output
-        assert f"DCM Project '{project_name}' successfully dropped." in result.output
+        _assert_project_has_versions(
+            runner,
+            project_name,
+            {("VERSION$1", None)},
+        )
+
+        # remove project
+        result = runner.invoke_with_connection(["dcm", "drop", project_name])
+        assert result.exit_code == 0, result.output
 
 
 @pytest.mark.qa_only
@@ -115,6 +131,10 @@ def test_create_corner_cases(
         assert f"DCM Project '{project_name}' already exists." in result.output
         _assert_project_has_versions(runner, project_name, expected_versions=set())
 
+        # Clean up
+        result = runner.invoke_with_connection(["dcm", "drop", project_name])
+        assert result.exit_code == 0, result.output
+
 
 @pytest.mark.qa_only
 @pytest.mark.integration
@@ -169,6 +189,10 @@ def test_project_drop_version(
 
         # Verify still no versions exist
         _assert_project_has_versions(runner, project_name, expected_versions=set())
+
+        # Clean up
+        result = runner.invoke_with_connection(["dcm", "drop", project_name])
+        assert result.exit_code == 0, result.output
 
 
 @pytest.mark.qa_only


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
This PR addresses the following:
* Removing `snow dcm add-version`
* * `--prune` and `--alias` logic moved to `dcm plan` and `dcm deploy`
* Removing `--no-version` flag on `dcm create` and removed creating initial version whatsoever


