### PR TITLE
SNOW-2231968 Add `--output-path` to `snow dcm plan`

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -84,6 +84,11 @@ alias_option = typer.Option(
     help="Alias for the deployment.",
     show_default=False,
 )
+output_path_option = OverrideableOption(
+    None,
+    "--output-path",
+    show_default=False,
+)
 
 
 add_object_command_aliases(
@@ -119,6 +124,7 @@ def deploy(
         from_stage=from_stage if from_stage else _sync_local_files(prune=prune),
         variables=variables,
         alias=alias,
+        output_path=None,
     )
     return QueryJsonValueResult(result)
 
@@ -132,6 +138,9 @@ def plan(
     variables: Optional[List[str]] = variables_flag,
     configuration: Optional[str] = configuration_flag,
     prune: bool = prune_option(),
+    output_path: Optional[str] = output_path_option(
+        help="Stage path where the deployment plan output will be stored."
+    ),
     **options,
 ):
     """
@@ -143,6 +152,7 @@ def plan(
         from_stage=from_stage if from_stage else _sync_local_files(prune=prune),
         dry_run=True,
         variables=variables,
+        output_path=output_path,
     )
     return QueryJsonValueResult(result)
 

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -31,6 +31,7 @@ class DCMProjectManager(SqlExecutionMixin):
         variables: List[str] | None = None,
         dry_run: bool = False,
         alias: str | None = None,
+        output_path: str | None = None,
     ):
 
         query = f"EXECUTE DCM PROJECT {project_name.sql_identifier}"
@@ -50,6 +51,9 @@ class DCMProjectManager(SqlExecutionMixin):
             ).removeprefix(" using")
         stage_path = StagePath.from_stage_str(from_stage)
         query += f" FROM {stage_path.absolute_path()}"
+        if output_path:
+            output_stage_path = StagePath.from_stage_str(output_path)
+            query += f" OUTPUT_PATH {output_stage_path.absolute_path()}"
         return self.execute_query(query=query)
 
     def create(self, project: DCMProjectEntityModel) -> None:

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -4678,12 +4678,12 @@
 # ---
 # name: test_help_messages[connection.remove]
   '''
-
-   Usage: root connection remove [OPTIONS]
-
-   Removes a connection from configuration file.
-
-
+                                                                                  
+   Usage: root connection remove [OPTIONS]                                        
+                                                                                  
+   Removes a connection from configuration file.                                  
+                                                                                  
+                                                                                  
   +- Options --------------------------------------------------------------------+
   | --connection-name  -n      TEXT  Name of the connection to remove.           |
   | --help             -h            Show this message and exit.                 |
@@ -4708,8 +4708,8 @@
   |                                                       [env var:              |
   |                                                       SNOWFLAKE_ENHANCED_EX… |
   +------------------------------------------------------------------------------+
-
-
+  
+  
   '''
 # ---
 # name: test_help_messages[connection.set-default]

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -4678,12 +4678,12 @@
 # ---
 # name: test_help_messages[connection.remove]
   '''
-                                                                                  
-   Usage: root connection remove [OPTIONS]                                        
-                                                                                  
-   Removes a connection from configuration file.                                  
-                                                                                  
-                                                                                  
+
+   Usage: root connection remove [OPTIONS]
+
+   Removes a connection from configuration file.
+
+
   +- Options --------------------------------------------------------------------+
   | --connection-name  -n      TEXT  Name of the connection to remove.           |
   | --help             -h            Show this message and exit.                 |
@@ -4708,8 +4708,8 @@
   |                                                       [env var:              |
   |                                                       SNOWFLAKE_ENHANCED_EX… |
   +------------------------------------------------------------------------------+
-  
-  
+
+
   '''
 # ---
 # name: test_help_messages[connection.set-default]
@@ -8038,6 +8038,8 @@
   |                                not specified default configuration is used.  |
   | --prune                        Remove unused artifacts from the stage during |
   |                                sync. Mutually exclusive with --from.         |
+  | --output-path            TEXT  Stage path where the deployment plan output   |
+  |                                will be stored.                               |
   | --help           -h            Show this message and exit.                   |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -157,3 +157,55 @@ def test_drop_version(mock_execute_query, if_exists):
     expected_query += " v1"
 
     mock_execute_query.assert_called_once_with(query=expected_query)
+
+
+@mock.patch(execute_queries)
+def test_validate_project_with_output_path(mock_execute_query, project_directory):
+    mgr = DCMProjectManager()
+    mgr.execute(
+        project_name=TEST_PROJECT,
+        from_stage="@test_stage",
+        dry_run=True,
+        configuration="some_configuration",
+        output_path="@output_stage/results",
+    )
+
+    mock_execute_query.assert_called_once_with(
+        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') PLAN USING CONFIGURATION some_configuration FROM @test_stage OUTPUT_PATH @output_stage/results"
+    )
+
+
+@mock.patch(execute_queries)
+@pytest.mark.parametrize(
+    "output_stage_name", ["@output_stage/path", "output_stage/path"]
+)
+def test_validate_project_with_output_path_different_formats(
+    mock_execute_query, project_directory, output_stage_name
+):
+    mgr = DCMProjectManager()
+    mgr.execute(
+        project_name=TEST_PROJECT,
+        from_stage="@test_stage",
+        dry_run=True,
+        output_path=output_stage_name,
+    )
+
+    mock_execute_query.assert_called_once_with(
+        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') PLAN FROM @test_stage OUTPUT_PATH @output_stage/path"
+    )
+
+
+@mock.patch(execute_queries)
+def test_deploy_project_with_output_path(mock_execute_query, project_directory):
+    mgr = DCMProjectManager()
+    mgr.execute(
+        project_name=TEST_PROJECT,
+        from_stage="@test_stage",
+        dry_run=False,
+        alias="v1",
+        output_path="@output_stage",
+    )
+
+    mock_execute_query.assert_called_once_with(
+        query="EXECUTE DCM PROJECT IDENTIFIER('my_project') DEPLOY AS v1 FROM @test_stage OUTPUT_PATH @output_stage"
+    )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
This PR adds `--output-path` to `snow dcm plan`. It allows to write rendered SQLs in given location
