### PR TITLE
Update README.md to show uv instead of pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Feel free to file an issue or submit a PR here for general cases. For official s
 
 ## Install Snowflake CLI
 
-### Install with pipx (PyPi)
+### Install with uv (PyPi)
 
-We recommend installing Snowflake CLI in isolated environment using [pipx](https://pipx.pypa.io/stable/). Requires Python >= 3.10
+We recommend installing Snowflake CLI in isolated environment using [uv](https://docs.astral.sh/uv/guides/tools/#installing-tools). Requires Python >= 3.10
 
 ```bash
-pipx install snowflake-cli
+uv tool install snowflake-cli
 snow --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ uv tool install snowflake-cli
 snow --help
 ```
 
+Or, with a single command
+```bash
+uvx --from snowflake-cli snow --help
+```
+
 ### Install with Homebrew (Mac only)
 
 Requires [Homebrew](https://brew.sh/).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Feel free to file an issue or submit a PR here for general cases. For official s
 
 ### Install with uv (PyPi)
 
-We recommend installing Snowflake CLI in isolated environment using [uv](https://docs.astral.sh/uv/guides/tools/#installing-tools). Requires Python >= 3.10
+We recommend installing Snowflake CLI in an isolated environment using [uv](https://docs.astral.sh/uv/guides/tools/#installing-tools). Requires Python >= 3.10
 
 ```bash
 uv tool install snowflake-cli


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.

### Changes description

Since uv now far supercedes what pipx does, and has ~ an order of magnitude more usage (https://pypistats.org/packages/uv vs https://pypistats.org/packages/pipx), this switches out pipx instructions for uv (or uvx)
