### PR TITLE
feat: [SNOW-988145] provide connection name as arg

### DIFF
--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -319,12 +319,9 @@ def add(
     )
 
 
-@app.command()
+@app.command(requires_connection=False)
 def remove(
-    connection_name: str = typer.Option(
-        None,
-        "--connection-name",
-        "-n",
+    connection_name: str = typer.Argument(
         help="Name of the connection to remove.",
         show_default=False,
     ),

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5135,7 +5135,7 @@
                                                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
-  | *    connection_name      TEXT  Name of the connection to remove to remove.  |
+  | *    connection_name      TEXT  Name of the connection to remove.            |
   |                                 [required]                                   |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5129,14 +5129,17 @@
 # name: test_help_messages[connection.remove]
   '''
                                                                                   
-   Usage: root connection remove [OPTIONS]                                        
+   Usage: root connection remove [OPTIONS] CONNECTION_NAME                        
                                                                                   
    Removes a connection from configuration file.                                  
                                                                                   
                                                                                   
+  +- Arguments ------------------------------------------------------------------+
+  | *    connection_name      TEXT  Name of the connection to remove to remove.  |
+  |                                 [required]                                   |
+  +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --connection-name  -n      TEXT  Name of the connection to remove.           |
-  | --help             -h            Show this message and exit.                 |
+  | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1776,7 +1776,7 @@ def _add_connection(runner, tmp_file, name, is_default=False, expected_to_fail=F
 
 def _remove_connection(runner, tmp_file, name, expected_to_fail=False):
     result = runner.invoke_with_config_file(
-        tmp_file.name, ["connection", "remove", "--connection-name", name]
+        tmp_file.name, ["connection", "remove", name]
     )
     if expected_to_fail:
         assert result.exit_code != 0, result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Changed connection name to be argument of snow connection remove command. An option felt inconsistent with other commands and also if that argument was not provided, CLI broke
