### PR TITLE
SNOW-2191699 SNOW-2181193 commands_registration shouldn't be eager

### DIFF
--- a/src/snowflake/cli/_app/cli_app.py
+++ b/src/snowflake/cli/_app/cli_app.py
@@ -256,7 +256,6 @@ class CliAppFactory:
                 "--commands-registration",
                 help="Commands registration",
                 hidden=True,
-                is_eager=True,
                 callback=self._commands_registration_callback(),
             ),
         ) -> None:


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

The `test_broken_plugin` and `test_failing_plugin` tests were reported flaky. The expected log messages contained only information about directory creation that indicates that plugins were not discovered. This could happen due to both `commands_registration` and `configuration_file` being marked as `eager` and some race condition there. Also, given `commands_registration` should be the last one, it shouldn't be eager in the first place.

Closes #2479 and #2468
