### PR TITLE
SNOW-1555911: Replace hardcoded keypair alias with variable for signing windows installer

### DIFF
--- a/scripts/packaging/win/build_installer.bat
+++ b/scripts/packaging/win/build_installer.bat
@@ -30,7 +30,7 @@ set SM_CLIENT_CERT_FILE=%WORKSPACE%\Certificate_pkcs12.p12
 smctl healthcheck || goto :error
 smctl windows certsync || goto :error
 
-smctl sign --keypair-alias key_1311463644 --input dist\snow\snow.exe || goto :error
+smctl sign --keypair-alias %digicert_key_name% --input dist\snow\snow.exe || goto :error
 signtool verify /v /pa dist\snow\snow.exe || goto :error
 
 candle.exe ^
@@ -48,7 +48,7 @@ light.exe ^
   snowflake_cli.wixobj ^
   snowflake_cli_exitdlg.wixobj || goto :error
 
-smctl sign --keypair-alias key_1311463644 --input %CLI_MSI% || goto :error
+smctl sign --keypair-alias %digicert_key_name% --input %CLI_MSI% || goto :error
 signtool verify /v /pa %CLI_MSI% || goto :error
 
 echo "[INFO] uploading artifacts"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
This change replaces hardcoded key name in the script that builds the Windows installer with variable reference that has been added to the Jenkins job in the other PR.

Test run: https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/SnowflakeCLI-Win-x86-64-Installer/245/console

The key name value from the parameter has been used correctly:
<img width="1450" height="133" alt="image" src="https://github.com/user-attachments/assets/23599ffb-bef0-4b50-af96-97caa172a72a" />



