### PR TITLE
SNOW-2337682 Ensure built-in plugins are loaded first.

### DIFF
--- a/src/snowflake/cli/_app/commands_registration/command_plugins_loader.py
+++ b/src/snowflake/cli/_app/commands_registration/command_plugins_loader.py
@@ -69,7 +69,20 @@ class CommandPluginsLoader:
                 )
 
     def load_all_registered_plugins(self) -> List[LoadedCommandPlugin]:
-        for plugin_name, plugin in self._plugin_manager.list_name_plugin():
+        all_plugins = list(self._plugin_manager.list_name_plugin())
+        builtin_plugin_names = set(get_builtin_plugin_name_to_plugin_spec().keys())
+
+        def plugin_sort_key(name_plugin_tuple):
+            _plugin_name, _ = name_plugin_tuple
+            is_builtin = _plugin_name in builtin_plugin_names
+            return (
+                not is_builtin,
+                _plugin_name,
+            )
+
+        sorted_plugins = sorted(all_plugins, key=plugin_sort_key)
+
+        for plugin_name, plugin in sorted_plugins:
             self._load_plugin(plugin_name, plugin)
         return list(self._loaded_plugins.values())
 


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
There's possibility of a race condition in loading plugins, order is unknown and override plugin can be added before build-in one. This change adds sorting of plugins by name to have fixed order and ensures that internal plugin is loaded before external one, even with the same name. 

Fixes #2604
