### PR TITLE
SNOW-2347456 Properly escape `_` and `%` in `snow logs --partial`

### DIFF
--- a/src/snowflake/cli/_plugins/logs/manager.py
+++ b/src/snowflake/cli/_plugins/logs/manager.py
@@ -96,7 +96,9 @@ class LogsManager(SqlExecutionMixin):
         # Build the object name condition based on partial_match flag
         if partial_match:
             # Use ILIKE for case-insensitive partial matching with wildcards
-            escaped_pattern = escape_like_pattern(escaped_object_name)
+            escaped_pattern = escape_like_pattern(
+                escaped_object_name, escape_sequence="\\"
+            )
             object_condition = f"object_name ILIKE '%{escaped_pattern}%'"
         else:
             # Use exact match (original behavior)

--- a/tests/logs/__snapshots__/test_logs.ambr
+++ b/tests/logs/__snapshots__/test_logs.ambr
@@ -133,14 +133,14 @@
               FROM SNOWFLAKE.TELEMETRY.EVENTS
               WHERE record_type = 'LOG'
               AND (record:severity_text IN ('INFO', 'WARN', 'ERROR', 'FATAL') or record:severity_text is NULL )
-              AND object_name ILIKE '%test\\_obj%'
+              AND object_name ILIKE '%test\_obj%'
               AND timestamp >= TO_TIMESTAMP_LTZ('2022-02-02T02:02:02')
   AND timestamp <= TO_TIMESTAMP_LTZ('2022-02-03T02:02:02')
   
               ORDER BY timestamp;
   '''
 # ---
-# name: test_partial_match_with_like_wildcards[test_obj_with_percent]
+# name: test_partial_match_with_like_wildcards["test%obj"]
   '''
   SELECT
       timestamp,
@@ -152,7 +152,7 @@
   FROM SNOWFLAKE.TELEMETRY.EVENTS
   WHERE record_type = 'LOG'
   AND (record:severity_text IN ('INFO', 'WARN', 'ERROR', 'FATAL') or record:severity_text is NULL )
-  AND object_name ILIKE '%test\\_obj\\_with\\_percent%'
+  AND object_name ILIKE '%"test\%obj"%'
   
   ORDER BY timestamp;
   '''
@@ -169,7 +169,7 @@
   FROM SNOWFLAKE.TELEMETRY.EVENTS
   WHERE record_type = 'LOG'
   AND (record:severity_text IN ('INFO', 'WARN', 'ERROR', 'FATAL') or record:severity_text is NULL )
-  AND object_name ILIKE '%test\\_obj\\_with\\_underscore%'
+  AND object_name ILIKE '%test\_obj\_with\_underscore%'
   
   ORDER BY timestamp;
   '''

--- a/tests/logs/test_logs.py
+++ b/tests/logs/test_logs.py
@@ -122,9 +122,7 @@ def test_partial_match_query_construction(
     assert queries[0] == snapshot
 
 
-@pytest.mark.parametrize(
-    "object_name", ["test_obj_with_underscore", "test_obj_with_percent"]
-)
+@pytest.mark.parametrize("object_name", ["test_obj_with_underscore", '"test%obj"'])
 def test_partial_match_with_like_wildcards(
     mock_connect, mock_ctx, runner, snapshot, object_name
 ):


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
...
