### PR TITLE
SNOW-2305287 make non-flaky version of testing show warehouses

### DIFF
--- a/tests_integration/test_object.py
+++ b/tests_integration/test_object.py
@@ -27,7 +27,6 @@ import json
 @pytest.mark.parametrize(
     "object_type,plural_object_type",
     [
-        ("warehouse", "warehouses"),
         ("schema", "schemas"),
         ("external-access-integration", "external access integrations"),
     ],
@@ -46,6 +45,42 @@ def test_show(
     assert len(actual) == len(expected)
     assert actual[0].keys() == expected[0].keys()
     assert actual[0]["name"] == expected[0]["name"]
+
+
+@pytest.mark.integration
+def test_show_warehouses(runner, test_database, snowflake_session):
+    """
+    Test warehouse listing with explicit validation to avoid flaky behavior.
+    """
+    result = runner.invoke_with_connection_json(
+        ["object", "list", "warehouse", "--format", "json"]
+    )
+
+    curr = snowflake_session.execute_string("show warehouses")
+    expected = row_from_cursor(curr[-1])
+
+    actual = result.json
+
+    # Check that we have some warehouses returned
+    assert len(actual) > 0, "No warehouses returned by CLI"
+    assert len(expected) > 0, "No warehouses returned by SQL query"
+
+    # Verify the structure is consistent
+    assert actual[0].keys() == expected[0].keys()
+
+    # Find warehouses that exist in both results
+    actual_names = {wh["name"].upper() for wh in actual}
+    expected_names = {wh["name"].upper() for wh in expected}
+
+    # Verify there's at least one common warehouse
+    common_warehouses = actual_names.intersection(expected_names)
+    assert (
+        len(common_warehouses) > 0
+    ), f"No common warehouses found. CLI: {actual_names}, SQL: {expected_names}"
+
+    # Verify that XSMALL warehouse exists (commonly used in tests)
+    if "XSMALL" in expected_names:
+        assert "XSMALL" in actual_names, "XSMALL warehouse not found in CLI results"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Comparing result of `snow object list warehouses` with `show warehouses` is prone to timing issues - another warehouses can be added/removed between the calls - and this test was flaky.

This PR makes it stable.

Closes: #2570 