### PR TITLE
NOSNOW add a global --color flag to disable colored output

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* Added global `--color` flag to control colored console output. Use `--color off` to disable colors.
 
 ## Fixes and improvements
 

--- a/src/snowflake/cli/_app/cli_app.py
+++ b/src/snowflake/cli/_app/cli_app.py
@@ -24,7 +24,6 @@ from typing import Optional
 
 import click
 import typer
-from click import Context as ClickContext
 from snowflake.cli import __about__
 from snowflake.cli._app.commands_registration.commands_registration_with_callbacks import (
     CommandsRegistrationWithCallbacks,
@@ -57,6 +56,7 @@ INTERNAL_CLI_FLAGS = {
     "docs",
     "structure",
     "info",
+    "color",
     "configuration_file",
     "pycharm_debug_library_path",
     "pycharm_debug_server_host",
@@ -79,7 +79,7 @@ class CliAppFactory:
     def __init__(self):
         self._commands_registration = CommandsRegistrationWithCallbacks()
         self._app: Optional[SnowCliMainTyper] = None
-        self._click_context: Optional[ClickContext] = None
+        self._click_context: Optional[click.Context] = None
 
     def _exit_with_cleanup(self):
         self._commands_registration.reset_running_instance_registration_state()
@@ -178,6 +178,25 @@ class CliAppFactory:
 
         return callback
 
+    @staticmethod
+    def _color_callback():
+        def callback(value: str):
+            try:
+                if click.get_current_context().resilient_parsing:
+                    return
+            except RuntimeError:
+                pass
+
+            if value.lower() == "off":
+                # Set NO_COLOR env which Rich check swhen creating console instances.
+                # This must be set before consoles are created, which is why this callback uses is_eager=True.
+                # Note: rich.reconfigure(no_color=True) only affects the default console,
+                # not consoles created by Typer/Click for help formatting, so we use the
+                # env var approach which affects all console instances.
+                os.environ["NO_COLOR"] = "1"
+
+        return callback
+
     def create_or_get_app(self) -> SnowCliMainTyper:
         if self._app:
             return self._app
@@ -234,6 +253,13 @@ class CliAppFactory:
                 "--info",
                 help="Shows information about the Snowflake CLI",
                 callback=self._info_callback(),
+            ),
+            color: str = typer.Option(
+                "auto",
+                "--color",
+                help="Controls colored output. 'auto' (default) auto-detects terminal capabilities, 'off' disables coloring.",
+                callback=self._color_callback(),
+                is_eager=True,
             ),
             configuration_file: Path = typer.Option(
                 None,


### PR DESCRIPTION
When invoked with `--color=off`, the tool will no longer color its output, other formatting (bold, italics) remains unchanged.

We opt for a multi state option, so that it's extensible with other behaviours and themes.

Implementation wise, it seems the most robust way to disable colors is to set `NO_COLOR` env, which then works across all other libraries using `rich`.

### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

