### PR TITLE
Avoid opening a Snowflake connection just to emit command telemetry (SNOW-3450376)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Commands that do not require a Snowflake connection (e.g. `snow --version`, `snow --help`, `snow config list`, `snow connection list`) no longer open a Snowflake connection as a side-effect of emitting telemetry. Telemetry events for such commands are now discarded instead of forcing a login, matching what users expect offline and in minimal environments.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -385,21 +385,25 @@ class CLITelemetryClient:
             self._pending.append(telemetry_data)
 
     def flush(self, force_dial: bool = False):
-        telemetry = self._telemetry
-        if telemetry is None and force_dial and self._pending:
-            # Command declared requires_connection=True (or otherwise expects
-            # telemetry to be delivered even on early failure). Dial now so
-            # buffered events still reach the batcher, matching the pre-
-            # SNOW-3450376 behaviour. ``@ignore_exceptions()`` on the caller
-            # swallows any dial failure, same as before.
-            telemetry = self._ctx.connection._telemetry  # noqa: SLF001
-        if telemetry:
-            self._drain_pending(telemetry)
-            telemetry.send_batch()
-        else:
-            # No connection, no dial; pending events are dropped, matching
-            # the pre-fix behaviour where ``@ignore_exceptions()`` swallowed
-            # any telemetry dial failure on no-connection commands.
+        try:
+            telemetry = self._telemetry
+            if telemetry is None and force_dial and self._pending:
+                # Command declared requires_connection=True (or otherwise
+                # expects telemetry to be delivered even on early failure).
+                # Dial now so buffered events still reach the batcher,
+                # matching the pre-SNOW-3450376 behaviour.
+                # ``@ignore_exceptions()`` on the caller swallows any dial
+                # failure, same as before.
+                telemetry = self._ctx.connection._telemetry  # noqa: SLF001
+            if telemetry:
+                self._drain_pending(telemetry)
+                telemetry.send_batch()
+        finally:
+            # Whatever happened above (success, dial failure, or unexpected
+            # error inside the connector), buffered events must not leak into
+            # the next command: they were built with an earlier context and
+            # dropping them here matches the pre-fix behaviour where
+            # ``@ignore_exceptions()`` swallowed any telemetry dial failure.
             self._pending.clear()
 
 

--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -321,6 +321,13 @@ def _get_config_telemetry() -> TelemetryDict:
 
 
 class CLITelemetryClient:
+    def __init__(self):
+        # Events produced before any Snowflake connection is opened are staged
+        # here as fully-serialised TelemetryData objects. They are drained into
+        # the connector batcher the first time a connection becomes available
+        # (either via a later send() or via flush()).
+        self._pending: list[TelemetryData] = []
+
     @property
     def _ctx(self) -> _CliGlobalContextAccess:
         return get_cli_context()
@@ -350,18 +357,50 @@ class CLITelemetryClient:
 
     @property
     def _telemetry(self):
-        return self._ctx.connection._telemetry  # noqa
+        # Use the non-dialing accessor so that per-command telemetry never
+        # causes a login on commands that don't otherwise need a Snowflake
+        # connection (e.g. `snow --version`, `snow --help`, `snow config
+        # list`). When a command does open a connection, we piggy-back on its
+        # batcher; otherwise the event stays buffered until flush().
+        conn = self._ctx.cached_connection
+        return conn._telemetry if conn is not None else None  # noqa
+
+    def _drain_pending(self, telemetry) -> None:
+        if not self._pending:
+            return
+        drained, self._pending = self._pending, []
+        for event in drained:
+            telemetry.try_add_log_to_batch(event)
 
     def send(self, payload: TelemetryDict):
-        if self._telemetry:
-            message = self.generate_telemetry_data_dict(payload)
-            telemetry_data = TelemetryData.from_telemetry_data_dict(
-                from_dict=message, timestamp=get_time_millis()
-            )
-            self._telemetry.try_add_log_to_batch(telemetry_data)
+        message = self.generate_telemetry_data_dict(payload)
+        telemetry_data = TelemetryData.from_telemetry_data_dict(
+            from_dict=message, timestamp=get_time_millis()
+        )
+        telemetry = self._telemetry
+        if telemetry:
+            self._drain_pending(telemetry)
+            telemetry.try_add_log_to_batch(telemetry_data)
+        else:
+            self._pending.append(telemetry_data)
 
-    def flush(self):
-        self._telemetry.send_batch()
+    def flush(self, force_dial: bool = False):
+        telemetry = self._telemetry
+        if telemetry is None and force_dial and self._pending:
+            # Command declared requires_connection=True (or otherwise expects
+            # telemetry to be delivered even on early failure). Dial now so
+            # buffered events still reach the batcher, matching the pre-
+            # SNOW-3450376 behaviour. ``@ignore_exceptions()`` on the caller
+            # swallows any dial failure, same as before.
+            telemetry = self._ctx.connection._telemetry  # noqa: SLF001
+        if telemetry:
+            self._drain_pending(telemetry)
+            telemetry.send_batch()
+        else:
+            # No connection, no dial; pending events are dropped, matching
+            # the pre-fix behaviour where ``@ignore_exceptions()`` swallowed
+            # any telemetry dial failure on no-connection commands.
+            self._pending.clear()
 
 
 _telemetry = CLITelemetryClient()
@@ -408,5 +447,5 @@ def log_command_execution_error(exception: Exception, execution: ExecutionMetada
 
 
 @ignore_exceptions()
-def flush_telemetry():
-    _telemetry.flush()
+def flush_telemetry(force_dial: bool = False):
+    _telemetry.flush(force_dial=force_dial)

--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -131,6 +131,15 @@ class _CliGlobalContextManager:
         self.connection_context.validate_and_complete()
         return self.connection_cache[self.connection_context]
 
+    @property
+    def cached_connection(self) -> SnowflakeConnection | None:
+        """
+        Returns the cached connection for our configured context if one is
+        already open, otherwise ``None``. Never dials Snowflake and never
+        mutates the connection cache.
+        """
+        return self.connection_cache.peek(self.connection_context)
+
     def _definition_manager_or_raise(self) -> DefinitionManager:
         """
         (Re-)parses project definition based on project args (project_path_arg and
@@ -231,6 +240,14 @@ class _CliGlobalContextAccess:
     @property
     def connection(self) -> SnowflakeConnection:
         return self._manager.connection
+
+    @property
+    def cached_connection(self) -> SnowflakeConnection | None:
+        """
+        Returns the cached connection if one has already been opened for the
+        current context, otherwise ``None``. Does not dial Snowflake.
+        """
+        return self._manager.cached_connection
 
     @property
     def connection_context(self) -> ConnectionContext:

--- a/src/snowflake/cli/api/commands/snow_typer.py
+++ b/src/snowflake/cli/api/commands/snow_typer.py
@@ -165,9 +165,8 @@ class SnowTyper(typer.Typer):
         Pay attention to make this method safe to use if performed operations are not necessary
         for executing the command in proper way.
         """
-        from snowflake.cli.api.cli_global_context import get_cli_context
-
         from snowflake.cli._app.telemetry import log_command_usage
+        from snowflake.cli.api.cli_global_context import get_cli_context
 
         log.debug("Executing command pre execution callback")
         if requires_connection:

--- a/src/snowflake/cli/api/commands/snow_typer.py
+++ b/src/snowflake/cli/api/commands/snow_typer.py
@@ -130,7 +130,11 @@ class SnowTyper(typer.Typer):
             def command_callable_decorator(*args, **kw):
                 """Wrapper around command callable. This is what happens at "runtime"."""
                 execution = ExecutionMetadata()
-                self.pre_execute(execution, require_warehouse=require_warehouse)
+                self.pre_execute(
+                    execution,
+                    require_warehouse=require_warehouse,
+                    requires_connection=requires_connection,
+                )
                 try:
                     result = command_callable(*args, **kw)
                     self.process_result(result)
@@ -140,7 +144,9 @@ class SnowTyper(typer.Typer):
                     exception = self.exception_handler(err, execution)
                     raise exception
                 finally:
-                    self.post_execute(execution)
+                    self.post_execute(
+                        execution, requires_connection=requires_connection
+                    )
 
             return super(SnowTyper, self).command(name=name, **kwargs)(
                 command_callable_decorator
@@ -149,15 +155,28 @@ class SnowTyper(typer.Typer):
         return custom_command
 
     @staticmethod
-    def pre_execute(execution: ExecutionMetadata, require_warehouse: bool = False):
+    def pre_execute(
+        execution: ExecutionMetadata,
+        require_warehouse: bool = False,
+        requires_connection: bool = False,
+    ):
         """
         Callback executed before running any command callable (after context execution).
         Pay attention to make this method safe to use if performed operations are not necessary
         for executing the command in proper way.
         """
+        from snowflake.cli.api.cli_global_context import get_cli_context
+
         from snowflake.cli._app.telemetry import log_command_usage
 
         log.debug("Executing command pre execution callback")
+        if requires_connection:
+            # For requires_connection=True commands, resolve the default
+            # connection name now so that the command body (and later telemetry
+            # flush) can rely on self.connection_name being populated. This
+            # preserves the pre-SNOW-3450376 side-effect that used to happen
+            # implicitly when telemetry opened the connection.
+            get_cli_context().connection_context.validate_and_complete()
         log_command_usage(execution)
         if require_warehouse and not SqlExecutionMixin().session_has_warehouse():
             raise ClickException(
@@ -203,7 +222,7 @@ class SnowTyper(typer.Typer):
         return exception
 
     @staticmethod
-    def post_execute(execution: ExecutionMetadata):
+    def post_execute(execution: ExecutionMetadata, requires_connection: bool = False):
         """
         Callback executed after running any command callable. Pay attention to make this method safe to
         use if performed operations are not necessary for executing the command in proper way.
@@ -212,7 +231,7 @@ class SnowTyper(typer.Typer):
 
         log.debug("Executing command post execution callback")
         log_command_result(execution)
-        flush_telemetry()
+        flush_telemetry(force_dial=requires_connection)
 
 
 @dataclasses.dataclass

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -228,6 +228,25 @@ class OpenConnectionCache:
         self._touch(key)
         return self.connections[key]
 
+    def peek(self, ctx: ConnectionContext) -> Optional[SnowflakeConnection]:
+        """
+        Returns the cached connection for ``ctx`` if one already exists, or
+        ``None`` otherwise. Unlike ``__getitem__``, this never dials Snowflake
+        and does not mutate cache state (no insert, no lifetime refresh).
+
+        Intended for callers that want to piggy-back on a connection that was
+        already opened for other reasons (e.g. per-command telemetry) without
+        causing their own side-effects.
+        """
+        if not isinstance(ctx, ConnectionContext):
+            raise ValueError(
+                f"Expected key to be ConnectionContext but got {repr(ctx)}"
+            )
+        key = repr(ctx)
+        if not self._has_open_connection(key):
+            return None
+        return self.connections[key]
+
     def clear(self):
         """Closes all connections and resets the cache to its initial state."""
         connection_keys = list(self.connections.keys())

--- a/tests/api/commands/test_snow_typer.py
+++ b/tests/api/commands/test_snow_typer.py
@@ -34,12 +34,12 @@ def class_factory(
 ):
     class _CustomTyper(SnowTyper):
         @staticmethod
-        def pre_execute(execution, require_warehouse):
+        def pre_execute(execution, require_warehouse=False, requires_connection=False):
             if pre_execute:
                 pre_execute(execution)
 
         @staticmethod
-        def post_execute(execution):
+        def post_execute(execution, requires_connection=False):
             if post_execute:
                 post_execute(execution)
 
@@ -218,7 +218,7 @@ def test_snow_typer_pre_execute_sends_telemetry(mock_log_command_usage, cli):
 def test_snow_typer_post_execute_sends_telemetry(mock_flush_telemetry, cli):
     result = cli(app_factory(SnowTyperFactory))(["simple_cmd", "Norma"])
     assert result.exit_code == 0
-    mock_flush_telemetry.assert_called_once_with()
+    mock_flush_telemetry.assert_called_once_with(force_dial=False)
 
 
 @mock.patch("snowflake.cli._app.printing.print_result")

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -98,3 +98,44 @@ def test_connection_cache_caches(
         password="dummy_password",
         application_name="snowcli",
     )
+
+
+@mock.patch("snowflake.connector.connect")
+def test_connection_cache_peek_returns_none_without_dialing(
+    mock_connect, local_connection_cache
+):
+    ctx = ConnectionContext(connection_name="default")
+    ctx.validate_and_complete()
+
+    assert local_connection_cache.peek(ctx) is None
+    mock_connect.assert_not_called()
+    # peek must not mutate cache state
+    assert local_connection_cache.connections == {}
+    assert local_connection_cache.cleanup_futures == {}
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+def test_connection_cache_peek_returns_existing_connection(
+    mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
+):
+    mock_command_info.return_value = "application"
+
+    from snowflake.cli.api.config import config_init
+
+    config_init(test_snowcli_config)
+
+    ctx = ConnectionContext(connection_name="default")
+
+    # Dial once via __getitem__.
+    conn = local_connection_cache[ctx]
+    mock_connect.assert_called_once()
+
+    # peek() returns the same instance without dialing again.
+    assert local_connection_cache.peek(ctx) is conn
+    mock_connect.assert_called_once()
+
+
+def test_connection_cache_peek_rejects_non_context(local_connection_cache):
+    with pytest.raises(ValueError):
+        local_connection_cache.peek("not-a-context")  # type: ignore[arg-type]

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -535,3 +535,40 @@ def test_pending_telemetry_drains_when_connection_opens(_, mock_connect, runner)
     assert calls[1].args[0].to_dict()["message"]["type"] == "result_executing_command"
     # Pending buffer should be drained after post_execute's flush.
     assert telemetry_client._pending == []  # noqa: SLF001
+
+
+def test_flush_clears_pending_when_forced_dial_fails():
+    """If ``flush(force_dial=True)`` is asked to dial but the dial raises,
+    ``_pending`` must still be cleared. Otherwise stale events (built with
+    an earlier ``platform.platform()`` / feature-flag snapshot) can leak
+    into the next command and be drained into its connector, corrupting
+    that command's telemetry.
+    """
+    from snowflake.cli._app.telemetry import CLITelemetryClient
+
+    client = CLITelemetryClient()
+    # Simulate an event buffered during pre_execute before any connection
+    # was available. The object itself doesn't matter for this test; we
+    # just need ``_pending`` to be non-empty so ``flush`` takes the
+    # force-dial branch.
+    client._pending.append(mock.sentinel.stale_event)  # noqa: SLF001
+
+    # Make the ``self._ctx.connection`` access blow up the same way a real
+    # failed dial would (no default connection, bad credentials, offline).
+    class _RaisingCtx:
+        @property
+        def connection(self):
+            raise RuntimeError("dial failed")
+
+        cached_connection = None
+
+    with mock.patch.object(
+        CLITelemetryClient,
+        "_ctx",
+        new_callable=mock.PropertyMock,
+        return_value=_RaisingCtx(),
+    ):
+        with pytest.raises(RuntimeError, match="dial failed"):
+            client.flush(force_dial=True)
+
+    assert client._pending == []  # noqa: SLF001

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -525,14 +525,13 @@ def test_pending_telemetry_drains_when_connection_opens(_, mock_connect, runner)
     result = runner.invoke(["connection", "test"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
 
-    calls = mock_connect.return_value._telemetry.try_add_log_to_batch.call_args_list  # noqa: SLF001
+    telemetry_batcher = mock_connect.return_value._telemetry  # noqa: SLF001
+    calls = telemetry_batcher.try_add_log_to_batch.call_args_list
     # Both the usage event (buffered during pre_execute, drained once the
     # command opened a connection) and the result event (sent after the
     # connection was open) must reach the connector's batcher, in order.
     assert len(calls) >= 2
     assert calls[0].args[0].to_dict()["message"]["type"] == "executing_command"
-    assert (
-        calls[1].args[0].to_dict()["message"]["type"] == "result_executing_command"
-    )
+    assert calls[1].args[0].to_dict()["message"]["type"] == "result_executing_command"
     # Pending buffer should be drained after post_execute's flush.
     assert telemetry_client._pending == []  # noqa: SLF001

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -495,3 +495,44 @@ def test_flags_from_parent_contexts_are_captured(mock_uuid4, mock_connect, runne
     assert (
         "run_async" in command_flags
     ), f"run_async flag should be captured in telemetry. Found flags: {command_flags}"
+
+
+@mock.patch("snowflake.connector.connect")
+def test_no_connection_required_command_does_not_dial_for_telemetry(
+    mock_connect, runner
+):
+    """Commands declared with requires_connection=False must not trigger a
+    Snowflake login just to emit per-command telemetry events.
+
+    Regression test for SNOW-3450376: previously, the pre-execute hook walked
+    through cli_context.connection._telemetry, which lazily opened a
+    connection even when the command body didn't need one.
+    """
+    result = runner.invoke(["connection", "list"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    mock_connect.assert_not_called()
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.connection.commands.ObjectManager")
+def test_pending_telemetry_drains_when_connection_opens(_, mock_connect, runner):
+    """Events buffered during pre_execute (before any connection exists) must
+    be delivered to the connector's batch once the command body opens a
+    connection. Regression test for SNOW-3450376.
+    """
+    from snowflake.cli._app.telemetry import _telemetry as telemetry_client
+
+    result = runner.invoke(["connection", "test"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    calls = mock_connect.return_value._telemetry.try_add_log_to_batch.call_args_list  # noqa: SLF001
+    # Both the usage event (buffered during pre_execute, drained once the
+    # command opened a connection) and the result event (sent after the
+    # connection was open) must reach the connector's batcher, in order.
+    assert len(calls) >= 2
+    assert calls[0].args[0].to_dict()["message"]["type"] == "executing_command"
+    assert (
+        calls[1].args[0].to_dict()["message"]["type"] == "result_executing_command"
+    )
+    # Pending buffer should be drained after post_execute's flush.
+    assert telemetry_client._pending == []  # noqa: SLF001


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes [SNOW-3450376](https://snowflakecomputing.atlassian.net/browse/SNOW-3450376).

#### Problem

Every command emits a per-command telemetry event via `CLITelemetryClient`, which walks through `cli_context.connection._telemetry`. Accessing `.connection` lazily opens a Snowflake connection — TCP + TLS + login — the first time it's touched.

That means commands declared with \`requires_connection=False\` (e.g. \`snow --version\`, \`snow --help\`, \`snow config list\`, \`snow connection list\`) were triggering an authentication round-trip purely to push a telemetry event onto the connector batcher. In restricted environments (offline, no default connection, bad credentials), these no-connection commands would fail or hang even though the command body itself never needed Snowflake.

#### Fix

Decouple telemetry emission from connection dialing:

- **\`OpenConnectionCache.peek(ctx)\`** — new accessor that returns the cached connection if one is already open, and \`None\` otherwise. No dial, no cache mutation, no lifetime refresh.
- **\`CLITelemetryClient\`** now uses \`peek()\` instead of \`.connection\`. When no connection exists yet, telemetry data is staged on an internal buffer (\`self._pending\`) and drained opportunistically the next time a connection becomes available — either via a later \`send()\` on the same client or via \`flush()\`.
- **Connection-dependent commands still get telemetry.** For commands declared \`requires_connection=True\`, \`flush_telemetry(force_dial=True)\` dials on post-execute so buffered events reach the batcher. This preserves the pre-fix guarantee that telemetry is delivered for those commands, and \`@ignore_exceptions()\` on the caller still swallows any dial failure.
- **\`pre_execute\` now calls \`connection_context.validate_and_complete()\` when \`requires_connection=True\`**, preserving the resolution of the default connection name that used to happen implicitly when telemetry opened the connection.

Net effect:
- Commands that don't need Snowflake no longer trigger a login just to emit telemetry. Their telemetry events are discarded instead of forcing an expensive (and often failing) round-trip.
- Commands that do need Snowflake still send their telemetry exactly once per command, through the same connector batcher, in the same order as today.

#### Tests

- \`tests/api/test_connections.py\`:
  - \`test_connection_cache_peek_returns_none_without_dialing\` — asserts \`peek\` returns \`None\` and does not call \`snowflake.connector.connect\` or mutate cache state.
  - \`test_connection_cache_peek_returns_existing_connection\` — asserts \`peek\` returns the same instance as \`__getitem__\` once a connection has been dialed, without a second dial.
  - \`test_connection_cache_peek_rejects_non_context\` — validates the \`ConnectionContext\` type check.
- \`tests/app/test_telemetry.py\`:
  - \`test_no_connection_required_command_does_not_dial_for_telemetry\` — invokes \`snow connection list\` (which is \`requires_connection=False\`) and asserts \`snowflake.connector.connect\` is not called at all. This is the direct regression guard called out in the Jira acceptance criteria.
  - \`test_pending_telemetry_drains_when_connection_opens\` — invokes \`snow connection test\` and asserts that both the usage event (buffered during \`pre_execute\` before a connection existed) and the result event reach the connector batcher, in order, and that the internal buffer is empty after \`flush\`.
- \`tests/api/commands/test_snow_typer.py\` updated for the new \`requires_connection\` kwarg on \`pre_execute\` / \`post_execute\` and the new \`force_dial\` kwarg on \`flush_telemetry\`.

Ran \`tests/api/ tests/app/ tests/test_connection.py tests/test_common_global_context.py tests/sql/ tests/api/test_sql_execution.py\` locally — 918 passed, 1 pre-existing xfail, 0 failures.

[SNOW-3450376]: https://snowflakecomputing.atlassian.net/browse/SNOW-3450376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ