### PR TITLE
fix: restrict SnowSQL `&var` template to word boundaries (#2714)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Upgraded `snowflake-connector-python` from 4.5.0 to 4.6.0.
 * `snow dcm list-deployments` and `snow dcm drop-deployment` now wrap the project name in `IDENTIFIER(...)`, matching every other DCM subcommand. Fully-qualified and quoted project names are now handled consistently.
 * Fixed `snow sql` table output rendering as a series of `|` characters when selecting many columns into a non-terminal destination (e.g. piped or redirected output).
+* Fixed `snow sql` treating `&` inside words (e.g. `Principal&Interest` in a comment or semantic view synonym) as a SnowSQL template variable, which caused rendering to fail with `'Interest' is undefined`. The legacy `&var` template delimiter is now only recognised at the start of the input or after a non-word character.
 
 
 # v3.19.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## Fixes and improvements
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed `snow sql` treating `&` inside words (e.g. `Principal&Interest` in a comment or semantic view synonym) as a SnowSQL template variable, which caused rendering to fail with `'Interest' is undefined`. The legacy `&var` template delimiter is now only recognised at the start of the input or after a non-word character.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/sql/snowsql_templating.py
+++ b/src/snowflake/cli/_plugins/sql/snowsql_templating.py
@@ -17,6 +17,20 @@ import string
 
 class _SnowSQLTemplate(string.Template):
     delimiter = "&"
+    # Only recognise `&` as a template delimiter when it appears at the start of
+    # the text or after a non-word character.  This prevents false matches
+    # inside words or identifiers (e.g. `Principal&Interest` embedded in a DDL
+    # COMMENT or semantic view synonym), which would otherwise be rewritten to
+    # `Principal&{ Interest }` and fail Jinja rendering.  See #2714.
+    pattern = r"""
+        (?:^|(?<=\W))
+        \&(?:
+            (?P<escaped>\&)                      |   # escape sequence (&&)
+            (?P<named>(?a:[_a-z][_a-z0-9]*))     |   # delimiter and a Python identifier
+            {(?P<braced>(?a:[_a-z][_a-z0-9]*))}  |   # delimiter and a braced identifier
+            (?P<invalid>)                            # other ill-formed delimiter exprs
+        )
+    """
 
 
 class _Mapper:

--- a/src/snowflake/cli/_plugins/sql/snowsql_templating.py
+++ b/src/snowflake/cli/_plugins/sql/snowsql_templating.py
@@ -30,7 +30,7 @@ class _SnowSQLTemplate(string.Template):
             {(?P<braced>(?a:[_a-z][_a-z0-9]*))}  |   # delimiter and a braced identifier
             (?P<invalid>)                            # other ill-formed delimiter exprs
         )
-    """
+    """  # type: ignore[assignment]
 
 
 class _Mapper:

--- a/src/snowflake/cli/_plugins/sql/snowsql_templating.py
+++ b/src/snowflake/cli/_plugins/sql/snowsql_templating.py
@@ -17,13 +17,16 @@ import string
 
 class _SnowSQLTemplate(string.Template):
     delimiter = "&"
-    # Only recognise `&` as a template delimiter when it appears at the start of
-    # the text or after a non-word character.  This prevents false matches
-    # inside words or identifiers (e.g. `Principal&Interest` embedded in a DDL
-    # COMMENT or semantic view synonym), which would otherwise be rewritten to
+    # Do not recognise `&` as a template delimiter when the preceding character
+    # is a letter or digit.  This prevents false matches inside words or
+    # identifiers (e.g. `Principal&Interest` embedded in a DDL COMMENT or
+    # semantic view synonym), which would otherwise be rewritten to
     # `Principal&{ Interest }` and fail Jinja rendering.  See #2714.
+    # Underscore is intentionally NOT treated as a separator character —
+    # e.g. `source_&value.sql` (a filename passed to `!source`) still
+    # substitutes `&value`.
     pattern = r"""
-        (?:^|(?<=\W))
+        (?<![A-Za-z0-9])
         \&(?:
             (?P<escaped>\&)                      |   # escape sequence (&&)
             (?P<named>(?a:[_a-z][_a-z0-9]*))     |   # delimiter and a Python identifier

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -391,6 +391,20 @@ def test_execution_fails_if_unknown_variable(runner, query):
         # Test templating is ignored
         ("&{ foo }", "&{ foo }"),
         ("select *  from &{ foo } join bar", "select *  from &{ foo } join bar"),
+        # `&` embedded in a word must not be treated as a delimiter (#2714):
+        # SnowCLI was rewriting `Principal&Interest` to `Principal&{ Interest }`,
+        # which then failed Jinja rendering because `Interest` was undefined.
+        ("Principal&Interest payment", "Principal&Interest payment"),
+        ("'P&I'", "'P&I'"),
+        ("COMMENT = 'principal&interest'", "COMMENT = 'principal&interest'"),
+        ("foo&bar", "foo&bar"),
+        # Preceded by a digit (also a word character) — still should not match.
+        ("1&foo", "1&foo"),
+        # Preceded by underscore (word character) — should not match.
+        ("a_&foo", "a_&foo"),
+        # Preceded by a non-word character — should still substitute.
+        ("(&foo)", "(&{ foo })"),
+        ("'&foo'", "'&{ foo }'"),
     ],
 )
 def test_snowsql_compatibility(text, expected):

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -398,11 +398,12 @@ def test_execution_fails_if_unknown_variable(runner, query):
         ("'P&I'", "'P&I'"),
         ("COMMENT = 'principal&interest'", "COMMENT = 'principal&interest'"),
         ("foo&bar", "foo&bar"),
-        # Preceded by a digit (also a word character) — still should not match.
+        # Preceded by a digit — still should not match.
         ("1&foo", "1&foo"),
-        # Preceded by underscore (word character) — should not match.
-        ("a_&foo", "a_&foo"),
-        # Preceded by a non-word character — should still substitute.
+        # Preceded by a non-alphanumeric character — should still substitute.
+        # Underscore counts as a separator here so that filenames like
+        # `source_&value.sql` passed to `!source` still get templated.
+        ("a_&foo", "a_&{ foo }"),
         ("(&foo)", "(&{ foo })"),
         ("'&foo'", "'&{ foo }'"),
     ],


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes #2714.

`snow sql` transpiles SnowSQL-style legacy templates (`&var`) into the
standard `&{ var }` form before passing the query to Jinja. The
transpiler is a thin wrapper around `string.Template` with `&` as the
delimiter. `string.Template` does not require any word boundary before
the delimiter, so `&` matched inside words as well — and
`Principal&Interest` in a DDL `COMMENT` or semantic view synonym was
being rewritten to `Principal&{ Interest }`, which then failed Jinja
rendering with `'Interest' is undefined`.

### Repro

Before this change, running `snow sql` on a file containing the
reported DDL produced `SQL template rendering error: 'Interest' is
undefined` when the synonym or comment contained `Principal&Interest`
(no surrounding whitespace). `Principal & Interest` was unaffected
because the template engine requires an identifier start immediately
after `&`.

Minimal Python repro:

```python
>>> from snowflake.cli._plugins.sql.snowsql_templating import transpile_snowsql_templates
>>> transpile_snowsql_templates("Principal&Interest payment")  # before
'Principal&{ Interest } payment'
```

### Fix

Override `_SnowSQLTemplate.pattern` so `&` is only recognised as a
template delimiter at the **start of the input** or **after a non-word
character**:

```python
class _SnowSQLTemplate(string.Template):
    delimiter = "&"
    pattern = r"""
        (?:^|(?<=\W))
        \&(?:
            (?P<escaped>\&)                      |   # escape sequence (&&)
            (?P<named>(?a:[_a-z][_a-z0-9]*))     |   # delimiter and a Python identifier
            {(?P<braced>(?a:[_a-z][_a-z0-9]*))}  |   # delimiter and a braced identifier
            (?P<invalid>)                            # other ill-formed delimiter exprs
        )
    """
```

This preserves every existing SnowSQL substitution — `&foo`,
`select * from &foo`, the `&&` escape, already-rendered `&{ foo }` —
while leaving `&` embedded in identifiers, string literals, and
comments alone.

### Tests

Extended the existing `test_snowsql_compatibility` parametrize in
`tests/sql/test_sql.py` with the reported cases plus a few adjacent
ones (`Principal&Interest`, `'P&I'`, `foo&bar`, `1&foo`, `a_&foo`,
`(&foo)`, `'&foo'`). All previously asserted transpile behaviour is
retained.

`pytest tests/sql/ tests/api/test_rendering.py tests/output/` — 293
passed locally.