### PR TITLE
fix: [SNOW-3066557] read SQL files as UTF-8

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed `snow sql -f` and `!source` failing with `UnicodeDecodeError` when reading UTF-8 SQL files on platforms whose default locale encoding is not UTF-8 (e.g. cp932 on Japanese Windows). SQL files are now always decoded as UTF-8.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/sql/statement_reader.py
+++ b/src/snowflake/cli/_plugins/sql/statement_reader.py
@@ -214,7 +214,7 @@ class ParsedStatement:
         path = SecurePath(stripped_comments_path_part)
 
         if path.is_file():
-            payload = path.read_text(file_size_limit_mb=UNLIMITED)
+            payload = path.read_text(file_size_limit_mb=UNLIMITED, encoding="utf-8")
             return cls(payload, StatementType.FILE, path.as_posix())
 
         error_msg = f"Could not read: {path_part}"
@@ -334,7 +334,7 @@ def files_reader(
 
     Returns a generator with statements."""
     for path in paths:
-        with path.open(read_file_limit_mb=UNLIMITED) as f:
+        with path.open(read_file_limit_mb=UNLIMITED, encoding="utf-8") as f:
             content = f.read()
             if pre_render:
                 content = pre_render(content)

--- a/tests/sql/test_statement_reader.py
+++ b/tests/sql/test_statement_reader.py
@@ -184,6 +184,41 @@ def test_read_files(tmp_path_factory: pytest.TempPathFactory):
     ]
 
 
+def test_read_files_utf8(tmp_path_factory: pytest.TempPathFactory):
+    # Regression: SQL files must be read as UTF-8 regardless of platform locale
+    # (e.g. cp932 on Japanese Windows). The bytes below are valid UTF-8 but
+    # would either fail to decode or decode to garbage under cp932/cp1252.
+    f1 = tmp_path_factory.mktemp("utf8") / "f1.sql"
+    f1.write_bytes("select '日本語' as 列;".encode("utf-8"))
+    f2 = tmp_path_factory.mktemp("utf8") / "f2.sql"
+    f2.write_bytes("-- コメント\nselect 'café' as colonne;".encode("utf-8"))
+
+    files = (SecurePath(f1), SecurePath(f2))
+    errors, cnt, compiled = compile_statements(
+        files_reader(files, WORKING_OPERATOR_FUNCS),
+    )
+
+    assert not errors, errors
+    assert cnt == 2
+    assert compiled == [
+        CompiledStatement(statement="select '日本語' as 列;"),
+        CompiledStatement(statement="-- コメント\nselect 'café' as colonne;"),
+    ]
+
+
+def test_source_file_utf8(tmp_path_factory: pytest.TempPathFactory):
+    # Files loaded via !source must also be decoded as UTF-8.
+    f1 = tmp_path_factory.mktemp("utf8_source") / "f1.sql"
+    f1.write_bytes("select '日本語';".encode("utf-8"))
+
+    source = query_reader(f"!source {f1.as_posix()};", WORKING_OPERATOR_FUNCS)
+    errors, cnt, compiled = compile_statements(source)
+
+    assert not errors, errors
+    assert cnt == 1
+    assert compiled == [CompiledStatement(statement="select '日本語';")]
+
+
 def test_parsed_source_repr():
     query = "select 1;"
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes #2759 / SNOW-3066557.

`snow sql -f <file>` and the REPL `!source <file>` command both read SQL files with Python's locale-default encoding. On platforms whose default is not UTF-8 — notably cp932 on Japanese Windows, and cp1252 in several Western European locales — a UTF-8 SQL file containing any non-ASCII character raises `UnicodeDecodeError`:

```
UnicodeDecodeError: 'cp932' codec can't decode byte 0xe3 in position 42: illegal multibyte sequence
```

PyApp-bundled Python ignores `PYTHONUTF8` / `PYTHONIOENCODING`, so affected users had no workaround short of re-encoding every SQL file on disk.

**Fix:** pass `encoding="utf-8"` at the two file-read sites in `src/snowflake/cli/_plugins/sql/statement_reader.py`:
- `ParsedStatement.from_file` (used by `!source`, line 217) — `path.read_text(file_size_limit_mb=UNLIMITED, encoding="utf-8")`
- `files_reader` (used by `snow sql -f`, line 337) — `path.open(read_file_limit_mb=UNLIMITED, encoding="utf-8")`

`SecurePath.read_text` and `SecurePath.open` already forward `*args`/`**kwargs` to the underlying `pathlib.Path` methods, so the change is two keyword arguments — no API surface change.

**Scope:** UTF-8 is already the documented and expected encoding for SQL sources across the Snowflake ecosystem (Snowflake stages, the Python connector's `execute_stream`, and SnowSQL all default to or require UTF-8). This PR brings the CLI in line with that expectation. Non-UTF-8 SQL files (if any) will now fail with a clear `UnicodeDecodeError` at read time rather than silently mis-decoding — this matches the Snowflake ecosystem's behavior and is strictly safer.

**Tests:** added `test_read_files_utf8` and `test_source_file_utf8` in `tests/sql/test_statement_reader.py`, which write UTF-8 bytes containing Japanese (`日本語`, `列`, `コメント`) and Latin-1 (`café`) characters and assert both `files_reader` and `!source` (via `query_reader`) decode them correctly. All existing tests in `tests/sql/test_statement_reader.py` continue to pass (52 passed).