### PR TITLE
fix: recognize localized Windows account names in permission whitelist (SNOW-3018675)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fix the spurious `Unauthorized users have access to configuration file` warning on non-English Windows installations. The built-in `SYSTEM` and `Administrators` accounts are now resolved from their well-known SIDs at runtime, so the localized names (e.g. `Système`/`Administrateurs` on French Windows) are recognized alongside the English names.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/secure_utils.py
+++ b/src/snowflake/cli/api/secure_utils.py
@@ -15,25 +15,125 @@
 import logging
 import stat
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from snowflake.connector.compat import IS_WINDOWS
 
 log = logging.getLogger(__name__)
+
+# Well-known Windows SIDs whose display names are localized per system language
+# (e.g. "SYSTEM" / "Administrators" in English, "Système" / "Administrateurs"
+# in French, "системный" / "Администраторы" in Russian). Resolving them at
+# runtime keeps the whitelist correct on non-English Windows installations.
+# https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+_LOCAL_SYSTEM_SID = "S-1-5-18"
+_BUILTIN_ADMINISTRATORS_SID = "S-1-5-32-544"
+
+# English fallbacks used if the Windows API call fails (or when running under
+# a stubbed API in tests). These match the pre-i18n behavior.
+_LOCAL_SYSTEM_FALLBACK_NAME = "SYSTEM"
+_BUILTIN_ADMINISTRATORS_FALLBACK_NAME = "Administrators"
+
+
+def _lookup_windows_sid_account_name(sid_str: str) -> Optional[str]:
+    """Resolve a well-known SID string to its localized account name via the
+    Windows API, or ``None`` if resolution fails.
+
+    Uses ``ctypes`` rather than ``pywin32`` so we don't add a new runtime
+    dependency. Only called on Windows.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:  # pragma: no cover - ctypes is part of stdlib
+        return None
+
+    try:
+        advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)  # type: ignore[attr-defined]
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    except (AttributeError, OSError):
+        # WinDLL is missing on non-Windows, and loading can fail under unusual
+        # runtimes. Fall back to the caller-supplied default in both cases.
+        return None
+
+    convert_string_sid_to_sid = advapi32.ConvertStringSidToSidW
+    convert_string_sid_to_sid.argtypes = [
+        wintypes.LPCWSTR,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    convert_string_sid_to_sid.restype = wintypes.BOOL
+
+    lookup_account_sid = advapi32.LookupAccountSidW
+    lookup_account_sid.argtypes = [
+        wintypes.LPCWSTR,
+        ctypes.c_void_p,
+        wintypes.LPWSTR,
+        wintypes.LPDWORD,
+        wintypes.LPWSTR,
+        wintypes.LPDWORD,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    lookup_account_sid.restype = wintypes.BOOL
+
+    local_free = kernel32.LocalFree
+    local_free.argtypes = [wintypes.HLOCAL]
+
+    sid = ctypes.c_void_p()
+    if not convert_string_sid_to_sid(sid_str, ctypes.byref(sid)):
+        return None
+
+    try:
+        name_size = wintypes.DWORD(256)
+        domain_size = wintypes.DWORD(256)
+        name = ctypes.create_unicode_buffer(name_size.value)
+        domain = ctypes.create_unicode_buffer(domain_size.value)
+        sid_name_use = wintypes.DWORD()
+        if not lookup_account_sid(
+            None,
+            sid,
+            name,
+            ctypes.byref(name_size),
+            domain,
+            ctypes.byref(domain_size),
+            ctypes.byref(sid_name_use),
+        ):
+            return None
+        return name.value or None
+    finally:
+        local_free(sid)
 
 
 def _get_windows_whitelisted_users():
     # whitelisted users list obtained in consultation with prodsec: CASEC-9627
     import os
 
-    return [
-        "SYSTEM",
-        "Administrators",
+    system_name = (
+        _lookup_windows_sid_account_name(_LOCAL_SYSTEM_SID)
+        or _LOCAL_SYSTEM_FALLBACK_NAME
+    )
+    admins_name = (
+        _lookup_windows_sid_account_name(_BUILTIN_ADMINISTRATORS_SID)
+        or _BUILTIN_ADMINISTRATORS_FALLBACK_NAME
+    )
+
+    whitelisted = [
+        system_name,
+        admins_name,
         "Network",
         "Domain Admins",
         "Domain Users",
         os.getlogin(),
     ]
+
+    # Keep the English names too, so administrators who have mixed-language
+    # inventories still pass the whitelist if a host returns English names
+    # under a non-English locale.
+    if system_name != _LOCAL_SYSTEM_FALLBACK_NAME:
+        whitelisted.append(_LOCAL_SYSTEM_FALLBACK_NAME)
+    if admins_name != _BUILTIN_ADMINISTRATORS_FALLBACK_NAME:
+        whitelisted.append(_BUILTIN_ADMINISTRATORS_FALLBACK_NAME)
+
+    return whitelisted
 
 
 def _run_icacls(file_path: Path) -> str:

--- a/tests/api/test_secure_utils.py
+++ b/tests/api/test_secure_utils.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from snowflake.cli.api import secure_utils
+from snowflake.cli.api.secure_utils import (
+    _BUILTIN_ADMINISTRATORS_FALLBACK_NAME,
+    _BUILTIN_ADMINISTRATORS_SID,
+    _LOCAL_SYSTEM_FALLBACK_NAME,
+    _LOCAL_SYSTEM_SID,
+    _get_windows_whitelisted_users,
+    windows_get_not_whitelisted_users_with_access,
+)
+
+
+@pytest.fixture
+def fake_getlogin():
+    with mock.patch.object(secure_utils, "_get_windows_whitelisted_users") as _:
+        pass
+    # Actually just patch os.getlogin via a fresh patcher each test.
+    with mock.patch("os.getlogin", return_value="testuser") as m:
+        yield m
+
+
+def _patch_sid_lookup(mapping):
+    """Patch ``_lookup_windows_sid_account_name`` to return names from a dict.
+
+    Unmapped SIDs resolve to ``None`` so the production fallback path runs.
+    """
+    return mock.patch.object(
+        secure_utils,
+        "_lookup_windows_sid_account_name",
+        side_effect=lambda sid: mapping.get(sid),
+    )
+
+
+def test_whitelisted_users_includes_english_names_on_english_windows(fake_getlogin):
+    """On English Windows, resolved names match the English fallbacks, and the
+    whitelist contains the expected set with no duplicates."""
+    mapping = {
+        _LOCAL_SYSTEM_SID: "SYSTEM",
+        _BUILTIN_ADMINISTRATORS_SID: "Administrators",
+    }
+    with _patch_sid_lookup(mapping):
+        users = _get_windows_whitelisted_users()
+
+    assert "SYSTEM" in users
+    assert "Administrators" in users
+    assert "Network" in users
+    assert "Domain Admins" in users
+    assert "Domain Users" in users
+    assert "testuser" in users
+    # No duplicates: the English fallbacks should not be appended a second time
+    # when the resolved names already match.
+    assert users.count("SYSTEM") == 1
+    assert users.count("Administrators") == 1
+
+
+def test_whitelisted_users_includes_localized_names_on_french_windows(fake_getlogin):
+    """On French Windows, the localized names are whitelisted alongside the
+    English fallbacks so mixed-language inventories still pass."""
+    mapping = {
+        _LOCAL_SYSTEM_SID: "Système",
+        _BUILTIN_ADMINISTRATORS_SID: "Administrateurs",
+    }
+    with _patch_sid_lookup(mapping):
+        users = _get_windows_whitelisted_users()
+
+    assert "Système" in users
+    assert "Administrateurs" in users
+    # English fallbacks are preserved to avoid regressing mixed-language setups.
+    assert "SYSTEM" in users
+    assert "Administrators" in users
+    assert "testuser" in users
+
+
+def test_whitelisted_users_falls_back_when_sid_lookup_fails(fake_getlogin):
+    """If the SID cannot be resolved (API failure, non-Windows host), fall
+    back to the English names so the whitelist never ends up empty."""
+    with _patch_sid_lookup({}):  # every lookup returns None
+        users = _get_windows_whitelisted_users()
+
+    assert _LOCAL_SYSTEM_FALLBACK_NAME in users
+    assert _BUILTIN_ADMINISTRATORS_FALLBACK_NAME in users
+
+
+def test_not_whitelisted_users_on_french_windows_does_not_flag_localized_admins(
+    fake_getlogin,
+):
+    """Regression test for SNOW-3018675 / #2743: on French Windows, the
+    ``Administrateurs`` group reported by ``icacls`` must not appear in the
+    unauthorized-users list."""
+    icacls_output = (
+        r"C:\Users\testuser\.snowflake\config.toml AUTORITE NT\Système:(I)(F)"
+        "\n"
+        r"                                         BUILTIN\Administrateurs:(I)(F)"
+        "\n"
+        r"                                         DESKTOP-ABC\testuser:(I)(F)"
+        "\n"
+    )
+    mapping = {
+        _LOCAL_SYSTEM_SID: "Système",
+        _BUILTIN_ADMINISTRATORS_SID: "Administrateurs",
+    }
+    with _patch_sid_lookup(mapping), mock.patch.object(
+        secure_utils, "_run_icacls", return_value=icacls_output
+    ):
+        result = windows_get_not_whitelisted_users_with_access(
+            Path(r"C:\Users\testuser\.snowflake\config.toml")
+        )
+
+    assert result == []
+
+
+def test_not_whitelisted_users_on_english_windows_unchanged(fake_getlogin):
+    """Pre-existing English-Windows behavior must still pass."""
+    icacls_output = (
+        r"C:\Users\testuser\.snowflake\config.toml NT AUTHORITY\SYSTEM:(I)(F)"
+        "\n"
+        r"                                         BUILTIN\Administrators:(I)(F)"
+        "\n"
+        r"                                         DESKTOP-ABC\testuser:(I)(F)"
+        "\n"
+    )
+    mapping = {
+        _LOCAL_SYSTEM_SID: "SYSTEM",
+        _BUILTIN_ADMINISTRATORS_SID: "Administrators",
+    }
+    with _patch_sid_lookup(mapping), mock.patch.object(
+        secure_utils, "_run_icacls", return_value=icacls_output
+    ):
+        result = windows_get_not_whitelisted_users_with_access(
+            Path(r"C:\Users\testuser\.snowflake\config.toml")
+        )
+
+    assert result == []
+
+
+def test_not_whitelisted_users_still_detects_unauthorized_user(fake_getlogin):
+    """A genuinely unauthorized user must still surface in the warning list."""
+    icacls_output = (
+        r"C:\Users\testuser\.snowflake\config.toml NT AUTHORITY\SYSTEM:(I)(F)"
+        "\n"
+        r"                                         BUILTIN\Administrators:(I)(F)"
+        "\n"
+        r"                                         DESKTOP-ABC\attacker:(I)(F)"
+        "\n"
+    )
+    mapping = {
+        _LOCAL_SYSTEM_SID: "SYSTEM",
+        _BUILTIN_ADMINISTRATORS_SID: "Administrators",
+    }
+    with _patch_sid_lookup(mapping), mock.patch.object(
+        secure_utils, "_run_icacls", return_value=icacls_output
+    ):
+        result = windows_get_not_whitelisted_users_with_access(
+            Path(r"C:\Users\testuser\.snowflake\config.toml")
+        )
+
+    assert result == ["attacker"]
+
+
+def test_sid_lookup_returns_none_on_non_windows():
+    """On non-Windows hosts, ``_lookup_windows_sid_account_name`` must return
+    ``None`` without raising (ctypes.WinDLL is not available)."""
+    # Call the real implementation — on Linux CI, WinDLL does not exist, so
+    # the helper should return None rather than propagate the AttributeError.
+    import sys
+
+    if sys.platform == "win32":
+        pytest.skip("This test covers non-Windows fallback behavior.")
+
+    assert secure_utils._lookup_windows_sid_account_name(_LOCAL_SYSTEM_SID) is None

--- a/tests/api/test_secure_utils.py
+++ b/tests/api/test_secure_utils.py
@@ -23,6 +23,7 @@ from snowflake.cli.api.secure_utils import (
     _LOCAL_SYSTEM_FALLBACK_NAME,
     _LOCAL_SYSTEM_SID,
     _get_windows_whitelisted_users,
+    _lookup_windows_sid_account_name,
     windows_get_not_whitelisted_users_with_access,
 )
 
@@ -184,4 +185,4 @@ def test_sid_lookup_returns_none_on_non_windows():
     if sys.platform == "win32":
         pytest.skip("This test covers non-Windows fallback behavior.")
 
-    assert secure_utils._lookup_windows_sid_account_name(_LOCAL_SYSTEM_SID) is None
+    assert _lookup_windows_sid_account_name(_LOCAL_SYSTEM_SID) is None


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes #2743 / SNOW-3018675.

On non-English Windows installations, `icacls` reports the built-in
`LocalSystem` and `BuiltinAdministrators` accounts under their localized
names (e.g. `AUTORITE NT\Système` / `BUILTIN\Administrateurs` on French
Windows). The whitelist in `secure_utils._get_windows_whitelisted_users`
was hardcoded to the English names `"SYSTEM"` and `"Administrators"`, so
these accounts were incorrectly flagged as unauthorized and users saw a
spurious `Unauthorized users [...] have access to configuration file`
warning on every CLI invocation.

**Fix:** resolve the well-known SIDs at runtime via the Windows API:

- `S-1-5-18` → LocalSystem
- `S-1-5-32-544` → BuiltinAdministrators

and include the resolved (localized) names in the whitelist. The English
names are still kept as fallbacks so mixed-language inventories and hosts
that happen to report the English names under a non-English locale don't
regress.

**Why ctypes instead of `pywin32`:** the original community PR (#2744)
adds `pywin32` as a runtime dependency just for this lookup. The issue
reporter explicitly suggested a ctypes alternative; this PR takes that
path so we don't grow the dependency surface. On non-Windows hosts the
SID helper detects the missing `WinDLL` and returns `None`, so the
whitelist falls back to the prior English-only behavior.

**Tests added** (`tests/api/test_secure_utils.py`):
- English Windows whitelist has no duplicates
- French Windows whitelist contains both `Système`/`Administrateurs` and the English fallbacks
- SID lookup failure falls back to English names
- French `icacls` output no longer flags `Administrateurs` as unauthorized
- English `icacls` output still works as before
- Genuine unauthorized users still surface in the result
- `_lookup_windows_sid_account_name` returns `None` cleanly on non-Windows

### References

- https://github.com/snowflakedb/snowflake-cli/issues/2743
- https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers