### PR TITLE
Print `Time Elapsed` after each REPL query (SNOW-2200621)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* `snow sql` REPL now prints `Time Elapsed: <seconds>s` after each query, matching SnowSQL's behavior.
 
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* `snow sql` REPL now prints `Time Elapsed: <seconds>s` after each query, matching SnowSQL's behavior.
 
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).

--- a/src/snowflake/cli/_plugins/sql/repl.py
+++ b/src/snowflake/cli/_plugins/sql/repl.py
@@ -1,3 +1,4 @@
+import time
 from contextlib import contextmanager
 from logging import getLogger
 from typing import Iterable
@@ -257,8 +258,11 @@ class Repl:
 
                 try:
                     log.debug("executing query")
+                    start = time.monotonic()
                     cursors = self._execute(user_input)
                     print_result(MultipleResults(QueryResult(c) for c in cursors))
+                    elapsed = time.monotonic() - start
+                    cli_console.message(f"Time Elapsed: {elapsed:.3f}s")
 
                 except Exception as e:
                     log.debug("error occurred: %s", e)

--- a/src/snowflake/cli/_plugins/sql/repl.py
+++ b/src/snowflake/cli/_plugins/sql/repl.py
@@ -1,3 +1,4 @@
+import time
 from contextlib import contextmanager
 from logging import getLogger
 from typing import Iterable
@@ -253,8 +254,11 @@ class Repl:
 
                 try:
                     log.debug("executing query")
+                    start = time.monotonic()
                     cursors = self._execute(user_input)
                     print_result(MultipleResults(QueryResult(c) for c in cursors))
+                    elapsed = time.monotonic() - start
+                    cli_console.message(f"Time Elapsed: {elapsed:.3f}s")
 
                 except Exception as e:
                     log.debug("error occurred: %s", e)

--- a/tests/sql/__snapshots__/test_repl.ambr
+++ b/tests/sql/__snapshots__/test_repl.ambr
@@ -65,6 +65,7 @@
   |---|
   | 1 |
   +---+
+  Time Elapsed: 0.123s
   
   Leaving REPL, bye ...
   

--- a/tests/sql/test_repl.py
+++ b/tests/sql/test_repl.py
@@ -35,10 +35,12 @@ def make_repl(mock_cursor):
 def test_repl_input_handling(repl, capsys, os_agnostic_snapshot):
     user_inputs = iter(("select 1;", "exit", "y"))
 
-    with mock.patch.object(
-        repl.session,
-        "prompt",
-        side_effect=user_inputs,
+    with (
+        mock.patch.object(repl.session, "prompt", side_effect=user_inputs),
+        mock.patch(
+            "snowflake.cli._plugins.sql.repl.time.monotonic",
+            side_effect=[0.0, 0.123],
+        ),
     ):
         repl.run()
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Closes #2484 / SNOW-2200621.

The `snow sql` REPL now prints `Time Elapsed: <seconds>s` after each query, mirroring SnowSQL's default behavior. This helps users with interactive performance investigations (spotting slow scans, warehouse sizing, comparing query variants).

**Implementation**

In `Repl._repl_loop` (`src/snowflake/cli/_plugins/sql/repl.py`), wall time is measured with `time.monotonic()` around `self._execute(...)` plus `print_result(...)`, and the result is printed via `cli_console.message(...)`. The timing sits inside the existing `try` block, so if execution raises, the error path is unchanged and no timing line is printed. Resolution is milliseconds (`.3f`).

**Example**

```
> select 1;
+---+
| 1 |
|---|
| 1 |
+---+
Time Elapsed: 0.182s
```

**Tests**

`tests/sql/test_repl.py::test_repl_input_handling` mocks `time.monotonic` with a deterministic `[0.0, 0.123]` sequence and the snapshot asserts the `Time Elapsed: 0.123s` line appears after the result. All 33 tests in `tests/sql/test_repl.py` pass.