### PR TITLE
Add strict/immutable options for Snowpark functions and procedures (#2226)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* Added `strict` and `immutable` options for Snowpark `function` and `procedure` entities in `snowflake.yml`. When set, `snow snowpark deploy` emits `RETURNS NULL ON NULL INPUT` and/or `IMMUTABLE` in the generated `CREATE FUNCTION`/`CREATE PROCEDURE` statement and treats a change in either value as a reason to replace the object.
 
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).

--- a/src/snowflake/cli/_plugins/snowpark/common.py
+++ b/src/snowflake/cli/_plugins/snowpark/common.py
@@ -123,6 +123,12 @@ class SnowparkObjectManager(SqlExecutionMixin):
             )
             query.append(f"RESOURCE_CONSTRAINT=({constraints})")
 
+        if entity.strict:
+            query.append("returns null on null input")
+
+        if entity.immutable:
+            query.append("immutable")
+
         if isinstance(entity, ProcedureEntityModel) and entity.execute_as_caller:
             query.append("execute as caller")
 
@@ -235,6 +241,20 @@ def _check_if_replace_is_required(
                 "Execute as caller settings do not match. Replacing the %s", object_type
             )
             return True
+
+    expected_null_handling = (
+        "RETURNS NULL ON NULL INPUT" if entity.strict else "CALLED ON NULL INPUT"
+    )
+    current_null_handling = resource_json.get("null handling", "CALLED ON NULL INPUT")
+    if current_null_handling.upper() != expected_null_handling:
+        log.info("Null handling does not match. Replacing the %s", object_type)
+        return True
+
+    expected_volatility = "IMMUTABLE" if entity.immutable else "VOLATILE"
+    current_volatility = resource_json.get("volatility", "VOLATILE")
+    if current_volatility.upper() != expected_volatility:
+        log.info("Volatility does not match. Replacing the %s", object_type)
+        return True
 
     return False
 

--- a/src/snowflake/cli/_plugins/snowpark/snowpark_entity.py
+++ b/src/snowflake/cli/_plugins/snowpark/snowpark_entity.py
@@ -192,6 +192,12 @@ class SnowparkEntity(EntityBase[Generic[T]]):
         if self.model.resource_constraint:
             query.append(self._get_resource_constraints_sql())
 
+        if self.model.strict:
+            query.append("RETURNS NULL ON NULL INPUT")
+
+        if self.model.immutable:
+            query.append("IMMUTABLE")
+
         if self.model.type == "procedure" and self.model.execute_as_caller:
             query.append("EXECUTE AS CALLER")
 

--- a/src/snowflake/cli/_plugins/snowpark/snowpark_entity_model.py
+++ b/src/snowflake/cli/_plugins/snowpark/snowpark_entity_model.py
@@ -64,6 +64,17 @@ class SnowparkEntityModel(
         default=None, title="Resource constraints for the function/procedure"
     )
 
+    strict: Optional[bool] = Field(
+        title="If True, the function/procedure is created with RETURNS NULL ON NULL INPUT "
+        "and the handler is not invoked when any input argument is NULL.",
+        default=False,
+    )
+    immutable: Optional[bool] = Field(
+        title="If True, the function/procedure is created as IMMUTABLE, letting Snowflake "
+        "reuse results for identical inputs. Only safe when the handler has no side effects.",
+        default=False,
+    )
+
     @field_validator("artifacts")
     @classmethod
     def _convert_artifacts(cls, artifacts: Union[dict, str]):

--- a/src/snowflake/cli/api/project/definition_conversion.py
+++ b/src/snowflake/cli/api/project/definition_conversion.py
@@ -200,6 +200,8 @@ def convert_snowpark_to_v2_data(snowpark: Snowpark) -> Dict[str, Any]:
             "external_access_integrations": entity.external_access_integrations,
             "secrets": entity.secrets,
             "imports": entity.imports,
+            "strict": entity.strict,
+            "immutable": entity.immutable,
             "identifier": identifier,
             "meta": {"use_mixins": [SNOWPARK_SHARED_MIXIN]},
         }

--- a/src/snowflake/cli/api/project/schemas/v1/snowpark/callable.py
+++ b/src/snowflake/cli/api/project/schemas/v1/snowpark/callable.py
@@ -48,6 +48,16 @@ class _CallableBase(UpdatableModel):
         title="Stage and path to previously uploaded files you want to import",
         default=[],
     )
+    strict: Optional[bool] = Field(
+        title="If True, create the function/procedure with RETURNS NULL ON NULL INPUT "
+        "so the handler is skipped when any input argument is NULL.",
+        default=False,
+    )
+    immutable: Optional[bool] = Field(
+        title="If True, create the function/procedure as IMMUTABLE so Snowflake may "
+        "reuse results for identical inputs. Only safe when the handler has no side effects.",
+        default=False,
+    )
 
     @field_validator("runtime")
     @classmethod

--- a/tests/helpers/__snapshots__/test_v1_to_v2.ambr
+++ b/tests/helpers/__snapshots__/test_v1_to_v2.ambr
@@ -21,6 +21,8 @@
       - name: name
         type: string
       stage: <! stage | to_snowflake_identifier !>
+      strict: false
+      immutable: false
       type: procedure
       execute_as_caller: false
     test_procedure:
@@ -39,6 +41,8 @@
       returns: string
       signature: ''
       stage: <! stage | to_snowflake_identifier !>
+      strict: false
+      immutable: false
       type: procedure
       execute_as_caller: false
     hello_function:
@@ -59,6 +63,8 @@
       - name: name
         type: string
       stage: <! stage | to_snowflake_identifier !>
+      strict: false
+      immutable: false
       type: function
   env:
     project_source: app/
@@ -190,6 +196,8 @@
       - name: name
         type: string
       stage: dev_deployment
+      strict: false
+      immutable: false
       type: procedure
       execute_as_caller: false
     func1:
@@ -214,6 +222,8 @@
         type: variant
       runtime: '3.1'
       stage: dev_deployment
+      strict: false
+      immutable: false
       type: function
     test_streamlit:
       identifier:
@@ -390,6 +400,8 @@
       - name: name
         type: string
       stage: dev_deployment
+      strict: false
+      immutable: false
       type: procedure
       execute_as_caller: false
     func1:
@@ -414,6 +426,8 @@
         type: variant
       runtime: '3.10'
       stage: dev_deployment
+      strict: false
+      immutable: false
       type: function
     test_streamlit:
       identifier:

--- a/tests/project/__snapshots__/test_config.ambr
+++ b/tests/project/__snapshots__/test_config.ambr
@@ -229,6 +229,7 @@
             'external_2',
           ]),
           'handler': 'app.func1_handler',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'func1',
@@ -251,6 +252,7 @@
               'name': 'b',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'procedures': list([
@@ -273,6 +275,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_function',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_db.custom_schema.fqn_function',
@@ -288,12 +291,14 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': None,
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_function',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_schema.fqn_function_only_schema',
@@ -309,12 +314,14 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': None,
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_function',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'schema_function',
@@ -330,12 +337,14 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': 'custom_db',
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_function',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'database_function',
@@ -351,12 +360,14 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': 'custom_db',
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_function',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_schema.database_function',
@@ -372,12 +383,14 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': 'custom_database',
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_function',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_database.custom_schema.fqn_function_error',
@@ -393,6 +406,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'procedures': list([
@@ -415,6 +429,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.func1_handler',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'func1',
@@ -437,6 +452,7 @@
               'name': 'b',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'procedures': list([
@@ -459,6 +475,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.func1_handler',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'func1',
@@ -479,6 +496,7 @@
               'name': 'b',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'procedures': list([
@@ -506,6 +524,7 @@
             'external_2',
           ]),
           'handler': 'app.hello',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'procedureName',
@@ -523,6 +542,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'project_name': 'my_snowpark_project',
@@ -546,6 +566,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_procedure',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_db.custom_schema.fqn_procedure',
@@ -561,6 +582,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': None,
@@ -568,6 +590,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_procedure',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_schema.fqn_procedure_only_schema',
@@ -583,6 +606,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': None,
@@ -590,6 +614,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_procedure',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'schema_procedure',
@@ -605,6 +630,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': 'custom_db',
@@ -612,6 +638,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_procedure',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'database_procedure',
@@ -627,6 +654,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': 'custom_db',
@@ -634,6 +662,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_procedure',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_schema.database_procedure',
@@ -649,6 +678,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': 'custom_database',
@@ -656,6 +686,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello_procedure',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'custom_database.custom_schema.fqn_procedure_error',
@@ -671,6 +702,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'project_name': 'my_snowpark_project',
@@ -694,6 +726,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'app.hello',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'procedureName',
@@ -711,6 +744,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
       ]),
       'project_name': 'my_snowpark_project',
@@ -734,6 +768,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'hello',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'procedureName',
@@ -749,6 +784,7 @@
               'name': 'name',
             }),
           ]),
+          'strict': False,
         }),
         dict({
           'database': None,
@@ -756,6 +792,7 @@
           'external_access_integrations': list([
           ]),
           'handler': 'test',
+          'immutable': False,
           'imports': list([
           ]),
           'name': 'test',
@@ -765,6 +802,7 @@
           'secrets': dict({
           }),
           'signature': '',
+          'strict': False,
         }),
       ]),
       'project_name': 'my_snowpark_project',

--- a/tests/snowpark/test_common.py
+++ b/tests/snowpark/test_common.py
@@ -72,6 +72,10 @@ def test_convert_resource_details_to_dict():
         ({"imports": ["@FOO.BAR.BAZ/my_snowpark_project/app.zip"]}, False),
         ({"runtime": "3.9"}, True),
         ({"execute_as_caller": False}, True),
+        ({"strict": True}, True),
+        ({"strict": False}, False),
+        ({"immutable": True}, True),
+        ({"immutable": False}, False),
     ],
 )
 def test_check_if_replace_is_required_entity_changes(


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Closes #2226.

Adds two new optional boolean fields to Snowpark `function` and `procedure` entities in `snowflake.yml`:

* `strict` — emits `RETURNS NULL ON NULL INPUT` in the generated `CREATE FUNCTION`/`CREATE PROCEDURE` statement, so the handler is skipped when any input argument is NULL.
* `immutable` — emits `IMMUTABLE`, letting Snowflake reuse results for identical inputs. Only safe when the handler has no side effects.

Both default to `false`, so existing projects deploy unchanged.

Example:

```yaml
entities:
  my_udf:
    type: function
    handler: app.my_udf
    returns: string
    signature: "(name string)"
    stage: dev
    artifacts: [src]
    strict: true
    immutable: true
```

#### Scope
- Added the two fields to `SnowparkEntityModel` (v2) and `_CallableBase` (v1).
- Forwarded them through the v1→v2 conversion layer so users on either schema version can opt in.
- Updated both SQL-emitting code paths:
  - `SnowparkObjectManager.create_or_replace` in `_plugins/snowpark/common.py` (used by `snow snowpark deploy`).
  - `SnowparkEntity.get_deploy_sql` in `_plugins/snowpark/snowpark_entity.py` (used by the workspace/native-app-children flow).
- Extended `_check_if_replace_is_required` to compare the project-declared values against `null handling` / `volatility` in `DESCRIBE FUNCTION/PROCEDURE` output, so a change in either field triggers a replace instead of silently no-op'ing.
- Added parametrized test cases for the new replace-detection branches and refreshed the affected v1 schema snapshot.
- Mentioned the feature under **New additions** in `RELEASE-NOTES.md`.