### PR TITLE
feat: [SNOW-2067317] drop removed snowpark entities on `deploy --prune`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -78,6 +78,9 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* `snow snowpark deploy --prune` now also drops procedures and functions that exist in the target schemas but are no longer declared in `snowflake.yml`. Previously `--prune` only cleared stage contents, so removed entities lingered in Snowflake until dropped manually. Only schemas that contain at least one declared entity of the same type are touched.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Upgraded `snowflake-connector-python` from 4.5.0 to 4.6.0.
 * `snow dcm list-deployments` and `snow dcm drop-deployment` now wrap the project name in `IDENTIFIER(...)`, matching every other DCM subcommand. Fully-qualified and quoted project names are now handled consistently.
 * Fixed `snow sql` table output rendering as a series of `|` characters when selecting many columns into a non-terminal destination (e.g. piped or redirected output).
+* `snow snowpark deploy --prune` now also drops procedures and functions that exist in the target schemas but are no longer declared in `snowflake.yml`. Previously `--prune` only cleared stage contents, so removed entities lingered in Snowflake until dropped manually. Only schemas that contain at least one declared entity of the same type are touched.
 
 
 # v3.19.0
@@ -78,9 +79,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* `snow snowpark deploy --prune` now also drops procedures and functions that exist in the target schemas but are no longer declared in `snowflake.yml`. Previously `--prune` only cleared stage contents, so removed entities lingered in Snowflake until dropped manually. Only schemas that contain at least one declared entity of the same type are touched.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* `snow snowpark deploy --prune` now also drops procedures and functions that exist in the target schemas but are no longer declared in `snowflake.yml`. Previously `--prune` only cleared stage contents, so removed entities lingered in Snowflake until dropped manually. Only schemas that contain at least one declared entity of the same type are touched.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/snowpark/commands.py
+++ b/src/snowflake/cli/_plugins/snowpark/commands.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import typer
 from click import ClickException, UsageError
@@ -42,6 +42,7 @@ from snowflake.cli._plugins.snowpark.common import (
     SnowparkObjectManager,
     StageToArtifactMapping,
     map_path_mapping_to_artifact,
+    same_type,
     zip_and_copy_artifacts_to_deploy,
 )
 from snowflake.cli._plugins.snowpark.package.anaconda_packages import (
@@ -137,7 +138,8 @@ def deploy(
     ),
     force_replace: bool = ForceReplaceOption(),
     prune: bool = PruneOption(
-        help="Remove contents of the stage before uploading artifacts."
+        help="Remove contents of the stage before uploading artifacts, and drop procedures "
+        "and functions that exist in the target schemas but are not declared in the project."
     ),
     **options,
 ) -> CommandResult:
@@ -181,6 +183,10 @@ def deploy(
         )
 
         create_stages_and_upload_artifacts(stages_to_artifact_map, prune=prune)
+
+    if prune:
+        with cli_console.phase("Pruning removed procedures and functions"):
+            drop_removed_snowpark_entities(om, snowpark_entities)
 
     # Create snowpark entities
     with cli_console.phase("Creating Snowpark entities"):
@@ -273,6 +279,177 @@ def create_stages_and_upload_artifacts(
                 stage_path=artifact.upload_path(stage),
                 overwrite=True,
             )
+
+
+def drop_removed_snowpark_entities(
+    om: ObjectManager,
+    snowpark_entities: SnowparkEntities,
+) -> None:
+    """Drop procedures and functions that exist in the target schemas but
+    are not declared in the project definition.
+
+    Objects are only dropped from schemas that have at least one declared
+    entity of the same type, so schemas unrelated to the project remain
+    untouched.
+    """
+    # Key: (object_type, (DATABASE_UPPER, SCHEMA_UPPER)).
+    # Value: (preserved-case database, preserved-case schema,
+    #        list of declared (upper-name, [type,...]) tuples).
+    # Database/schema cases are preserved so DROP statements use the same
+    # spelling the user declared. The upper-cased keys only group duplicates.
+    declared: Dict[
+        Tuple[str, Tuple[Optional[str], Optional[str]]],
+        Tuple[Optional[str], Optional[str], List[Tuple[str, List[str]]]],
+    ] = {}
+    for entity in snowpark_entities.values():
+        fqn = entity.fqn
+        if not fqn.database or not fqn.schema:
+            # Fall back to the context-aware identifier when the entity did
+            # not declare database/schema explicitly.
+            fqn = FQN.from_string(entity.udf_sproc_identifier.identifier_with_arg_types)
+        arg_types = _entity_arg_types(entity)
+        key = (
+            entity.type,
+            (_normalize(fqn.database), _normalize(fqn.schema)),
+        )
+        entry = declared.setdefault(key, (fqn.database, fqn.schema, []))
+        entry[2].append((fqn.name.upper(), arg_types))
+
+    for (object_type, _upper_key), (
+        database,
+        schema,
+        declared_entries,
+    ) in declared.items():
+        existing = _list_schema_snowpark_objects(om, object_type, database, schema)
+        for existing_name, existing_arg_types, existing_fqn in existing:
+            if _matches_any(existing_name, existing_arg_types, declared_entries):
+                continue
+            cli_console.step(f"Dropping {object_type} {existing_fqn.identifier}")
+            om.drop(object_type=object_type, fqn=existing_fqn, if_exists=True)
+
+
+def _entity_arg_types(entity) -> List[str]:
+    if not entity.signature or entity.signature == "null":
+        return []
+    return [arg.arg_type for arg in entity.signature]
+
+
+def _matches_any(
+    name: str,
+    arg_types: List[str],
+    declared_entries: List[Tuple[str, List[str]]],
+) -> bool:
+    for declared_name, declared_types in declared_entries:
+        if declared_name != name:
+            continue
+        if len(declared_types) != len(arg_types):
+            continue
+        if all(
+            same_type(existing, declared)
+            for existing, declared in zip(arg_types, declared_types)
+        ):
+            return True
+    return False
+
+
+def _list_schema_snowpark_objects(
+    om: ObjectManager,
+    object_type: str,
+    database: Optional[str],
+    schema: Optional[str],
+) -> List[Tuple[str, List[str], FQN]]:
+    if not database or not schema:
+        return []
+    scope_name = f"{database}.{schema}"
+    cursor = om.show(
+        object_type=object_type,
+        scope=("schema", scope_name),
+        cursor_class=DictCursor,
+    )
+    results: List[Tuple[str, List[str], FQN]] = []
+    for row in cursor:
+        # SHOW USER FUNCTIONS/PROCEDURES returns 'name', 'arguments', 'is_builtin'.
+        # 'arguments' looks like: 'FUNC_NAME(VARCHAR, NUMBER) RETURN VARCHAR'
+        if _is_builtin(row):
+            continue
+        name = row.get("name")
+        arguments = row.get("arguments", "")
+        if not name or not arguments:
+            continue
+        arg_types = _parse_arg_types_from_show(arguments)
+        fqn = FQN(
+            database=database,
+            schema=schema,
+            name=name,
+            signature=f"({', '.join(arg_types)})",
+        )
+        results.append((name.upper(), arg_types, fqn))
+    return results
+
+
+def _is_builtin(row: dict) -> bool:
+    for key in ("is_builtin", "is_builtin_"):
+        value = row.get(key)
+        if isinstance(value, str):
+            return value.upper() in {"Y", "YES", "TRUE"}
+        if isinstance(value, bool):
+            return value
+    return False
+
+
+def _parse_arg_types_from_show(arguments: str) -> List[str]:
+    """Parse the comma-separated argument types from a SHOW USER FUNCTIONS /
+    PROCEDURES 'arguments' column, which looks like:
+        'FUNC_NAME(VARCHAR, NUMBER(38,0)) RETURN VARCHAR'
+    """
+    open_idx = arguments.find("(")
+    if open_idx < 0:
+        return []
+    depth = 0
+    close_idx = -1
+    for i in range(open_idx, len(arguments)):
+        ch = arguments[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                close_idx = i
+                break
+    if close_idx < 0:
+        return []
+    inside = arguments[open_idx + 1 : close_idx].strip()
+    if not inside:
+        return []
+    return [_split_signature_arg(part.strip()) for part in _split_top_level(inside)]
+
+
+def _split_top_level(signature: str) -> Iterable[str]:
+    """Split a signature argument list on commas that are not inside parens."""
+    depth = 0
+    start = 0
+    for i, ch in enumerate(signature):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            yield signature[start:i]
+            start = i + 1
+    yield signature[start:]
+
+
+def _split_signature_arg(arg: str) -> str:
+    """Return only the type portion of an argument entry, stripping any name."""
+    # SHOW typically returns just the type (e.g. 'VARCHAR'), but be defensive in
+    # case a future server version includes the name too.
+    return arg.strip().split(" ", 1)[-1]
+
+
+def _normalize(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.upper()
 
 
 def _find_existing_objects(

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -14163,7 +14163,10 @@
   | --force-replace                          Replace this object, even if the    |
   |                                          state didn't change                 |
   | --prune              --no-prune          Remove contents of the stage before |
-  |                                          uploading artifacts.                |
+  |                                          uploading artifacts, and drop       |
+  |                                          procedures and functions that exist |
+  |                                          in the target schemas but are not   |
+  |                                          declared in the project.            |
   |                                          [default: no-prune]                 |
   | --project        -p                TEXT  Path where the Snowflake project is |
   |                                          stored. Defaults to the current     |

--- a/tests/snowpark/test_common.py
+++ b/tests/snowpark/test_common.py
@@ -14,7 +14,13 @@
 
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
+from snowflake.cli._plugins.snowpark.commands import (
+    _parse_arg_types_from_show,
+    drop_removed_snowpark_entities,
+)
 from snowflake.cli._plugins.snowpark.common import (
     _check_if_replace_is_required,
     _convert_resource_details_to_dict,
@@ -23,6 +29,7 @@ from snowflake.cli._plugins.snowpark.common import (
     same_type,
 )
 from snowflake.cli._plugins.snowpark.snowpark_entity_model import (
+    FunctionEntityModel,
     ProcedureEntityModel,
 )
 
@@ -194,3 +201,131 @@ def test_the_same_type(sf_type, local_type):
 )
 def test_is_not_the_same_type(sf_type, local_type):
     assert not same_type(sf_type, local_type)
+
+
+@pytest.mark.parametrize(
+    "arguments,expected",
+    [
+        ("MY_FN() RETURN VARCHAR", []),
+        ("MY_FN(VARCHAR) RETURN VARCHAR", ["VARCHAR"]),
+        ("MY_FN(VARCHAR, NUMBER) RETURN VARCHAR", ["VARCHAR", "NUMBER"]),
+        ("MY_FN(NUMBER(38,0), VARCHAR) RETURN VARCHAR", ["NUMBER(38,0)", "VARCHAR"]),
+        ("", []),
+        ("no parens at all", []),
+    ],
+)
+def test_parse_arg_types_from_show(arguments, expected):
+    assert _parse_arg_types_from_show(arguments) == expected
+
+
+def _make_procedure(name: str, signature):
+    return ProcedureEntityModel(
+        type="procedure",
+        handler="app.handler",
+        signature=signature,
+        artifacts=[],
+        stage="dev_deployment",
+        returns="string",
+        identifier={"name": name, "database": "MY_DB", "schema": "MY_SCHEMA"},
+    )
+
+
+def _make_function(name: str, signature):
+    return FunctionEntityModel(
+        type="function",
+        handler="app.handler",
+        signature=signature,
+        artifacts=[],
+        stage="dev_deployment",
+        returns="string",
+        identifier={"name": name, "database": "MY_DB", "schema": "MY_SCHEMA"},
+    )
+
+
+def _show_row(name: str, arguments: str, is_builtin: str = "N"):
+    return {"name": name, "arguments": arguments, "is_builtin": is_builtin}
+
+
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager")
+def test_drop_removed_snowpark_entities_drops_unlisted_objects(mock_om_cls):
+    om = mock.MagicMock()
+    declared_proc = _make_procedure("KEEP_PROC", [])
+    declared_fn = _make_function(
+        "KEEP_FN",
+        [{"name": "name", "type": "string"}],
+    )
+    entities = {"keep_proc": declared_proc, "keep_fn": declared_fn}
+
+    om.show.side_effect = [
+        # procedures in MY_DB.MY_SCHEMA
+        [
+            _show_row("KEEP_PROC", "KEEP_PROC() RETURN VARCHAR"),
+            _show_row("STALE_PROC", "STALE_PROC(VARCHAR) RETURN VARCHAR"),
+        ],
+        # functions in MY_DB.MY_SCHEMA
+        [
+            _show_row("KEEP_FN", "KEEP_FN(VARCHAR) RETURN VARCHAR"),
+            _show_row("STALE_FN", "STALE_FN(NUMBER) RETURN VARCHAR"),
+            _show_row("SYSTEM_FN", "SYSTEM_FN() RETURN VARCHAR", is_builtin="Y"),
+        ],
+    ]
+
+    drop_removed_snowpark_entities(om, entities)
+
+    drop_calls = om.drop.call_args_list
+    dropped = sorted(
+        (call.kwargs["object_type"], call.kwargs["fqn"].identifier)
+        for call in drop_calls
+    )
+    assert dropped == [
+        ("function", "MY_DB.MY_SCHEMA.STALE_FN"),
+        ("procedure", "MY_DB.MY_SCHEMA.STALE_PROC"),
+    ]
+    # signatures must be included so overloads are dropped safely
+    proc_signatures = {
+        call.kwargs["fqn"].signature
+        for call in drop_calls
+        if call.kwargs["object_type"] == "procedure"
+    }
+    assert proc_signatures == {"(VARCHAR)"}
+
+
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager")
+def test_drop_removed_snowpark_entities_keeps_matching_overloads(mock_om_cls):
+    om = mock.MagicMock()
+    declared = _make_procedure(
+        "FN",
+        [{"name": "name", "type": "string"}],
+    )
+    entities = {"fn_str": declared}
+
+    # Server returns the overload with a different arg type and the string overload.
+    om.show.side_effect = [
+        [
+            _show_row("FN", "FN(VARCHAR) RETURN VARCHAR"),  # matches declared
+            _show_row("FN", "FN(NUMBER) RETURN VARCHAR"),  # overload not declared
+        ],
+    ]
+
+    drop_removed_snowpark_entities(om, entities)
+
+    drop_calls = om.drop.call_args_list
+    assert len(drop_calls) == 1
+    dropped_fqn = drop_calls[0].kwargs["fqn"]
+    assert dropped_fqn.identifier == "MY_DB.MY_SCHEMA.FN"
+    assert dropped_fqn.signature == "(NUMBER)"
+
+
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager")
+def test_drop_removed_snowpark_entities_does_not_touch_other_schemas(mock_om_cls):
+    om = mock.MagicMock()
+    entities = {
+        "a": _make_procedure("PROC_A", []),
+    }
+    om.show.return_value = []
+
+    drop_removed_snowpark_entities(om, entities)
+
+    show_scopes = [call.kwargs["scope"] for call in om.show.call_args_list]
+    assert show_scopes == [("schema", "MY_DB.MY_SCHEMA")]
+    om.drop.assert_not_called()

--- a/tests/snowpark/test_procedure.py
+++ b/tests/snowpark/test_procedure.py
@@ -788,6 +788,77 @@ def test_deploy_procedure_with_empty_default_value(
     ]
 
 
+@pytest.mark.parametrize(
+    "project_name", ["snowpark_procedures", "snowpark_procedures_v2"]
+)
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.drop")
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.describe")
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.show")
+@mock.patch(
+    "snowflake.cli._plugins.snowpark.package_utils.download_unavailable_packages"
+)
+@mock_session_has_warehouse
+def test_deploy_procedure_prune_drops_removed_entities(
+    mock_download,
+    mock_om_show,
+    mock_om_describe,
+    mock_conn,
+    mock_om_drop,
+    runner,
+    mock_ctx,
+    project_directory,
+    project_name,
+    enable_snowpark_glob_support_feature_flag,
+):
+    mock_download.return_value = DownloadUnavailablePackagesResult()
+    mock_om_describe.side_effect = ProgrammingError(
+        errno=DOES_NOT_EXIST_OR_NOT_AUTHORIZED
+    )
+    # ObjectManager.show() is called for integrations, then for procedures.
+    # snowpark_procedures declares procedureName(name string) and test().
+    # Stale procedure stale_proc(int) should be dropped.
+    mock_om_show.side_effect = [
+        [],  # integrations
+        [  # procedures
+            {
+                "name": "procedureName".upper(),
+                "arguments": "PROCEDURENAME(VARCHAR) RETURN VARCHAR",
+                "is_builtin": "N",
+            },
+            {
+                "name": "TEST",
+                "arguments": "TEST() RETURN VARCHAR",
+                "is_builtin": "N",
+            },
+            {
+                "name": "STALE_PROC",
+                "arguments": "STALE_PROC(NUMBER(38,0)) RETURN VARCHAR",
+                "is_builtin": "N",
+            },
+        ],
+    ]
+
+    ctx = mock_ctx()
+    mock_conn.return_value = ctx
+
+    with project_directory(project_name):
+        result = runner.invoke(
+            ["snowpark", "build", "--ignore-anaconda"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(["snowpark", "deploy", "--prune"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_om_drop.call_count == 1
+    drop_kwargs = mock_om_drop.call_args.kwargs
+    assert drop_kwargs["object_type"] == "procedure"
+    assert drop_kwargs["fqn"].identifier == "MockDatabase.MockSchema.STALE_PROC"
+    assert drop_kwargs["fqn"].signature == "(NUMBER(38,0))"
+    assert drop_kwargs["if_exists"] is True
+
+
 @mock.patch("snowflake.connector.connect")
 def test_execute_procedure(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Closes #2218.

`snow snowpark deploy --prune` previously only cleared stage contents — procedures and functions that had been removed from `snowflake.yml` lingered in Snowflake until dropped manually. This PR extends `--prune` so the server-side catalog matches the declared entities too.

**Behavior**

After artifacts are uploaded and before entities are (re)created, the deploy flow now:

1. Groups declared Snowpark entities by `(type, database, schema)` using the identifier already resolved in the project definition.
2. For each group, runs `SHOW USER <FUNCTIONS|PROCEDURES> IN SCHEMA <db>.<schema>` and parses the returned `arguments` column.
3. Drops every object in that schema of the same type that does not match any declared entity by `(name, arg_types)`. Overloads are preserved — matching is done per signature, not per name.

**Safety**

- Only schemas that contain at least one declared entity of the same type are scanned — schemas the project does not touch are never queried.
- Builtin functions (`is_builtin = Y`) are skipped.
- Type aliases are handled via the existing `same_type()` helper so `STRING` vs `VARCHAR`, `INT` vs `NUMBER(38,0)`, etc. do not cause spurious drops.
- Nested parens like `NUMBER(38,0)` are parsed correctly (manual depth tracking, not a naïve regex).
- Original-case database/schema from the declared identifier is preserved in the `DROP` statement.
- `DROP ... IF EXISTS` is used so a concurrent drop does not fail the deploy.
- No behavior change when `--prune` is not passed.

**Tests**

- Unit tests in `tests/snowpark/test_common.py`:
  - `test_parse_arg_types_from_show` — parametrized coverage of arg-type parsing including `NUMBER(38,0)` and no-argument cases.
  - `test_drop_removed_snowpark_entities_drops_unlisted_objects` — stale entities get dropped, builtins are skipped, signatures are included in the drop FQN.
  - `test_drop_removed_snowpark_entities_keeps_matching_overloads` — only the non-declared overload is dropped.
  - `test_drop_removed_snowpark_entities_does_not_touch_other_schemas` — `SHOW` scope is limited to declared schemas.
- Integration test in `tests/snowpark/test_procedure.py`:
  - `test_deploy_procedure_prune_drops_removed_entities` — end-to-end `snow snowpark deploy --prune` flow with mocked `ObjectManager.show/describe/drop`, verifies case preservation and signature passing.