### PR TITLE
feat: [SNOW-2211628] resolve snowpark deps from pyproject.toml (#2497)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* `snow snowpark build` now falls back to PEP 621 `[project].dependencies` in `pyproject.toml` when no `requirements.txt` is present. `requirements.txt` remains the canonical source when both files exist.
 
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).

--- a/src/snowflake/cli/_plugins/snowpark/commands.py
+++ b/src/snowflake/cli/_plugins/snowpark/commands.py
@@ -327,6 +327,31 @@ def _read_snowflake_requirements_file(file_path: SecurePath):
     return file_path.read_text(file_size_limit_mb=DEFAULT_SIZE_LIMIT_MB).splitlines()
 
 
+def _select_requirements_source(project_paths: SnowparkProjectPaths):
+    """Picks the dependency source to use for a snowpark build.
+
+    Prefers ``requirements.txt`` when present — it remains the canonical
+    format and keeps existing projects behaving identically. Falls back to
+    PEP 621 ``[project].dependencies`` in ``pyproject.toml`` when no
+    ``requirements.txt`` is found. Returns ``None`` when no dependency
+    source is available, in which case only code artifacts are bundled.
+    """
+    if project_paths.requirements.exists():
+        return (
+            "requirements.txt",
+            package_utils.parse_requirements(
+                requirements_file=project_paths.requirements,
+            ),
+        )
+    if project_paths.pyproject.exists():
+        requirements = package_utils.parse_pyproject_dependencies(
+            pyproject_file=project_paths.pyproject,
+        )
+        if requirements:
+            return ("pyproject.toml", requirements)
+    return None
+
+
 @app.command("build", requires_connection=True)
 @with_project_definition()
 def build(
@@ -353,15 +378,17 @@ def build(
     # Clean up bundle root
     project_paths.remove_up_bundle_root()
 
-    # Resolve dependencies
-    if project_paths.requirements.exists():
+    # Resolve dependencies. requirements.txt takes precedence for backwards
+    # compatibility; fall back to PEP 621 [project].dependencies in
+    # pyproject.toml so projects that only track deps there still get their
+    # packages bundled.
+    requirements_source = _select_requirements_source(project_paths)
+    if requirements_source is not None:
+        source_label, requirements = requirements_source
         with (
-            cli_console.phase("Resolving dependencies from requirements.txt"),
+            cli_console.phase(f"Resolving dependencies from {source_label}"),
             SecurePath.temporary_directory() as temp_deps_dir,
         ):
-            requirements = package_utils.parse_requirements(
-                requirements_file=project_paths.requirements,
-            )
             anaconda_packages = (
                 AnacondaPackages.empty()
                 if ignore_anaconda

--- a/src/snowflake/cli/_plugins/snowpark/package_utils.py
+++ b/src/snowflake/cli/_plugins/snowpark/package_utils.py
@@ -23,6 +23,7 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional
 
+import tomllib
 from click import ClickException
 from snowflake.cli._plugins.snowpark.models import (
     Requirement,
@@ -61,6 +62,47 @@ def parse_requirements(
             line = re.sub(r"\s*#.*", "", line).strip()
             if line:
                 reqs.append(Requirement.parse_line(line))
+    return reqs
+
+
+def parse_pyproject_dependencies(
+    pyproject_file: SecurePath,
+) -> List[Requirement]:
+    """Reads runtime dependencies from a PEP 621 ``pyproject.toml`` file.
+
+    Only ``[project].dependencies`` is consulted. ``build-system.requires``
+    and ``[project.optional-dependencies]`` are intentionally ignored so that
+    `snow snowpark build` doesn't pull in tooling needed only at build/test
+    time. If the file has no ``[project]`` table (e.g. a pure Poetry project
+    that hasn't adopted PEP 621), an empty list is returned.
+    """
+    if not pyproject_file.exists():
+        return []
+
+    content = pyproject_file.read_text(file_size_limit_mb=DEFAULT_SIZE_LIMIT_MB)
+    try:
+        data = tomllib.loads(content)
+    except tomllib.TOMLDecodeError as err:
+        raise ClickException(f"Failed to parse {pyproject_file.path}: {err}") from err
+
+    project = data.get("project") or {}
+    raw_deps = project.get("dependencies") or []
+    if not isinstance(raw_deps, list):
+        raise ClickException(
+            f"Invalid [project].dependencies in {pyproject_file.path}: "
+            "expected a list of PEP 508 requirement strings."
+        )
+
+    reqs: List[Requirement] = []
+    for entry in raw_deps:
+        if not isinstance(entry, str):
+            raise ClickException(
+                f"Invalid dependency entry in {pyproject_file.path}: "
+                f"expected a string, got {type(entry).__name__}."
+            )
+        line = entry.strip()
+        if line:
+            reqs.append(Requirement.parse_line(line))
     return reqs
 
 

--- a/src/snowflake/cli/_plugins/snowpark/snowpark_entity.py
+++ b/src/snowflake/cli/_plugins/snowpark/snowpark_entity.py
@@ -117,17 +117,34 @@ class SnowparkEntity(EntityBase[Generic[T]]):
         if not output_dir.exists():  # type: ignore[union-attr]
             SecurePath(output_dir).mkdir(parents=True)
 
-        # 1 Check if requirements exits
-        if (self.root / "requirements.txt").exists():
+        # 1 Check if requirements exist. Prefer requirements.txt; fall back
+        # to PEP 621 [project].dependencies in pyproject.toml.
+        requirements_txt = self.root / "requirements.txt"
+        pyproject = self.root / "pyproject.toml"
+        if requirements_txt.exists():
             download_results = self._process_requirements(
                 bundle_dir=output_dir,  # type: ignore
                 archive_name="dependencies.zip",
-                requirements_file=SecurePath(self.root / "requirements.txt"),
+                requirements_file=SecurePath(requirements_txt),
                 ignore_anaconda=ignore_anaconda,
                 skip_version_check=skip_version_check,
                 index_url=index_url,
                 allow_shared_libraries=allow_shared_libraries,
             )
+        elif pyproject.exists():
+            pyproject_requirements = package_utils.parse_pyproject_dependencies(
+                pyproject_file=SecurePath(pyproject),
+            )
+            if pyproject_requirements:
+                download_results = self._process_requirements_list(
+                    bundle_dir=output_dir,  # type: ignore
+                    archive_name="dependencies.zip",
+                    requirements=pyproject_requirements,
+                    ignore_anaconda=ignore_anaconda,
+                    skip_version_check=skip_version_check,
+                    index_url=index_url,
+                    allow_shared_libraries=allow_shared_libraries,
+                )
 
         # 2 get the artifacts list
         artifacts = map_path_mapping_to_artifact(project_paths, self.model.artifacts)
@@ -215,9 +232,30 @@ class SnowparkEntity(EntityBase[Generic[T]]):
         Parameters:
 
         """
+        requirements = package_utils.parse_requirements(requirements_file)
+        return self._process_requirements_list(
+            bundle_dir=bundle_dir,
+            archive_name=archive_name,
+            requirements=requirements,
+            ignore_anaconda=ignore_anaconda,
+            skip_version_check=skip_version_check,
+            index_url=index_url,
+            allow_shared_libraries=allow_shared_libraries,
+        )
+
+    def _process_requirements_list(
+        self,
+        bundle_dir: Path,
+        archive_name: str,
+        requirements,
+        ignore_anaconda: bool,
+        skip_version_check: bool = False,
+        index_url: Optional[str] = None,
+        allow_shared_libraries: bool = False,
+    ) -> DownloadUnavailablePackagesResult:
+        """Download dependencies for an already-parsed list of requirements."""
         anaconda_packages_manager = AnacondaPackagesManager()
         with SecurePath.temporary_directory() as tmp_dir:
-            requirements = package_utils.parse_requirements(requirements_file)
             anaconda_packages = (
                 AnacondaPackages.empty()
                 if ignore_anaconda

--- a/src/snowflake/cli/_plugins/snowpark/snowpark_project_paths.py
+++ b/src/snowflake/cli/_plugins/snowpark/snowpark_project_paths.py
@@ -79,6 +79,10 @@ class SnowparkProjectPaths(ProjectPaths):
         return SecurePath(self.path_relative_to_root(Path("requirements.txt")))
 
     @property
+    def pyproject(self) -> SecurePath:
+        return SecurePath(self.path_relative_to_root(Path("pyproject.toml")))
+
+    @property
     def bundle_root(self) -> Path:
         return bundle_root(self.project_root, "snowpark")
 

--- a/src/snowflake/cli/_plugins/snowpark/zipper.py
+++ b/src/snowflake/cli/_plugins/snowpark/zipper.py
@@ -47,6 +47,7 @@ IGNORED_FILES = [
     "**/requirements.txt",
     "**/requirements.snowflake.txt",
     "**/requirements.other.txt",
+    "**/pyproject.toml",
     "**/snowflake.yml",
 ]
 

--- a/tests/snowpark/test_build.py
+++ b/tests/snowpark/test_build.py
@@ -42,6 +42,54 @@ def test_snowpark_build_no_deprecated_warnings_by_default(
         assert "flag is deprecated" not in result.output
 
 
+@patch("snowflake.cli._plugins.snowpark.package_utils.download_unavailable_packages")
+def test_snowpark_build_falls_back_to_pyproject_toml(
+    mock_download, runner, project_directory
+):
+    """When requirements.txt is absent, the build reads PEP 621 dependencies
+    from pyproject.toml instead."""
+    mock_download.return_value = DownloadUnavailablePackagesResult()
+    with project_directory("snowpark_functions") as tmp_dir:
+        (tmp_dir / "requirements.txt").unlink()
+        (tmp_dir / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "snowpark-funcs"\n'
+            'version = "0.1.0"\n'
+            'dependencies = ["snowflake-snowpark-python"]\n'
+        )
+
+        result = runner.invoke(["snowpark", "build", "--ignore-anaconda"])
+
+        assert result.exit_code == 0, result.output
+        assert "Resolving dependencies from pyproject.toml" in result.output
+        assert mock_download.called
+        called_requirements = mock_download.call_args.kwargs["requirements"]
+        assert [r.name for r in called_requirements] == ["snowflake_snowpark_python"]
+
+
+@patch("snowflake.cli._plugins.snowpark.package_utils.download_unavailable_packages")
+def test_snowpark_build_prefers_requirements_txt_over_pyproject(
+    mock_download, runner, project_directory
+):
+    """requirements.txt is kept as the canonical source; pyproject.toml is a
+    fallback and should be ignored when both are present."""
+    mock_download.return_value = DownloadUnavailablePackagesResult()
+    with project_directory("snowpark_functions") as tmp_dir:
+        (tmp_dir / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "snowpark-funcs"\n'
+            'version = "0.1.0"\n'
+            'dependencies = ["should-be-ignored"]\n'
+        )
+
+        result = runner.invoke(["snowpark", "build", "--ignore-anaconda"])
+
+        assert result.exit_code == 0, result.output
+        assert "Resolving dependencies from requirements.txt" in result.output
+        called_requirements = mock_download.call_args.kwargs["requirements"]
+        assert "should_be_ignored" not in {r.name for r in called_requirements}
+
+
 @pytest.mark.parametrize(
     "artifacts, zip_name, expected_files",
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,6 +147,78 @@ def test_parse_requirements(correct_requirements_txt: str):
     assert result[2].specs == [(">=", "3.2.1")]
 
 
+def test_parse_pyproject_dependencies_reads_pep621_deps(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "example"\n'
+        'version = "0.1.0"\n'
+        "dependencies = [\n"
+        '    "snowflake-snowpark-python==1.15.0",\n'
+        '    "requests>=2.31",\n'
+        '    "pandas",\n'
+        "]\n"
+    )
+    result = package_utils.parse_pyproject_dependencies(SecurePath(pyproject))
+    result.sort(key=lambda r: r.name)
+
+    assert len(result) == 3
+    assert result[0].name == "pandas"
+    assert result[0].specs == []
+    assert result[1].name == "requests"
+    assert result[1].specs == [(">=", "2.31")]
+    assert result[2].name == "snowflake_snowpark_python"
+    assert result[2].specs == [("==", "1.15.0")]
+
+
+def test_parse_pyproject_dependencies_missing_file_returns_empty(tmp_path):
+    result = package_utils.parse_pyproject_dependencies(
+        SecurePath(tmp_path / "no_such_file.toml")
+    )
+    assert result == []
+
+
+def test_parse_pyproject_dependencies_without_project_table(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[build-system]\nrequires = ["setuptools>=68"]\nbuild-backend = "setuptools.build_meta"\n'
+    )
+    assert package_utils.parse_pyproject_dependencies(SecurePath(pyproject)) == []
+
+
+def test_parse_pyproject_dependencies_ignores_optional_and_build_deps(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[build-system]\nrequires = ["setuptools>=68"]\nbuild-backend = "setuptools.build_meta"\n'
+        "\n[project]\n"
+        'name = "example"\n'
+        'version = "0.1.0"\n'
+        'dependencies = ["requests"]\n'
+        "\n[project.optional-dependencies]\n"
+        'dev = ["pytest"]\n'
+    )
+    result = package_utils.parse_pyproject_dependencies(SecurePath(pyproject))
+    assert [r.name for r in result] == ["requests"]
+
+
+def test_parse_pyproject_dependencies_invalid_toml_raises(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project\nname = 'broken'\n")
+    with pytest.raises(Exception) as exc:
+        package_utils.parse_pyproject_dependencies(SecurePath(pyproject))
+    assert "Failed to parse" in str(exc.value)
+
+
+def test_parse_pyproject_dependencies_non_list_deps_raises(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "example"\nversion = "0.1"\ndependencies = "requests"\n'
+    )
+    with pytest.raises(Exception) as exc:
+        package_utils.parse_pyproject_dependencies(SecurePath(pyproject))
+    assert "list of PEP 508" in str(exc.value)
+
+
 @patch("platform.system")
 @pytest.mark.parametrize(
     "argument, expected",


### PR DESCRIPTION
Closes #2497 / [SNOW-2211628](https://snowflakecomputing.atlassian.net/browse/SNOW-2211628).

### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

`snow snowpark build` now falls back to PEP 621 `[project].dependencies` in `pyproject.toml` when no `requirements.txt` is present, so projects that track their dependencies exclusively in `pyproject.toml` no longer need to maintain a duplicate `requirements.txt` just to package snowpark artifacts.

**Behavior**

- `requirements.txt` is still the canonical source. When both files exist, `requirements.txt` wins — zero change for existing projects.
- When only `pyproject.toml` exists and it has a non-empty `[project].dependencies` list, those PEP 508 requirement strings are parsed (via `tomllib`) and fed through the existing anaconda-lookup + pip-wheel-download pipeline.
- The build emits either `Resolving dependencies from requirements.txt` or `Resolving dependencies from pyproject.toml` as the phase header so it's visible which source was used.
- `pyproject.toml` is excluded from the bundled artifact zip (same treatment as `requirements.txt`).
- `[project.optional-dependencies]` and `[build-system].requires` are ignored; only runtime `dependencies` is read.

**Files**
- `snowpark/package_utils.py` — new `parse_pyproject_dependencies()` helper using stdlib `tomllib`.
- `snowpark/snowpark_project_paths.py` — new `pyproject` property.
- `snowpark/commands.py` — `build` command uses a `_select_requirements_source()` helper; the phase header names the source.
- `snowpark/snowpark_entity.py` — mirrors the fallback in the v2 entity `bundle()` path; refactors to split requirements-file parsing from the download flow via `_process_requirements_list()`.
- `snowpark/zipper.py` — adds `**/pyproject.toml` to `IGNORED_FILES`.
- `tests/test_utils.py` — 6 unit tests covering the happy path, missing file, missing `[project]`, ignoring optional/build deps, invalid TOML, and non-list `dependencies`.
- `tests/snowpark/test_build.py` — 2 integration tests: (a) deleting `requirements.txt` and writing a `pyproject.toml` falls back correctly; (b) when both files exist, `requirements.txt` wins.
- `RELEASE-NOTES.md` — Unreleased > New additions entry.

**Out of scope**
- `uv`/Poetry lockfile formats.
- `[tool.*]` custom snowpark-specific tables.
- `project.optional-dependencies` — can follow up with an `--extras` flag if there's demand.

[SNOW-2211628]: https://snowflakecomputing.atlassian.net/browse/SNOW-2211628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ