### PR TITLE
fix: treat missing-key cleanup as a no-op in OpenConnectionCache

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed a `KeyError` in the open-connection cache's cleanup path: when a scheduled cleanup timer fired for a connection that had already been removed (e.g. by `cache.clear()` or an earlier cleanup), the cache raised instead of treating the missing key as a no-op.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -292,9 +292,16 @@ class OpenConnectionCache:
 
     def _cleanup(self, key: str):
         """Closes the cached connection at the given key."""
-        if key not in self.connections:
+        # Always cancel the pending cleanup timer, even if the connection is
+        # no longer in the cache (e.g. because it was already removed by a
+        # previous cleanup or by clear()), so we do not leave an orphaned
+        # timer behind.
+        self._cancel_cleanup_future_if_exists(key)
+
+        conn = self.connections.pop(key, None)
+        if conn is None:
             logger.debug("Cleaning up connection %s, but not found in cache!", key)
+            return
 
         # doesn't cancel in-flight async queries
-        self._cancel_cleanup_future_if_exists(key)
-        self.connections.pop(key).close()
+        conn.close()

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -122,3 +122,23 @@ def test_connection_cache_caches(
         password="dummy_password",
         application_name="snowcli",
     )
+
+
+def test_connection_cache_cleanup_tolerates_missing_key(local_connection_cache):
+    """_cleanup() must be a no-op when the key is not in the cache.
+
+    The cleanup timer scheduled by _touch() races with clear() and with a
+    second _cleanup() for the same key: whichever wins removes the
+    connection, and the loser fires later with a stale key. Before this
+    guard, the loser raised KeyError on `self.connections.pop(key)`.
+    """
+    # No connections in the cache — simulating a fired timer after clear().
+    local_connection_cache._cleanup("missing-key")  # noqa: SLF001
+
+    # Also verify that a lingering cleanup future for the missing key is
+    # cancelled rather than leaked.
+    fake_future = mock.Mock()
+    local_connection_cache.cleanup_futures["orphan-key"] = fake_future
+    local_connection_cache._cleanup("orphan-key")  # noqa: SLF001
+    fake_future.cancel.assert_called_once()
+    assert "orphan-key" not in local_connection_cache.cleanup_futures


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

`OpenConnectionCache._cleanup(key)` had a defensive `if key not in self.connections` check
(`src/snowflake/cli/api/connections.py:293`) that logged a debug line and then fell
through to `self.connections.pop(key).close()` — which raises `KeyError` on the exact
case the check was supposed to handle.

In practice the cleanup timer scheduled by `_touch()` can race with:

* `clear()` (which iterates a snapshot of `connections` and calls `_cleanup` for each key),
* a second `_cleanup(key)` for the same key, or
* an explicit eviction path that removes a connection before its timer fires.

Whichever caller wins removes the connection from `self.connections`, and the loser
fires later with a stale key and crashes on `pop(key)` rather than being a no-op.

The fix:

* Pop with a default of `None` and early-return when the connection is already gone,
  logging the same debug message.
* Move `_cancel_cleanup_future_if_exists(key)` before the early-return so a lingering
  timer for the missing key is always cancelled rather than leaked.

Added a unit test that invokes `_cleanup` on a key that was never inserted, and on a
key whose only remaining state is a pending cleanup future, verifying no exception is
raised and the future is cancelled.