### PR TITLE
Fallback to default Snowsight root when URL cannot be resolved (SNOW-2904031)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.
+* Snowsight URLs are now generated with a graceful fallback to `https://app.snowflake.com` when the connection's region or account cannot be resolved (for example, on Azure accounts whose host does not match the 6-part `<account>.<x>.<y>.<z>.snowflakecomputing.com` shape). Previously, commands such as `snow app run`, `snow streamlit deploy`, and `snow apps service get-endpoints` could fail purely because a precise URL could not be built even though the underlying deployment succeeded.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
 * The `build_eai` field of a `snowflake-app` entity can now be specified as a bare string (e.g. `build_eai: MY_EAI`) in addition to the existing `build_eai:\n  name: MY_EAI` object form.
 

--- a/src/snowflake/cli/_plugins/connection/util.py
+++ b/src/snowflake/cli/_plugins/connection/util.py
@@ -257,17 +257,39 @@ def get_snowsight_host(conn: SnowflakeConnection) -> str:
         return "https://app.snowflake.com"
 
 
+SNOWSIGHT_DEFAULT_HOST = "https://app.snowflake.com"
+
+
 def make_snowsight_url(conn: SnowflakeConnection, path: str) -> str:
     """
     Returns a URL on the correct Snowsight instance for the connected account.
     The path that is passed in must already be properly URL-encoded, and
     can optionally contain a hash/fragment (e.g. #).
 
+    If the deployment or account cannot be resolved (for example, on
+    accounts whose host does not match the 6-part
+    ``<account>.<x>.<y>.<z>.snowflakecomputing.com`` shape that
+    ``get_host_region`` recognizes — which includes many Azure accounts
+    with 5-part hosts like ``<account>.<region>.azure.snowflakecomputing.com``),
+    falls back to the generic Snowsight root URL instead of raising.
+    The caller already has a working connection at this point, so failing
+    a downstream command purely because we cannot build a precise URL is
+    a worse outcome than returning a usable generic link.
+
     See also identifier_for_url.
     """
-    snowsight_host = get_snowsight_host(conn)
-    deployment = get_context(conn)
-    account = get_account(conn)
+    try:
+        snowsight_host = get_snowsight_host(conn)
+        deployment = get_context(conn)
+        account = get_account(conn)
+    except (MissingConnectionRegionError, MissingConnectionAccountError) as e:
+        log.warning(
+            "Could not resolve Snowsight URL for this connection; "
+            "falling back to %s. Reason: %s",
+            SNOWSIGHT_DEFAULT_HOST,
+            e,
+        )
+        return SNOWSIGHT_DEFAULT_HOST
     path_with_slash = path if path.startswith("/") else f"/{path}"
     return f"{snowsight_host}/{deployment}/{account}{path_with_slash}"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,9 @@ import snowflake.cli._plugins.snowpark.models
 import snowflake.cli._plugins.snowpark.package.utils
 from snowflake.cli._plugins.connection.util import (
     LOCAL_DEPLOYMENT_REGION,
+    SNOWSIGHT_DEFAULT_HOST,
+    MissingConnectionAccountError,
+    MissingConnectionRegionError,
     UIParameter,
     get_context,
     get_host_region,
@@ -219,6 +222,41 @@ def test_make_snowsight_url(
     get_account.return_value = account
     actual = make_snowsight_url(None, path)  # all uses of conn are mocked
     assert actual == expected
+
+
+@patch("snowflake.cli._plugins.connection.util.get_account")
+@patch("snowflake.cli._plugins.connection.util.get_context")
+@patch("snowflake.cli._plugins.connection.util.get_snowsight_host")
+@pytest.mark.parametrize(
+    "raising_fn, exc",
+    [
+        (
+            "get_context",
+            MissingConnectionRegionError(
+                "acct.westeurope.azure.snowflakecomputing.com"
+            ),
+        ),
+        ("get_account", MissingConnectionAccountError(mock.MagicMock())),
+    ],
+)
+def test_make_snowsight_url_falls_back_when_url_cannot_be_resolved(
+    get_snowsight_host, get_context, get_account, raising_fn, exc
+):
+    """When the region or account cannot be resolved (e.g. Azure 5-part hosts),
+    make_snowsight_url should return the default Snowsight root instead of raising.
+    """
+    get_snowsight_host.return_value = "https://app.snowflake.com"
+    get_context.return_value = "org"
+    get_account.return_value = "account"
+
+    if raising_fn == "get_context":
+        get_context.side_effect = exc
+    else:
+        get_account.side_effect = exc
+
+    actual = make_snowsight_url(None, "/#/streamlit-apps/MY_APP")
+    assert actual == SNOWSIGHT_DEFAULT_HOST
+    assert SNOWSIGHT_DEFAULT_HOST == "https://app.snowflake.com"
 
 
 @patch("snowflake.cli._plugins.connection.util.get_account")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes #2724 (SNOW-2904031).

Several commands build Snowsight links via `make_snowsight_url(conn, path)` — `snow app run`, `snow streamlit deploy`, `snow apps service get-endpoints`, notebook URL emission, etc. When the connection's region or account cannot be resolved the helper raised `MissingConnectionRegionError` / `MissingConnectionAccountError`. That surfaced as a command failure even though the underlying SQL (create streamlit, deploy app, …) had already succeeded.

The most common case for this was reported by customers on Azure accounts, where the host has the 5-part form ``<account>.<region>.azure.snowflakecomputing.com`` rather than the 6-part ``<account>.<x>.<y>.<z>.snowflakecomputing.com`` shape that `get_host_region` recognizes.

This PR centralizes the graceful fallback inside `make_snowsight_url`:

* Catch `MissingConnectionRegionError` and `MissingConnectionAccountError`.
* Log a warning with the reason.
* Return a new module-level constant `SNOWSIGHT_DEFAULT_HOST = "https://app.snowflake.com"` so the caller still gets a usable (if generic) link.

Because the fix lives in `make_snowsight_url`, it covers **all** callers (native app, streamlit entity/manager, notebook, apps/service) with one change. The per-callsite `try/except` wrappers in `streamlit/manager.py` and `streamlit/streamlit_entity.py` that were introduced in #2925 for the same underlying bug remain in place as harmless defense-in-depth.

### Tests

* Added two new parametrized cases in `tests/test_utils.py::test_make_snowsight_url_falls_back_when_url_cannot_be_resolved` that force `get_context` / `get_account` to raise and assert the returned URL is `https://app.snowflake.com`.
* All existing `tests/test_utils.py`, `tests/streamlit/`, `tests/nativeapp/`, `tests/notebook/`, and `tests/apps/` suites pass locally (3629 tests + 90 snapshots).


---
Supersedes #2926 — identical commits (same SHA: `a0e1e744`). Re-opened from an upstream branch because branch protection on `main` requires `*-trusted` status checks that only fire for PRs from the upstream repo, not forks.
