### PR TITLE
fix: [SNOW-2378114] skip Anaconda lookup in `snowpark package create` when no connection is configured

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* `snow snowpark package create` now falls back to `--ignore-anaconda` behavior (skipping the Anaconda channel lookup and emitting a warning) when no Snowflake connection is configured, so the zip can still be built in CI environments without Snowflake credentials. Previously the command failed with `Connection default is not configured`.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/snowpark/package/commands.py
+++ b/src/snowflake/cli/_plugins/snowpark/package/commands.py
@@ -42,6 +42,7 @@ from snowflake.cli._plugins.snowpark.snowpark_shared import (
 )
 from snowflake.cli._plugins.snowpark.zipper import zip_dir
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.exceptions import MissingConfigurationError
 from snowflake.cli.api.output.types import CommandResult, MessageResult
 from snowflake.cli.api.secure_path import SecurePath
 
@@ -117,6 +118,25 @@ def package_upload(
     return MessageResult(upload(file=file, stage=stage, overwrite=overwrite))
 
 
+def _resolve_anaconda_packages(ignore_anaconda: bool) -> AnacondaPackages:
+    """Resolve the Anaconda package list for `package create`.
+
+    When `ignore_anaconda` is set — or when no Snowflake connection is configured —
+    an empty set is returned so the command can run offline. Any other error from
+    the Anaconda lookup is re-raised so real misconfigurations stay visible.
+    """
+    if ignore_anaconda:
+        return AnacondaPackages.empty()
+    try:
+        return AnacondaPackagesManager().find_packages_available_in_snowflake_anaconda()
+    except MissingConfigurationError:
+        log.warning(
+            "No Snowflake connection is configured; skipping Anaconda channel check "
+            "and building the package as if --ignore-anaconda was passed."
+        )
+        return AnacondaPackages.empty()
+
+
 @app.command("create", requires_connection=True)
 def package_create(
     name: str = typer.Argument(
@@ -132,18 +152,17 @@ def package_create(
 ) -> CommandResult:
     """
     Creates a Python package as a zip file that can be uploaded to a stage and imported for a Snowpark Python app.
+
+    If no Snowflake connection is configured, the Anaconda channel lookup is
+    skipped (equivalent to `--ignore-anaconda`) so the zip can still be built
+    in environments without Snowflake credentials.
     """
     with SecurePath.temporary_directory() as packages_dir:
         package = Requirement.parse(name)
-        anaconda_packages_manager = AnacondaPackagesManager()
         download_result = download_unavailable_packages(
             requirements=[package],
             target_dir=packages_dir,
-            anaconda_packages=(
-                AnacondaPackages.empty()
-                if ignore_anaconda
-                else anaconda_packages_manager.find_packages_available_in_snowflake_anaconda()
-            ),
+            anaconda_packages=_resolve_anaconda_packages(ignore_anaconda),
             skip_version_check=skip_version_check,
             pip_index_url=index_url,
         )

--- a/tests/snowpark/test_package.py
+++ b/tests/snowpark/test_package.py
@@ -87,6 +87,81 @@ class TestPackage:
         assert "in-anaconda-package>=2" in result.output
         assert os.path.isfile("totally-awesome-package.zip"), result.output
 
+    @patch(
+        "snowflake.cli._plugins.snowpark.package.commands.download_unavailable_packages"
+    )
+    @patch(
+        "snowflake.cli._plugins.snowpark.package_utils.pip_wheel",
+    )
+    @patch(
+        "snowflake.cli._plugins.snowpark.package.commands.AnacondaPackagesManager.find_packages_available_in_snowflake_anaconda"
+    )
+    def test_package_create_with_ignore_anaconda_does_not_query_anaconda(
+        self,
+        mock_find_anaconda,
+        mock_pip_wheel,
+        mock_download,
+        temporary_directory,
+        runner,
+    ) -> None:
+        mock_pip_wheel.return_value = 9
+        mock_download.return_value = DownloadUnavailablePackagesResult(
+            anaconda_packages=[],
+        )
+
+        result = runner.invoke(
+            [
+                "snowpark",
+                "package",
+                "create",
+                "totally-awesome-package",
+                "--ignore-anaconda",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_find_anaconda.assert_not_called()
+
+    @patch(
+        "snowflake.cli._plugins.snowpark.package.commands.download_unavailable_packages"
+    )
+    @patch(
+        "snowflake.cli._plugins.snowpark.package_utils.pip_wheel",
+    )
+    @patch(
+        "snowflake.cli._plugins.snowpark.package.commands.AnacondaPackagesManager.find_packages_available_in_snowflake_anaconda"
+    )
+    def test_package_create_without_connection_falls_back_to_ignore_anaconda(
+        self,
+        mock_find_anaconda,
+        mock_pip_wheel,
+        mock_download,
+        caplog,
+        temporary_directory,
+        runner,
+    ) -> None:
+        from snowflake.cli.api.exceptions import MissingConfigurationError
+
+        mock_pip_wheel.return_value = 9
+        mock_find_anaconda.side_effect = MissingConfigurationError(
+            "Connection default is not configured"
+        )
+        mock_download.return_value = DownloadUnavailablePackagesResult(
+            anaconda_packages=[],
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="snowflake.cli._plugins.snowpark.package"
+        ):
+            result = runner.invoke(
+                ["snowpark", "package", "create", "totally-awesome-package"]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_find_anaconda.assert_called_once()
+        assert "No Snowflake connection is configured" in caplog.text
+        assert os.path.isfile("totally-awesome-package.zip"), result.output
+
     @mock.patch("snowflake.cli._plugins.snowpark.package.manager.StageManager")
     @mock.patch("snowflake.cli._plugins.snowpark.package.manager.FQN.from_string")
     @mock.patch("snowflake.connector.connect")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

`snow snowpark package create` currently requires a Snowflake connection solely so it can check the Anaconda channel for the requested package. In CI environments without Snowflake credentials, the command fails immediately with:

```
Connection default is not configured
```

even though the zip can be built entirely offline. The workaround is `--ignore-anaconda`, but users have to discover the flag and add it explicitly. This hits CI pipelines that used to work on Snowflake CLI 2.3.0 and regressed later — see [#2637](https://github.com/snowflakedb/snowflake-cli/issues/2637).

This PR makes the Anaconda lookup best-effort:

- If `--ignore-anaconda` is passed, behavior is unchanged (no lookup).
- If no connection is configured (the lookup raises `MissingConfigurationError`), the command logs a warning, skips the channel check, and continues building the zip as if `--ignore-anaconda` had been passed.
- Any other error from the lookup is re-raised so real misconfigurations stay visible.

The code path for `requires_connection=True` is preserved — only the lookup itself is made best-effort. Users with a working connection still get the Anaconda short-circuit (the "package already in Anaconda" message).

#### Test coverage
Two new unit tests were added to `tests/snowpark/test_package.py`:
- `test_package_create_with_ignore_anaconda_does_not_query_anaconda` — verifies `--ignore-anaconda` never calls the Anaconda lookup.
- `test_package_create_without_connection_falls_back_to_ignore_anaconda` — verifies a `MissingConfigurationError` from the lookup is caught, logged, and the zip is produced.

#### Jira
[SNOW-2378114](https://snowflakecomputing.atlassian.net/browse/SNOW-2378114) / related issue [#2637](https://github.com/snowflakedb/snowflake-cli/issues/2637).

[SNOW-2378114]: https://snowflakecomputing.atlassian.net/browse/SNOW-2378114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ