### PR TITLE
fix(sql): leave embedded `&` alone when it's not a SnowSQL variable

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 * The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* SnowSQL-compatible `&name` variable substitution in `snow sql` now only fires at a token boundary (start of input or after a non-identifier character). An ampersand embedded inside an identifier or string literal — for example `Principal&Interest` in a semantic view `COMMENT` or `SYNONYMS` clause — is left alone instead of being treated as a variable reference and failing with `SQL template rendering error: 'Interest' is undefined`.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/sql/snowsql_templating.py
+++ b/src/snowflake/cli/_plugins/sql/snowsql_templating.py
@@ -14,9 +14,24 @@
 
 import string
 
+# The default string.Template pattern matches `&name` anywhere in the input,
+# so an ampersand embedded inside an identifier or string literal (for example
+# `Principal&Interest` in a semantic view synonym or COMMENT) is treated as a
+# variable reference. This pattern requires the bare `&name` form to appear at
+# a token boundary — start of input, or after a non-identifier character — so
+# that a `&` wedged inside a word is left alone. The braced `&{name}` form
+# stays explicit and works anywhere; `&&` is still the literal-ampersand escape.
+_SNOWSQL_PATTERN = (
+    r"\&(?P<escaped>\&)"
+    r"|(?<![A-Za-z0-9_])\&(?P<named>[_a-z][_a-z0-9]*)"
+    r"|\&\{(?P<braced>[_a-z][_a-z0-9]*)\}"
+    r"|(?<![A-Za-z0-9_])\&(?P<invalid>)"
+)
+
 
 class _SnowSQLTemplate(string.Template):
     delimiter = "&"
+    pattern = _SNOWSQL_PATTERN  # type: ignore[assignment]
 
 
 class _Mapper:

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -397,6 +397,40 @@ def test_snowsql_compatibility(text, expected):
     assert transpile_snowsql_templates(text) == expected
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Issue #2714: embedded `&` must not be treated as a variable marker.
+        "Principal&Interest",
+        "principal&interest",
+        "COMMENT = 'Scheduled monthly payment amount with principal&interest'",
+        "WITH SYNONYMS ('Principal&Interest payment')",
+        # A `&` preceded by an identifier character is part of the surrounding
+        # token, not a template variable.
+        "abc&foo",
+        "abc_&foo",
+        "42&foo",
+    ],
+)
+def test_embedded_ampersand_is_not_a_variable(text):
+    assert transpile_snowsql_templates(text) == text
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # The bare `&name` form only fires at a token boundary.
+        ("where col = &foo", "where col = &{ foo }"),
+        ("(&foo)", "(&{ foo })"),
+        ("&foo+&bar", "&{ foo }+&{ bar }"),
+        # The braced form keeps working next to identifier characters.
+        ("abc&{foo}", "abc&{ foo }"),
+    ],
+)
+def test_bare_variable_still_substitutes_at_token_boundary(text, expected):
+    assert transpile_snowsql_templates(text) == expected
+
+
 @pytest.mark.parametrize("template_start,template_end", [("&{", "}"), ("<%", "%>")])
 @mock.patch("snowflake.cli._plugins.sql.commands.SqlManager._execute_string")
 def test_uses_variables_from_snowflake_yml(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes #2714.

Before Jinja rendering, `snow sql` runs a SnowSQL-compatibility pass that turns bare `&name` into `&{ name }` (and leaves `&{name}` / `&&` untouched) so that legacy SnowSQL scripts keep working. The pass was built on `string.Template`, whose default pattern matches `&name` **anywhere** in the input — it doesn't require a token boundary before the `&`. That meant an ampersand wedged inside an identifier or string literal — e.g. `Principal&Interest` in a semantic view `COMMENT` or `WITH SYNONYMS` clause — was being parsed as a variable reference. The pass emitted the `&{ ... } syntax is deprecated` warning, Jinja then tried to render `{{ Interest }}`, and the whole thing bombed out:

```
% snow sql -f create_semantic_view.sql
Warning: &{ ... } syntax is deprecated and will no longer be supported. Use <% ... %> syntax instead.
SQL template rendering error: 'Interest' is undefined
╭─ Error ────────────────────────────────────────────────────────────╮
│ SQL rendering error                                                │
╰────────────────────────────────────────────────────────────────────╯
```

The reporter's workaround was to pad the `&` with spaces, which is fine for a hand-edited script but not workable for DDL that came from a SQL generator or an LLM that picked `Principal&Interest` as a synonym.

**Change.** Tighten the `_SnowSQLTemplate` pattern so the bare `&name` form only fires at a token boundary — start of input, or after a non-identifier (i.e. not `[A-Za-z0-9_]`) character. An ampersand that sits next to identifier characters is left alone. The other two forms are unchanged:

| Input | Before | After |
| --- | --- | --- |
| `&foo` | `&{ foo }` | `&{ foo }` |
| `select * from &foo join bar` | `select * from &{ foo } join bar` | `select * from &{ foo } join bar` |
| `&&foo` (escape) | `&foo` | `&foo` |
| `&{ foo }` (braced) | `&{ foo }` | `&{ foo }` |
| `Principal&Interest` | (parsed as variable, errors) | `Principal&Interest` |
| `COMMENT = 'principal&interest'` | (parsed as variable, errors) | `COMMENT = 'principal&interest'` |
| `abc&foo` | `abc&{ foo }` | `abc&foo` |

That last row is a deliberate behavior change: the previous pattern would have substituted `&foo` even when it was glued to preceding identifier characters, which is both ambiguous and at odds with what SnowSQL itself does. Anyone who actually wanted a substitution in that spot can still write `abc&{foo}` (braced), which continues to work.

**Scope.** This only changes the SnowSQL-compat pre-pass in `snow sql`. The standard `<% ... %>` template syntax and the Jinja block rendering are untouched.

### Tests

- `tests/sql/test_sql.py::test_snowsql_compatibility` — existing parameterized suite, unchanged, still green.
- `tests/sql/test_sql.py::test_embedded_ampersand_is_not_a_variable` — new: `Principal&Interest`, `'Scheduled monthly payment amount with principal&interest'`, `"WITH SYNONYMS ('Principal&Interest payment')"`, `abc&foo`, `abc_&bar`, `42&foo`.
- `tests/sql/test_sql.py::test_bare_variable_still_substitutes_at_token_boundary` — new: confirms `where col = &foo`, `(&foo)`, `&foo+&bar`, and `abc&{foo}` (braced form next to identifier chars) all still substitute as before.

`hatch run default:pytest tests/sql/` — 223 passed. Pre-commit (`ruff`, `black`, `mypy`, `codespell`, etc.) clean on all three changed files.