### PR TITLE
fix: [SNOW-2361367] notebook/streamlit deploy without CREATE STAGE privilege

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 * The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* Entity deploys (`snow notebook deploy`, `snow streamlit deploy`, `snow dcm deploy`, and other commands that sync artifacts to a stage) now check whether the target stage already exists before issuing `CREATE STAGE IF NOT EXISTS`. This means a role that holds only `USAGE`/`READ`/`WRITE` on a pre-existing stage can deploy without also being granted `CREATE STAGE` on the schema. In particular, `snow notebook deploy` no longer fails for roles that were previously forced to hold `CREATE STAGE` purely to satisfy the no-op `IF NOT EXISTS` path.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -40,9 +40,18 @@ from snowflake.cli.api.commands.common import (
 )
 from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.constants import PYTHON_3_12
+from snowflake.cli.api.errno import (
+    DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED,
+    INSUFFICIENT_PRIVILEGES,
+)
 from snowflake.cli.api.exceptions import CliError
 from snowflake.cli.api.identifiers import FQN
-from snowflake.cli.api.project.util import VALID_IDENTIFIER_REGEX, to_string_literal
+from snowflake.cli.api.project.util import (
+    VALID_IDENTIFIER_REGEX,
+    identifier_to_show_like_pattern,
+    to_identifier,
+    to_string_literal,
+)
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.stage_path import StagePath
@@ -542,6 +551,34 @@ class StageManager(SqlExecutionMixin):
         with self.use_role(role) if role else nullcontext():
             stage_path = self.build_path(stage_name) / path
             return self.execute_query(f"remove {stage_path.path_for_sql()}")
+
+    def stage_exists(self, fqn: FQN) -> bool:
+        """
+        Returns True if the caller can see a stage named ``fqn`` via SHOW STAGES.
+
+        Used to skip CREATE STAGE IF NOT EXISTS when the stage already exists —
+        that statement requires CREATE STAGE on the schema even when it's a no-op,
+        which breaks deploys for roles that only have USAGE/READ/WRITE on the stage.
+        """
+        pattern = identifier_to_show_like_pattern(to_identifier(fqn.name))
+        if fqn.database and fqn.schema:
+            in_clause = f" in schema {fqn.database}.{fqn.schema}"
+        elif fqn.schema:
+            in_clause = f" in schema {fqn.schema}"
+        elif fqn.database:
+            in_clause = f" in database {fqn.database}"
+        else:
+            in_clause = ""
+        try:
+            result = self.execute_query(f"show stages like {pattern}{in_clause}")
+        except ProgrammingError as err:
+            if err.errno in (
+                DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED,
+                INSUFFICIENT_PRIVILEGES,
+            ):
+                return False
+            raise
+        return result.rowcount > 0
 
     def create(
         self,

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -122,11 +122,19 @@ def sync_deploy_root_with_stage(
     elif not package_name:
         # ensure stage exists
         stage_fqn = FQN.from_stage(stage_path_parts.stage)
+        stage_manager = StageManager()
         if use_temporary_stage:
             console.step(f"Creating temporary stage {stage_fqn}.")
+            stage_manager.create(fqn=stage_fqn, temporary=True)
+        elif stage_manager.stage_exists(stage_fqn):
+            # CREATE STAGE IF NOT EXISTS still requires CREATE STAGE on the
+            # schema, so roles that can only USE an existing stage would get
+            # INSUFFICIENT_PRIVILEGES here. Skip the create when the stage is
+            # already visible to the caller.
+            console.step(f"Using existing stage {stage_fqn}.")
         else:
             console.step(f"Creating stage {stage_fqn} if not exists.")
-        StageManager().create(fqn=stage_fqn, temporary=use_temporary_stage)
+            stage_manager.create(fqn=stage_fqn, temporary=False)
     else:
         # ensure stage exists - nativeapp behavior
         sql_facade = get_snowflake_facade()

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -236,6 +236,82 @@ def test_sync_deploy_root_with_stage_subdir(
     )
 
 
+STAGE_MANAGER_MODULE = "snowflake.cli._plugins.stage.manager.StageManager"
+
+
+@pytest.mark.parametrize("stage_exists", [True, False])
+@mock.patch(f"{STAGE_MANAGER_MODULE}.create")
+@mock.patch(f"{STAGE_MANAGER_MODULE}.stage_exists")
+@mock.patch(f"{ENTITIES_UTILS_MODULE}.compute_stage_diff")
+@mock.patch(f"{ENTITIES_UTILS_MODULE}.sync_local_diff_with_stage")
+def test_sync_deploy_root_with_stage_generic_path_skips_create_when_stage_exists(
+    mock_local_diff_with_stage,
+    mock_compute_stage_diff,
+    mock_stage_exists,
+    mock_create,
+    temporary_directory,
+    stage_exists,
+):
+    """Non-nativeapp callers (notebook, streamlit, DCM) must not issue
+    CREATE STAGE IF NOT EXISTS when the stage is already visible — that SQL
+    requires CREATE STAGE on the schema and fails for roles that only hold
+    USAGE/READ/WRITE on the stage."""
+    mock_stage_exists.return_value = stage_exists
+    mock_compute_stage_diff.return_value = DiffResult()
+    mock_local_diff_with_stage.return_value = None
+
+    sync_deploy_root_with_stage(
+        console=cc,
+        deploy_root=Path(temporary_directory),
+        bundle_map=mock.Mock(spec=BundleMap),
+        prune=False,
+        recursive=True,
+        stage_path_parts=DefaultStagePathParts.from_fqn("db.schema.my_stage"),
+    )
+
+    mock_stage_exists.assert_called_once()
+    called_fqn = mock_stage_exists.call_args.args[0]
+    assert called_fqn.name == "my_stage"
+    assert called_fqn.schema == "schema"
+    assert called_fqn.database == "db"
+    if stage_exists:
+        mock_create.assert_not_called()
+    else:
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["temporary"] is False
+
+
+@mock.patch(f"{STAGE_MANAGER_MODULE}.create")
+@mock.patch(f"{STAGE_MANAGER_MODULE}.stage_exists")
+@mock.patch(f"{ENTITIES_UTILS_MODULE}.compute_stage_diff")
+@mock.patch(f"{ENTITIES_UTILS_MODULE}.sync_local_diff_with_stage")
+def test_sync_deploy_root_with_stage_temporary_stage_always_creates(
+    mock_local_diff_with_stage,
+    mock_compute_stage_diff,
+    mock_stage_exists,
+    mock_create,
+    temporary_directory,
+):
+    """Temporary stages are always created fresh; the existence pre-check
+    would be wrong here because a prior session's temp stage isn't visible."""
+    mock_compute_stage_diff.return_value = DiffResult()
+    mock_local_diff_with_stage.return_value = None
+
+    sync_deploy_root_with_stage(
+        console=cc,
+        deploy_root=Path(temporary_directory),
+        bundle_map=mock.Mock(spec=BundleMap),
+        prune=False,
+        recursive=True,
+        stage_path_parts=DefaultStagePathParts.from_fqn("db.schema.my_stage"),
+        use_temporary_stage=True,
+    )
+
+    mock_stage_exists.assert_not_called()
+    mock_create.assert_called_once()
+    assert mock_create.call_args.kwargs["temporary"] is True
+
+
 @mock.patch(SQL_FACADE_STAGE_EXISTS)
 @mock.patch(SQL_EXECUTOR_EXECUTE)
 @mock.patch(f"{ENTITIES_UTILS_MODULE}.sync_local_diff_with_stage")

--- a/tests/notebook/__snapshots__/test_notebook_commands.ambr
+++ b/tests/notebook/__snapshots__/test_notebook_commands.ambr
@@ -2,7 +2,7 @@
 # name: test_deploy_default_stage_paths[notebook1][query]
   '''
   DESCRIBE NOTEBOOK IDENTIFIER('notebook1');
-  create stage if not exists IDENTIFIER('notebooks')
+  show stages like 'NOTEBOOKS'
   CREATE OR REPLACE NOTEBOOK IDENTIFIER('notebook1')
   FROM '@notebooks'
   QUERY_WAREHOUSE = 'xsmall'
@@ -14,7 +14,7 @@
 # name: test_deploy_default_stage_paths[notebook2][query]
   '''
   DESCRIBE NOTEBOOK IDENTIFIER('notebook2');
-  create stage if not exists IDENTIFIER('notebooks')
+  show stages like 'NOTEBOOKS'
   CREATE OR REPLACE NOTEBOOK IDENTIFIER('notebook2')
   FROM '@notebooks'
   QUERY_WAREHOUSE = 'xsmall'
@@ -26,7 +26,7 @@
 # name: test_deploy_single_notebook[notebook_containerized_v2][query]
   '''
   DESCRIBE NOTEBOOK IDENTIFIER('containerized_notebook');
-  create stage if not exists IDENTIFIER('notebooks')
+  show stages like 'NOTEBOOKS'
   CREATE OR REPLACE NOTEBOOK IDENTIFIER('containerized_notebook')
   FROM '@notebooks'
   QUERY_WAREHOUSE = 'xsmall'
@@ -40,7 +40,7 @@
 # name: test_deploy_single_notebook[notebook_v2][query]
   '''
   DESCRIBE NOTEBOOK IDENTIFIER('custom_identifier');
-  create stage if not exists IDENTIFIER('custom_stage')
+  show stages like 'CUSTOM\\_STAGE'
   CREATE OR REPLACE NOTEBOOK IDENTIFIER('custom_identifier')
   FROM '@custom_stage'
   QUERY_WAREHOUSE = 'xsmall'

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -20,7 +20,12 @@ from unittest.mock import MagicMock
 import pytest
 from snowflake.cli._plugins.git.manager import GitManager
 from snowflake.cli._plugins.stage.manager import StageManager, TemporaryDirectory
-from snowflake.cli.api.errno import DOES_NOT_EXIST_OR_NOT_AUTHORIZED
+from snowflake.cli.api.errno import (
+    DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED,
+    DOES_NOT_EXIST_OR_NOT_AUTHORIZED,
+    INSUFFICIENT_PRIVILEGES,
+)
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.stage_path import StagePath
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor, SnowflakeCursor
@@ -767,6 +772,61 @@ def test_stage_create_quoted(mock_execute, runner, mock_cursor):
     mock_execute.assert_called_once_with(
         """create stage if not exists IDENTIFIER('"stage name"') encryption = (type = 'SNOWFLAKE_FULL')"""
     )
+
+
+@pytest.mark.parametrize(
+    "fqn, expected_query",
+    [
+        (FQN.from_string("stagename"), "show stages like 'STAGENAME'"),
+        (
+            FQN.from_string("myschema.stagename"),
+            "show stages like 'STAGENAME' in schema myschema",
+        ),
+        (
+            FQN.from_string("mydb.myschema.stagename"),
+            "show stages like 'STAGENAME' in schema mydb.myschema",
+        ),
+        (
+            FQN.from_string('"Mixed Case"'),
+            "show stages like 'Mixed Case'",
+        ),
+        # underscores in the name must be escaped so LIKE treats them literally,
+        # not as single-character wildcards.
+        (
+            FQN.from_string("stage_name"),
+            r"show stages like 'STAGE\\_NAME'",
+        ),
+    ],
+)
+@mock.patch(f"{STAGE_MANAGER}.execute_query")
+def test_stage_exists_returns_true_when_row_found(
+    mock_execute, mock_cursor, fqn, expected_query
+):
+    mock_execute.return_value = mock_cursor(["row"], [])
+    assert StageManager().stage_exists(fqn) is True
+    mock_execute.assert_called_once_with(expected_query)
+
+
+@mock.patch(f"{STAGE_MANAGER}.execute_query")
+def test_stage_exists_returns_false_when_no_rows(mock_execute, mock_cursor):
+    mock_execute.return_value = mock_cursor([], [])
+    assert StageManager().stage_exists(FQN.from_string("stageName")) is False
+
+
+@pytest.mark.parametrize(
+    "errno", [DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED, INSUFFICIENT_PRIVILEGES]
+)
+@mock.patch(f"{STAGE_MANAGER}.execute_query")
+def test_stage_exists_returns_false_on_expected_errors(mock_execute, errno):
+    mock_execute.side_effect = ProgrammingError(msg="boom", errno=errno)
+    assert StageManager().stage_exists(FQN.from_string("stageName")) is False
+
+
+@mock.patch(f"{STAGE_MANAGER}.execute_query")
+def test_stage_exists_reraises_unexpected_errors(mock_execute):
+    mock_execute.side_effect = ProgrammingError(msg="boom", errno=999)
+    with pytest.raises(ProgrammingError):
+        StageManager().stage_exists(FQN.from_string("stageName"))
 
 
 @mock.patch("snowflake.cli._plugins.object.commands.ObjectManager.execute_query")

--- a/tests/streamlit/streamlit_test_class.py
+++ b/tests/streamlit/streamlit_test_class.py
@@ -29,6 +29,11 @@ class StreamlitTestClass:
             "snowflake.cli._plugins.stage.manager.StageManager.create",
         ).start()
 
+        self.mock_stage_exists = mock.patch(
+            "snowflake.cli._plugins.stage.manager.StageManager.stage_exists",
+            return_value=False,
+        ).start()
+
         self.mock_list_files = mock.patch(
             "snowflake.cli._plugins.stage.manager.StageManager.list_files",
             return_value=MockCursor.from_input([], []),


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Entity artifact deploys that are not backed by a native-app package — `snow notebook deploy`, `snow streamlit deploy`, `snow dcm deploy`, and anything else that goes through `sync_deploy_root_with_stage` with `package_name=None` — always issued `CREATE STAGE IF NOT EXISTS <stage>` before uploading files. That statement requires `CREATE STAGE` on the parent schema even when it's a no-op, so a role that had only `USAGE`/`READ`/`WRITE` on an already-provisioned stage could not deploy without also being granted `CREATE STAGE`.

This change mirrors the existing native-app path:

1. Adds `StageManager.stage_exists(fqn)` that runs `show stages like …` and returns `False` on `DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED` or `INSUFFICIENT_PRIVILEGES` (so callers that genuinely can't see the stage still fall through to `create`).
2. Teaches `sync_deploy_root_with_stage`'s generic branch (`not package_name`) to call `stage_exists` first and skip `create` when the stage is already visible. Temporary stages keep the old behavior — always create — because a prior session's temp stage isn't visible anyway.

### Tests
* New unit tests in `tests/stage/test_stage.py` cover the new `stage_exists` helper (SHOW LIKE patterning with/without schema/database, quoted identifiers, underscore escaping, and swallowing of `DOES_NOT_EXIST_OR_CANNOT_BE_PERFORMED` / `INSUFFICIENT_PRIVILEGES`).
* New unit tests in `tests/nativeapp/test_manager.py` cover the generic branch of `sync_deploy_root_with_stage`: `create` is skipped when the stage exists, called when it doesn't, and always called (no pre-check) for temporary stages.
* Notebook snapshot tests updated to reflect the new SHOW LIKE pre-check (the conftest mock cursor returns a row, so `create` is correctly skipped — this is exactly the bug-fix path).
* Streamlit test fixtures patched to return `stage_exists=False` so existing `mock_create_stage.assert_called_once()` assertions continue to hold.

### References
* Fixes #2627
* Jira: SNOW-2361367