### PR TITLE
Add command_ci_auth_type telemetry field for CI/CD integrations

### DIFF
--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -61,6 +61,7 @@ class CLITelemetryField(Enum):
     COMMAND_EXECUTION_TIME = "command_execution_time"
     COMMAND_CI_ENVIRONMENT = "command_ci_environment"
     COMMAND_CI_INTEGRATION_VERSION = "command_ci_integration_version"
+    COMMAND_CI_AUTH_TYPE = "command_ci_auth_type"
     COMMAND_AGENT_ENVIRONMENT = "command_agent_environment"
     # Configuration
     CONFIG_FEATURE_FLAGS = "config_feature_flags"
@@ -282,6 +283,26 @@ def _get_ci_integration_version() -> str:
     return os.environ.get("SF_CICD_INTEGRATION_VERSION", "")
 
 
+# Canonical auth-type tokens emitted by the official Snowflake CI/CD integrations
+# via SF_CICD_AUTH_TYPE: "oidc", "key_pair", "password", "externalbrowser",
+# "oauth", "programmatic_access_token". The set is intentionally open -- unknown
+# values are still recorded rather than dropped -- but integrations should reuse
+# these so the field stays consistent across GitHub Actions, Azure DevOps and the
+# GitLab component.
+def _get_ci_auth_type() -> str:
+    """Get the auth type the official Snowflake CI/CD integration configured, if any.
+
+    Integrations set ``SF_CICD_AUTH_TYPE`` on their OIDC/workload-identity path
+    (mirroring how they already set ``SNOWFLAKE_AUTHENTICATOR``); credential
+    fallbacks the integration never configures leave it unset.
+
+    This helper is the single resolution point for the value: a future change can
+    fall back to inferring the actual authenticator from the resolved connection
+    when the env var is absent, without touching the integrations or the field.
+    """
+    return os.environ.get("SF_CICD_AUTH_TYPE", "").strip().lower()
+
+
 def _detect_agent_environment() -> str:
     """Detect AI coding agent based on environment variables."""
     if "CORTEX_SESSION_ID" in os.environ:
@@ -372,6 +393,7 @@ class CLITelemetryClient:
             CLITelemetryField.VERSION_PYTHON: python_version(),
             CLITelemetryField.COMMAND_CI_ENVIRONMENT: _get_ci_environment_type(),
             CLITelemetryField.COMMAND_CI_INTEGRATION_VERSION: _get_ci_integration_version(),
+            CLITelemetryField.COMMAND_CI_AUTH_TYPE: _get_ci_auth_type(),
             CLITelemetryField.COMMAND_AGENT_ENVIRONMENT: _detect_agent_environment(),
             CLITelemetryField.CONFIG_FEATURE_FLAGS: {
                 k: str(v) for k, v in get_feature_flags_section().items()

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -77,6 +77,9 @@ def test_executing_command_sends_telemetry_usage_data_legacy_config(
             "command_ci_integration_version"
         ]  # to avoid side effect from CI
         del usage_command_event["message"][
+            "command_ci_auth_type"
+        ]  # to avoid side effect from CI
+        del usage_command_event["message"][
             "command_agent_environment"
         ]  # to avoid side effect from agent environment
         assert usage_command_event == {
@@ -145,6 +148,9 @@ def test_executing_command_sends_telemetry_usage_data_ng_config(
         ]  # to avoid side effect from CI
         del usage_command_event["message"][
             "command_ci_integration_version"
+        ]  # to avoid side effect from CI
+        del usage_command_event["message"][
+            "command_ci_auth_type"
         ]  # to avoid side effect from CI
         del usage_command_event["message"][
             "command_agent_environment"
@@ -610,6 +616,57 @@ def test_ci_integration_version_appears_in_telemetry(_, mock_conn, runner):
         usage_command_event["message"]["command_ci_environment"] == "SF_GITHUB_ACTION"
     )
     assert usage_command_event["message"]["command_ci_integration_version"] == "v2.0.2"
+
+
+def test_get_ci_auth_type_returns_value_when_set():
+    """Test that the auth type is returned when the env var is set."""
+    from snowflake.cli._app.telemetry import _get_ci_auth_type
+
+    with mock.patch.dict(os.environ, {"SF_CICD_AUTH_TYPE": "oidc"}, clear=True):
+        assert _get_ci_auth_type() == "oidc"
+
+
+def test_get_ci_auth_type_returns_empty_when_unset():
+    """Test that empty string is returned when the env var is not set."""
+    from snowflake.cli._app.telemetry import _get_ci_auth_type
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert _get_ci_auth_type() == ""
+
+
+def test_get_ci_auth_type_is_normalized():
+    """Test that the auth type is lower-cased and trimmed so integrations can
+    emit any casing without fragmenting the telemetry value."""
+    from snowflake.cli._app.telemetry import _get_ci_auth_type
+
+    with mock.patch.dict(os.environ, {"SF_CICD_AUTH_TYPE": "  OIDC  "}, clear=True):
+        assert _get_ci_auth_type() == "oidc"
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.connection.commands.ObjectManager")
+def test_ci_auth_type_appears_in_telemetry(_, mock_conn, runner):
+    """Test that the auth type is included in the telemetry payload."""
+    with mock.patch.dict(
+        os.environ,
+        {"SF_GITHUB_ACTION": "true", "SF_CICD_AUTH_TYPE": "oidc"},
+        clear=True,
+    ):
+        result = runner.invoke(["connection", "test"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    usage_command_event = (
+        mock_conn.return_value._telemetry.try_add_log_to_batch.call_args_list[  # noqa: SLF001
+            0
+        ]
+        .args[0]
+        .to_dict()
+    )
+
+    assert (
+        usage_command_event["message"]["command_ci_environment"] == "SF_GITHUB_ACTION"
+    )
+    assert usage_command_event["message"]["command_ci_auth_type"] == "oidc"
 
 
 def test_sf_gitlab_component_takes_priority_over_gitlab_ci():


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand. — N/A: backend telemetry field only, no user-facing CLI surface.
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code. — N/A: matches the existing `command_ci_integration_version` field, which is unit-tested only.
   * [ ] Manually tested on macOS — N/A: pure-Python env-var read, covered by unit tests.
   * [ ] Manually tested on Windows — N/A.
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md`. — not included for now; happy to add a "New additions" bullet if maintainers want one.
   * [ ] I've updated documentation if behavior changed. — N/A: no behavior/doc change.

### Changes description

Adds a new `command_ci_auth_type` telemetry field that records the authentication type the official Snowflake CI/CD integrations configure, so we can measure OIDC adoption across CI/CD.

- New `CLITelemetryField.COMMAND_CI_AUTH_TYPE` and helper `_get_ci_auth_type()` in `src/snowflake/cli/_app/telemetry.py`, wired into `generate_telemetry_data_dict`.
- The value is read from the `SF_CICD_AUTH_TYPE` environment variable (lower-cased + trimmed), exactly mirroring the existing `SF_CICD_INTEGRATION_VERSION` → `command_ci_integration_version` mechanism. The integrations set it to `oidc` on their OIDC/workload-identity path; credential fallbacks the integration never configures leave it unset (empty string).
- Open value vocabulary (`oidc`, `key_pair`, `password`, `externalbrowser`, `oauth`, `programmatic_access_token`) documented next to the helper; unknown values are recorded rather than dropped.
- `_get_ci_auth_type()` is the single resolution point, so a later change can fall back to inferring the real authenticator from the resolved connection without touching the integrations or the field.

Companion PRs set `SF_CICD_AUTH_TYPE=oidc` in the integrations: snowflakedb/snowflake-actions#10, snowflakedb/snowflake-ado-extension#21, and the GitLab snowflake-cicd-component (MR !13). Those are forward-compatible and can merge in any order; this PR is the consumer that activates the signal.

### Tests
`hatch run pytest tests/app/test_telemetry.py` — 59 passed (4 new: value-when-set, empty-when-unset, normalization, and end-to-end payload).