### PR TITLE
Bump GitPython from 3.1.59 to 3.1.62 to fix CVE-2026-78676

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -50,6 +50,7 @@
 * Security improvements
 
 * Upgraded GitPython from 3.1.59 to 3.1.62 to address CVE CVE-2026-78676.
+* Upgraded typing-extension from 4.14.1 to 4.16.0 (required by GitPython)
 
 # v3.26.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -49,6 +49,7 @@
 * `snow streamlit deploy --replace` of an existing versioned SPCS v2 app now restarts the running Streamlit service after uploading files, so content-only updates show up without a Snowsight restart. First-time deploys, `CREATE OR REPLACE` conversions, and `--legacy` deploys are unchanged. Warehouse runtimes and no-op uploads (no file changes) are also unchanged.
 * Security improvements
 
+* Upgraded GitPython from 3.1.59 to 3.1.62 to address CVE CVE-2026-78676.
 
 # v3.26.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,8 @@
 ## Deprecations
 
 ## New additions
+* Upgraded GitPython from 3.1.59 to 3.1.62 to address CVE CVE-2026-78676.
+* Upgraded typing-extension from 4.14.1 to 4.16.0 (required by GitPython)
 
 ## Fixes and improvements
 * Telemetry no longer opens a Snowflake connection on its own. Under `externalbrowser` or OAuth authorization-code authentication, commands that never touch Snowflake — such as `snow connection list`, `snow app bundle`, and `snow sql --help` — no longer open a browser tab, and no longer hang in headless or CI runs waiting for one that cannot appear.
@@ -48,9 +50,6 @@
 * Upgraded snowflake-connector-python from 4.7.1 to 4.7.3.
 * `snow streamlit deploy --replace` of an existing versioned SPCS v2 app now restarts the running Streamlit service after uploading files, so content-only updates show up without a Snowsight restart. First-time deploys, `CREATE OR REPLACE` conversions, and `--legacy` deploys are unchanged. Warehouse runtimes and no-op uploads (no file changes) are also unchanged.
 * Security improvements
-
-* Upgraded GitPython from 3.1.59 to 3.1.62 to address CVE CVE-2026-78676.
-* Upgraded typing-extension from 4.14.1 to 4.16.0 (required by GitPython)
 
 # v3.26.0
 

--- a/pylock.toml
+++ b/pylock.toml
@@ -793,6 +793,7 @@ version = "4.16.0"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", upload-time = 2026-07-02T08:40:05Z, size = 113555, hashes = { sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", upload-time = 2026-07-02T08:40:04Z, size = 45571, hashes = { sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8" } }]
+
 [[packages]]
 name = "typing-inspection"
 version = "0.4.2"

--- a/pylock.toml
+++ b/pylock.toml
@@ -268,9 +268,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5
 
 [[packages]]
 name = "gitpython"
-version = "3.1.59"
-sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", upload-time = 2026-08-10T12:03:20Z, size = 230445, hashes = { sha256 = "0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", upload-time = 2026-08-10T12:03:18Z, size = 220996, hashes = { sha256 = "67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c" } }]
+version = "3.1.62"
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/3ca813cbacb23ab6fe46ff38a9b5ef8e73e970c8051f2ce903aacafe0446/gitpython-3.1.62.tar.gz", upload-time = 2026-09-07T02:57:21Z, size = 231728, hashes = { sha256 = "1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d6/0b/29d7965215f8ef830a7ca1f42997fe13e5693d85e9edb18f938d063ef5f2/gitpython-3.1.62-py3-none-any.whl", upload-time = 2026-09-07T02:57:19Z, size = 222753, hashes = { sha256 = "7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e" } }]
 
 [[packages]]
 name = "id"

--- a/pylock.toml
+++ b/pylock.toml
@@ -789,10 +789,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/ca/e8/b3d537470e84046
 
 [[packages]]
 name = "typing-extensions"
-version = "4.14.1"
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", upload-time = 2025-07-04T13:28:34Z, size = 107673, hashes = { sha256 = "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", upload-time = 2025-07-04T13:28:32Z, size = 43906, hashes = { sha256 = "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76" } }]
-
+version = "4.16.0"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", upload-time = 2026-07-02T08:40:05Z, size = 113555, hashes = { sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", upload-time = 2026-07-02T08:40:04Z, size = 45571, hashes = { sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8" } }]
 [[packages]]
 name = "typing-inspection"
 version = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 dependencies = [
   # Actual project dependencies, from which we generate [project.dependencies] section serving as a lockfile for PyPi
   "click==8.1.8",
-  "GitPython==3.1.59",
+  "GitPython==3.1.62",
   "PyYAML==6.0.2",
   "id==1.5.0",
   "jinja2==3.1.6",


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
...
Update GitPython from 3.1.59 to 3.1.62 to addresse CVE-2026-78676