### PR TITLE
fix(deps): bump jaraco-context to patch CVE-2026-23949

### DIFF
--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -19,7 +19,7 @@ id==1.5.0
 idna==3.10
 importlib-metadata==8.7.0 ; python_full_version < '3.12'
 jaraco-classes==3.4.0
-jaraco-context==6.0.1
+jaraco-context==6.1.2
 jaraco-functools==4.2.1
 jeepney==0.9.0 ; sys_platform == 'linux'
 jinja2==3.1.6


### PR DESCRIPTION
Automated dependency bump to address a disclosed CVE.

- **CVE:** CVE-2026-23949
- **Advisory:** https://github.com/advisories/GHSA-58pv-8j8x-9vj2
- **Severity:** high
- **Package:** `jaraco-context` `6.0.1` → `6.1.2`

Zip Slip path traversal in `jaraco.context.tarball()`'s `strip_first_component` filter — a malicious tar archive can extract files outside the intended directory (e.g. `dummy_dir/../../etc/passwd`). Fixed upstream in 6.1.0; this bumps to the current latest release, 6.1.2.

Detected by [osv-scanner](https://google.github.io/osv-scanner/). Only `snyk/requirements.txt` is touched, matching this repo's own existing dependency-bump PR convention (e.g. #2895, #3035, #2844) — the resolved/hashed `pylock.toml` is presumably regenerated by the project's own lock tooling from `pyproject.toml` and wasn't hand-edited here.

### Verification
- Reproduced locally: no (dependency-only version bump, no code change)
- Command: `grep -n jaraco-context snyk/requirements.txt`
- Before: `jaraco-context==6.0.1`
- After: `jaraco-context==6.1.2`
- Environment: n/a